### PR TITLE
Increase healthcheck test timeouts from 30s to 60s

### DIFF
--- a/agentkit/engines/node/src/__tests__/healthcheck.test.mjs
+++ b/agentkit/engines/node/src/__tests__/healthcheck.test.mjs
@@ -56,7 +56,7 @@ describe('runHealthcheck()', () => {
     expect(result.tools.length).toBeGreaterThan(0);
   });
 
-  it('detects node and git as installed tools', { timeout: 30_000 }, async () => {
+  it('detects node and git as installed tools', { timeout: 60_000 }, async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
@@ -77,7 +77,7 @@ describe('runHealthcheck()', () => {
     expect(gitTool.found).toBe(true);
   });
 
-  it('reports agentkit setup status', { timeout: 30_000 }, async () => {
+  it('reports agentkit setup status', { timeout: 60_000 }, async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true);


### PR DESCRIPTION
## Summary
Increased the timeout duration for two healthcheck test cases to provide more time for test execution and reduce flakiness.

## Changes
- Updated timeout for "detects node and git as installed tools" test from 30,000ms to 60,000ms
- Updated timeout for "reports agentkit setup status" test from 30,000ms to 60,000ms

## Details
These tests perform system-level operations (detecting installed tools like Node.js and Git, and checking agentkit setup status) that can be slow or variable depending on system conditions. Doubling the timeout from 30 seconds to 60 seconds provides a more reliable test execution window and reduces the likelihood of timeout failures in CI/CD environments or on slower systems.

https://claude.ai/code/session_01WZbL4EXB6KGQmj37Q35cY2