### PR TITLE
feat(wave-2b): post-sync summary, dry-run mode, first-sync hint, full…

### DIFF
--- a/.agentkit/overlays/__TEMPLATE__/settings.yaml
+++ b/.agentkit/overlays/__TEMPLATE__/settings.yaml
@@ -9,4 +9,10 @@ renderTargets:
   - cursor
   - windsurf
   - copilot
+  - gemini
+  - codex
+  - warp
+  - cline
+  - roo
   - ai
+  - mcp


### PR DESCRIPTION
… render targets

- §16a: categorizeFile() + printSyncSummary() for grouped file breakdown after sync
- §16b: --dry-run flag renders to temp, prints summary, skips writing
- §16c: first-sync hint when no .agentkit-repo marker exists
- §18: settings.yaml default template now includes all 11 render targets

<!-- GENERATED by AgentKit Forge v0.1.1 — DO NOT EDIT -->
<!-- Source: .agentkit/spec + .agentkit/overlays/__TEMPLATE__ -->
<!-- Regenerate: pnpm -C .agentkit agentkit:sync -->
## Summary

Brief description of what this PR does and why.

Closes #<!-- issue number -->

## Changes

- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Test Plan

Describe how you tested these changes:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

### Validation Commands

```bash
# Commands to verify this change works correctly
```

## Checklist

- [ ] Tests pass locally (`npm test` / `cargo test` / equivalent)
- [ ] Linter passes with no new warnings
- [ ] Build succeeds
- [ ] Documentation updated (if behavior changed)
- [ ] No secrets, tokens, or credentials in the diff
- [ ] Breaking changes documented (if applicable)
- [ ] Reviewed my own diff before requesting review
