### PR TITLE
fix: narrow execCommand() defense-in-depth to executable name only

### DIFF
--- a/agentkit/engines/node/src/__tests__/runner.test.mjs
+++ b/agentkit/engines/node/src/__tests__/runner.test.mjs
@@ -53,19 +53,12 @@ describe('execCommand()', () => {
   });
 
   it('does not interpret shell metacharacters as command separators', () => {
-    // On non-Windows: spawnSync (no shell) treats semicolons as literal args
-    // On Windows: the defense-in-depth check in execCommand blocks metacharacters
+    // spawnSync passes args as an array — semicolons are literal, not separators.
+    // On Windows (shell:true), Node auto-escapes each arg for cmd.exe.
     const result = execCommand('echo safe; echo injected');
-    if (process.platform === 'win32') {
-      // Windows: blocked by isValidCommand() guard
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain('shell metacharacters');
-    } else {
-      // Linux/macOS: semicolons are literal text, not command separators
-      const lines = result.stdout.trim().split('\n');
-      expect(lines).toHaveLength(1);
-      expect(lines[0]).toContain('safe;');
-    }
+    const lines = result.stdout.trim().split('\n');
+    expect(lines).toHaveLength(1); // Only one echo, not two
+    expect(lines[0]).toContain('safe;'); // Semicolon is literal text
   });
 });
 


### PR DESCRIPTION
The previous check ran isValidCommand() on the entire raw command string, which rejected legitimate commands containing parentheses in arguments (e.g. `node -e "process.stderr.write(String(42))"`). This caused 3 test failures on Windows CI where the check is active.

Now only the parsed executable name is validated for shell metacharacters. Arguments are safe because spawnSync auto-escapes each array element when constructing the cmd.exe command line on Windows.

https://claude.ai/code/session_01HMoYggGSasg7SNsfB4hCos

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->
