### PR TITLE
fix(governance): detect .agentkit rename touches and normalize placeholder link

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -84,7 +84,11 @@ jobs:
               (response) => response.data
             );
 
-            const touchesAgentkit = files.some((file) => file.filename.startsWith('.agentkit/'));
+            const touchesAgentkit = files.some(
+              (file) =>
+                file.filename.startsWith('.agentkit/') ||
+                (file.previous_filename && file.previous_filename.startsWith('.agentkit/'))
+            );
 
             if (!touchesAgentkit) {
               core.info('No .agentkit changes detected; upstream issue link check skipped.');

--- a/docs/08_reference/agentkit_sync_integration_patch_plan.md
+++ b/docs/08_reference/agentkit_sync_integration_patch_plan.md
@@ -41,7 +41,7 @@ In generated branch-protection workflow:
 
 - Trigger applies to PRs targeting `dev` and `main`.
 - If PR touches `.agentkit/**`, PR body must contain upstream issue URL pattern:
-  - [https://github.com/JustAGhosT/agentkit-forge/issues/<number>](https://github.com/JustAGhosT/agentkit-forge/issues/170)
+  - [https://github.com/JustAGhosT/agentkit-forge/issues/<number>](https://github.com/JustAGhosT/agentkit-forge/issues/<number>)
 - On missing link, required check fails with clear remediation message.
 
 ### 2) Branch protection script behavior


### PR DESCRIPTION
> **Area:** devops | **Priority:** P2 — Medium | **Phase:** active

## Summary\n- detect .agentkit/** touches on PR file renames/moves by checking both ilename and previous_filename in branch-protection guardrail logic\n- normalize placeholder issue-link example so display text and href are consistent\n\n## Why\n- rename/move edge cases could bypass .agentkit guardrail detection\n- mixed placeholder/hardcoded URL examples can mislead contributors\n\n## Files\n- .github/workflows/branch-protection.yml\n- docs/08_reference/agentkit_sync_integration_patch_plan.md\n\n## Tracking\n- Refs #180\n- Refs #181\n\n## Validation\n- file diagnostics clean for both updated files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow to detect both current and renamed `.agentkit` files.

* **Documentation**
  * Updated reference documentation URL patterns to use generic placeholders for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
