### PR TITLE
Fix healthcheck test timeout by using temp directory

### DIFF
--- a/agentkit/engines/node/src/__tests__/healthcheck.test.mjs
+++ b/agentkit/engines/node/src/__tests__/healthcheck.test.mjs
@@ -21,9 +21,13 @@ describe('runHealthcheck()', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 
+    // Use a temp directory without stack markers (package.json, Cargo.toml, etc.)
+    // so the healthcheck skips expensive build/test/lint commands that cause timeouts.
+    mkdirSync(TEST_ROOT, { recursive: true });
+
     const result = await runHealthcheck({
       agentkitRoot: AGENTKIT_ROOT,
-      projectRoot: PROJECT_ROOT,
+      projectRoot: TEST_ROOT,
       flags: {},
     });
 


### PR DESCRIPTION
## Summary
Updated the healthcheck test to use a temporary directory instead of the actual project root, preventing expensive build/test/lint commands from running during test execution.

## Key Changes
- Modified `runHealthcheck()` test to create and use a temporary test directory (`TEST_ROOT`) instead of `PROJECT_ROOT`
- Added directory creation with `mkdirSync(TEST_ROOT, { recursive: true })`
- Added explanatory comments clarifying that the temp directory lacks stack markers (package.json, Cargo.toml, etc.) to skip expensive operations

## Implementation Details
The healthcheck function appears to detect project type and run associated commands based on the presence of configuration files. By using a clean temporary directory without these markers, the test avoids triggering time-consuming build, test, and lint operations that were causing test timeouts. This allows the healthcheck logic itself to be tested without the overhead of actual project operations.

https://claude.ai/code/session_01Jhw5GhVpv5oiv2KqdwJpvz