### PR TITLE
fix(check): align formatting gate to pinned prettier

### DIFF
--- a/.agentkit/engines/node/src/__tests__/check.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/check.test.mjs
@@ -18,7 +18,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const AGENTKIT_ROOT = resolve(__dirname, '..', '..', '..', '..');
 const PROJECT_ROOT = resolve(AGENTKIT_ROOT, '..');
 
-function createCheckFixture({ withBuild = true } = {}) {
+function createCheckFixture({ withBuild = true, formatter = null, withPrettierBin = false } = {}) {
   const root = mkdtempSync(resolve(tmpdir(), 'agentkit-check-test-'));
   const agentkitRoot = resolve(root, '.agentkit');
   const projectRoot = resolve(root, 'project');
@@ -28,11 +28,19 @@ function createCheckFixture({ withBuild = true } = {}) {
 
   writeFileSync(resolve(projectRoot, 'package.json'), '{}\n', 'utf-8');
 
+  if (withPrettierBin) {
+    const prettierBin = resolve(agentkitRoot, 'node_modules', 'prettier', 'bin');
+    mkdirSync(prettierBin, { recursive: true });
+    writeFileSync(resolve(prettierBin, 'prettier.cjs'), 'process.exit(0);\n', 'utf-8');
+  }
+
   const buildLine = withBuild ? '    buildCommand: "node -e \\\"\\\""\n' : '';
+  const formatterLine = formatter ? `    formatter: "${formatter}"\n` : '';
   const teamsYaml = `techStacks:
   - name: test-stack
     detect:
       - package.json
+${formatterLine}    
     typecheck: "node -e \\\"\\\""
     testCommand: "node -e \\\"\\\""
 ${buildLine}`;
@@ -115,13 +123,56 @@ describe('runCheck()', () => {
       cleanupFixture(fixture.root);
     }
   }, 20_000);
+
+  it('resolves prettier path from agentkitRoot when roots are split', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const fixture = createCheckFixture({
+      withBuild: false,
+      formatter: 'prettier',
+      withPrettierBin: true,
+    });
+    try {
+      const expectedPrettierBin = resolve(
+        fixture.agentkitRoot,
+        'node_modules',
+        'prettier',
+        'bin',
+        'prettier.cjs'
+      ).replace(/\\/g, '/');
+
+      const formatter = resolveFormatter('prettier', fixture.agentkitRoot);
+      expect(formatter.cmd).toBe('prettier');
+      expect(formatter.check).toBe(`node "${expectedPrettierBin}" --check .`);
+      expect(formatter.fix).toBe(`node "${expectedPrettierBin}" --write .`);
+
+      const result = await runCheck({
+        agentkitRoot: fixture.agentkitRoot,
+        projectRoot: fixture.projectRoot,
+        flags: { fast: true },
+      });
+
+      const formatStep = result.stacks[0]?.steps.find((step) => step.step === 'format');
+      expect(formatStep?.status).toBe('PASS');
+    } finally {
+      cleanupFixture(fixture.root);
+    }
+  }, 20_000);
 });
 
 describe('resolveFormatter()', () => {
   it('maps known formatters to check/fix commands', () => {
-    const r = resolveFormatter('prettier');
-    expect(r.check).toBe('node .agentkit/node_modules/prettier/bin/prettier.cjs --check .');
-    expect(r.fix).toBe('node .agentkit/node_modules/prettier/bin/prettier.cjs --write .');
+    const expectedPrettierBin = resolve(
+      AGENTKIT_ROOT,
+      'node_modules',
+      'prettier',
+      'bin',
+      'prettier.cjs'
+    ).replace(/\\/g, '/');
+    const r = resolveFormatter('prettier', AGENTKIT_ROOT);
+    expect(r.check).toBe(`node "${expectedPrettierBin}" --check .`);
+    expect(r.fix).toBe(`node "${expectedPrettierBin}" --write .`);
     expect(r.cmd).toBe('prettier');
   });
 

--- a/.agentkit/engines/node/src/check.mjs
+++ b/.agentkit/engines/node/src/check.mjs
@@ -18,16 +18,17 @@ import { appendEvent } from './orchestrator.mjs';
  * Build the check steps for a detected stack.
  * @param {object} stack - Stack config from teams.yaml techStacks
  * @param {object} flags - CLI flags
+ * @param {string} agentkitRoot - Path to .agentkit root
  * @returns {Array<{ name: string, command: string, fixCommand?: string }>}
  */
-function buildSteps(stack, flags) {
+function buildSteps(stack, flags, agentkitRoot) {
   const steps = [];
 
   if (stack.formatter) {
     if (typeof stack.formatter !== 'string' || !stack.formatter.trim()) {
       console.warn(`[agentkit:check] Skipping non-string formatter value`);
     } else {
-      const resolved = resolveFormatter(stack.formatter);
+      const resolved = resolveFormatter(stack.formatter, agentkitRoot);
       if (!isValidCommand(resolved.check)) {
         console.warn(`[agentkit:check] Skipping invalid formatter command: ${stack.formatter}`);
       } else if (!isAllowedFormatter(resolved)) {
@@ -122,14 +123,19 @@ const ALLOWED_NPX_PACKAGES = new Set(['prettier']);
  * Returns an object with { cmd, check, fix } so buildSteps can use
  * tool-specific CLI syntax instead of hardcoding Prettier-style flags.
  * @param {string} formatter
+ * @param {string} [agentkitRoot]
  * @returns {{ cmd: string, check: string, fix: string }}
  */
-function resolveFormatter(formatter) {
+function resolveFormatter(formatter, agentkitRoot) {
+  const prettierBin = agentkitRoot
+    ? resolve(agentkitRoot, 'node_modules', 'prettier', 'bin', 'prettier.cjs').replace(/\\/g, '/')
+    : '.agentkit/node_modules/prettier/bin/prettier.cjs';
+
   const map = {
     prettier: {
       cmd: 'prettier',
-      check: 'node .agentkit/node_modules/prettier/bin/prettier.cjs --check .',
-      fix: 'node .agentkit/node_modules/prettier/bin/prettier.cjs --write .',
+      check: `node "${prettierBin}" --check .`,
+      fix: `node "${prettierBin}" --write .`,
     },
     black: { cmd: 'black', check: 'black --check .', fix: 'black .' },
     'cargo fmt': { cmd: 'cargo fmt', check: 'cargo fmt -- --check', fix: 'cargo fmt' },
@@ -280,7 +286,7 @@ export async function runCheck({ agentkitRoot, projectRoot, flags = {} }) {
 
   for (const stack of detectedStacks) {
     console.log(`--- Stack: ${stack.name} ---`);
-    const steps = buildSteps(stack, flags);
+    const steps = buildSteps(stack, flags, agentkitRoot);
     const stackResults = [];
 
     for (const step of steps) {


### PR DESCRIPTION
## Summary
Addresses follow-up issue #199 on a clean branch from dev by aligning quality-gate formatting checks to the pinned Prettier binary under .agentkit.

## Changes
- Update esolveFormatter('prettier') in check.mjs to use:
  - 
ode .agentkit/node_modules/prettier/bin/prettier.cjs --check .
  - 
ode .agentkit/node_modules/prettier/bin/prettier.cjs --write .
- Update check.test.mjs formatter mapping expectations accordingly.

## Validation
- pnpm -C .agentkit exec vitest run engines/node/src/__tests__/check.test.mjs engines/node/src/__tests__/validate.test.mjs

## Tracking
- Refs #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Prettier formatter to invoke the local binary instead of npx for code formatting checks and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->