### PR TITLE
docs(history): add post-PR72 CI/config stabilization record

### DIFF
--- a/docs/history/implementations/0003-2026-03-01-post-history-ci-and-config-stabilization-implementation.md
+++ b/docs/history/implementations/0003-2026-03-01-post-history-ci-and-config-stabilization-implementation.md
@@ -1,0 +1,70 @@
+# Post-History CI and Config Stabilization - Historical Summary
+
+**Completed**: 2026-03-01
+**Duration**: Multi-pass validation and corrective updates
+**Status**: ✅ **SUCCESSFULLY COMPLETED**
+**PR**: [#72](https://github.com/JustAGhosT/agentkit-forge/pull/72) ⚡ optimize sync command with async I/O and concurrency
+
+## Overview
+Captured all work completed after the previous history baseline (`dc13466`). This phase focused on branch convergence follow-up, CI/test reliability fixes, generated-file synchronization, and adding MCP/A2A local config definitions used by agent tooling.
+
+## Implementation Summary
+
+### Projects/Components Affected
+- ✅ **Engine source reconciliation** - task protocol/template utility consistency after remote integration
+- ✅ **Test reliability** - cross-platform and intent-safe test updates
+- ✅ **CI sync guard compliance** - regenerated docs chatmode output drift
+- ✅ **Local agent config** - `.mcp` server and A2A configuration bootstrap
+
+### Key Changes Made
+1. **Post-baseline branch merge follow-up** (`3f680b5`) - integrated remote branch updates affecting:
+   - `.agentkit/engines/node/src/task-protocol.mjs`
+   - `.agentkit/engines/node/src/template-utils.mjs`
+2. **Cross-platform test hardening** (`2f0421b`) - adjusted test expectations to preserve behavior while avoiding shell-specific assumptions:
+   - `.agentkit/engines/node/src/__tests__/runner.test.mjs`
+   - `.agentkit/engines/node/src/__tests__/template-utils.test.mjs`
+3. **Fresh-install CI log visibility fix** (`497f64d`) - ensured expected sync output is observable during test execution:
+   - `.agentkit/engines/node/src/__tests__/fresh-install.test.mjs`
+4. **Generated artifact drift correction** (`98c183b`) - refreshed sync-generated docs chatmode scope:
+   - `.github/chatmodes/team-docs.chatmode.md`
+5. **Tooling configuration addition** (`45b2dc1`) - added MCP/A2A local config files:
+   - `.mcp/a2a-config.json`
+   - `.mcp/servers.json`
+
+### Issues Resolved
+- **PR branch integration drift** after baseline history creation.
+- **Cross-environment test fragility** due to shell/platform assumptions.
+- **CI assertion mismatch** in fresh-install sync-output expectation.
+- **Generated-file guard failures** caused by stale synced artifacts.
+- **Missing local MCP/A2A bootstrap config** for current tool orchestration setup.
+
+## Validation
+- Repeated targeted and full-suite test runs were executed during this period.
+- Post-fix suite state was verified green in local runs before push.
+- Generated-file cleanliness was re-validated with tracked-diff checks after sync refresh.
+
+## Results
+This phase restored CI alignment and reduced recurrence risk for test and generated-output regressions while preserving intended runtime behavior.
+
+### Impact
+- Improved confidence in PR #72 mergeability and CI reproducibility.
+- Reduced flaky/failing pathways in install/sync and command-runner test flows.
+- Established local MCP/A2A config artifacts required for newer agent workflows.
+
+## Related Commits
+- `3f680b5` - Merge remote tracking updates into active branch
+- `2f0421b` - Cross-platform and intent-safe test fixes
+- `497f64d` - Fresh-install sync output visibility fix
+- `98c183b` - Sync-generated docs chatmode refresh
+- `45b2dc1` - MCP/A2A config additions
+
+## Related Documentation
+- **Previous baseline**: `docs/history/implementations/0001-2026-03-01-origin-main-merge-reconciliation-implementation.md`
+- **Previous baseline**: `docs/history/implementations/0002-2026-03-01-sync-test-performance-stabilization-implementation.md`
+- **PR**: https://github.com/JustAGhosT/agentkit-forge/pull/72
+
+---
+
+**Implementation Team**: @smitj + GitHub Copilot
+**Review Status**: Ready for PR review
+**Next Steps**: Keep history entries incremental per post-baseline commit group to preserve traceability


### PR DESCRIPTION
## Summary\n- add incremental history document for work completed after prior history baseline\n- capture CI/test stabilization fixes, generated sync drift correction, and MCP/A2A config additions\n\n## Files\n- docs/history/implementations/0003-2026-03-01-post-history-ci-and-config-stabilization-implementation.md\n\n## Validation\n- documentation-only change\n- no runtime behavior changes\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added historical documentation detailing CI and configuration stabilization improvements, including key changes made and validation activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->