### PR TITLE
🔒 Security Fix: Replace execSync with execFileSync to prevent shell injection

### DIFF
--- a/.agentkit/engines/node/src/cost-tracker.mjs
+++ b/.agentkit/engines/node/src/cost-tracker.mjs
@@ -9,7 +9,7 @@
  */
 import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, readdirSync, renameSync } from 'fs';
 import { resolve, basename } from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { formatTimestamp } from './runner.mjs';
 
 // ---------------------------------------------------------------------------
@@ -85,12 +85,12 @@ export function initSession({ agentkitRoot, projectRoot }) {
   let branch = 'unknown';
   let user = 'unknown';
   try {
-    branch = execSync('git rev-parse --abbrev-ref HEAD', {
+    branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
       cwd: projectRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
   } catch { /* git not available — using default branch */ }
   try {
-    user = execSync('git config user.email', {
+    user = execFileSync('git', ['config', 'user.email'], {
       cwd: projectRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
     }).trim() || 'unknown';
   } catch { /* git not available — using default user */ }
@@ -160,7 +160,7 @@ export function endSession({ agentkitRoot, projectRoot, sessionId }) {
   // Count files modified via git
   let filesModified = 0;
   try {
-    const result = execSync('git diff --name-only HEAD', {
+    const result = execFileSync('git', ['diff', '--name-only', 'HEAD'], {
       cwd: projectRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
     });
     filesModified = result.trim().split('\n').filter(Boolean).length;

--- a/.agentkit/engines/node/src/orchestrator.mjs
+++ b/.agentkit/engines/node/src/orchestrator.mjs
@@ -3,7 +3,7 @@
  * State machine for the 5-phase lifecycle: Discovery → Planning → Implementation → Validation → Ship.
  * Manages orchestrator state, event logging, and session locking.
  */
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import {
   appendFileSync,
   existsSync,
@@ -137,7 +137,7 @@ function createDefaultState(projectRoot) {
 
   let branch = 'main';
   try {
-    branch = execSync('git rev-parse --abbrev-ref HEAD', {
+    branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
       cwd: projectRoot,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -283,7 +283,7 @@ export function acquireLock(projectRoot, holder = {}) {
 
 function getHostname() {
   try {
-    return execSync('hostname', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    return execFileSync('hostname', [], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
   } catch {
     return 'unknown';
   }


### PR DESCRIPTION
Fixed security vulnerability in `cost-tracker.mjs` and `orchestrator.mjs` by replacing `execSync` with `execFileSync` to avoid shell command execution.

🎯 **What:** Replaced `execSync` with `execFileSync` in `cost-tracker.mjs` and `orchestrator.mjs`.
⚠️ **Risk:** `execSync` executes commands in a shell, which can be vulnerable to shell injection if inputs are not properly sanitized (though inputs here were mostly static).
🛡️ **Solution:** `execFileSync` executes the file directly without a shell, treating arguments as an array of strings, eliminating the risk of shell injection.

Changes:
- In `.agentkit/engines/node/src/cost-tracker.mjs`:
    - Replaced `execSync('git rev-parse ...')` with `execFileSync('git', ['rev-parse', ...])`.
    - Replaced `execSync('git config ...')` with `execFileSync('git', ['config', ...])`.
    - Replaced `execSync('git diff ...')` with `execFileSync('git', ['diff', ...])`.
- In `.agentkit/engines/node/src/orchestrator.mjs`:
    - Replaced `execSync('git rev-parse ...')` with `execFileSync('git', ['rev-parse', ...])`.
    - Replaced `execSync('hostname')` with `execFileSync('hostname', [])`.

Verification:
- Ran existing tests for `cost-tracker` (11 passed) and `orchestrator` (20 passed).
- Manual verification of logic confirms correct argument passing.

---
*PR created automatically by Jules for task [5004873469817247253](https://jules.google.com/task/5004873469817247253) started by @JustAGhosT*