### PR TITLE
Mock external dependencies in healthcheck test to improve reliability

### DIFF
--- a/agentkit/engines/node/src/__tests__/healthcheck.test.mjs
+++ b/agentkit/engines/node/src/__tests__/healthcheck.test.mjs
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { runHealthcheck } from '../healthcheck.mjs';
+import * as runner from '../runner.mjs';
+import * as orchestrator from '../orchestrator.mjs';
 import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -12,17 +14,31 @@ const STATE_DIR = resolve(TEST_ROOT, '.claude', 'state');
 
 describe('runHealthcheck()', () => {
   afterEach(() => {
-    if (existsSync(TEST_ROOT)) rmSync(TEST_ROOT, { recursive: true });
+    if (existsSync(TEST_ROOT)) rmSync(TEST_ROOT, { recursive: true, force: true, maxRetries: 3, retryDelay: 200 });
     vi.restoreAllMocks();
   });
 
-  it('returns structured result with tools list', { timeout: 30_000 }, async () => {
+  it('returns structured result with tools list', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 
-    // Use a temp directory without stack markers (package.json, Cargo.toml, etc.)
-    // so the healthcheck skips expensive build/test/lint commands that cause timeouts.
+    // Mock tool checks to avoid spawning real processes — this test only
+    // verifies result shape, not actual tool detection (tests below cover that).
+    // Real spawns are slow on cold CI caches and hold directory handles that
+    // cause EBUSY on Windows cleanup.
+    vi.spyOn(runner, 'commandExists').mockImplementation(
+      (cmd) => cmd === 'node' || cmd === 'git',
+    );
+    vi.spyOn(runner, 'execCommand').mockReturnValue({
+      exitCode: 0, stdout: 'v20.0.0\n', stderr: '', durationMs: 5,
+    });
+
+    // Prevent orchestrator from writing state files into TEST_ROOT.
+    vi.spyOn(orchestrator, 'loadState').mockReturnValue({});
+    vi.spyOn(orchestrator, 'saveState').mockImplementation(() => {});
+    vi.spyOn(orchestrator, 'appendEvent').mockImplementation(() => {});
+
     mkdirSync(TEST_ROOT, { recursive: true });
 
     const result = await runHealthcheck({


### PR DESCRIPTION
## Summary
Updated the healthcheck test to mock external tool checks and orchestrator operations, improving test reliability and performance by avoiding slow subprocess spawns and file system contention on CI.

## Key Changes
- Added mocks for `runner.commandExists()` and `runner.execCommand()` to simulate tool detection without spawning real processes
- Added mocks for `orchestrator.loadState()`, `saveState()`, and `appendEvent()` to prevent state file I/O during testing
- Removed test timeout override (30s → default) since mocks eliminate the need for extended timeouts
- Enhanced cleanup robustness by adding `force: true`, `maxRetries: 3`, and `retryDelay: 200` options to `rmSync()` to handle Windows file handle issues

## Implementation Details
The test now focuses on verifying the result shape and structure rather than actual tool detection. This approach:
- Eliminates slow cold-cache subprocess spawns on CI
- Prevents EBUSY errors on Windows during directory cleanup caused by held file handles
- Makes the test faster and more deterministic
- Allows dedicated tests to cover actual tool detection logic separately

https://claude.ai/code/session_01NFHiqTydvvvuF5jai9EPoe