### PR TITLE
feat(intake): implement tracker-neutral ownership flow for sync-backlog

### DIFF
--- a/.agentkit/engines/node/src/__tests__/spec-validator.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/spec-validator.test.mjs
@@ -412,6 +412,11 @@ describe('PROJECT_ENUMS', () => {
     expect(PROJECT_ENUMS.cloudProvider).toContain('azure');
     expect(PROJECT_ENUMS.cloudProvider).toContain('gcp');
   });
+
+  it('includes issue tracker and intake cadence enums', () => {
+    expect(PROJECT_ENUMS.issueTracker).toEqual(['github', 'linear', 'none']);
+    expect(PROJECT_ENUMS.intakeCadence).toEqual(['daily', 'on-demand', 'weekly']);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -581,5 +586,64 @@ describe('validateProjectYaml', () => {
 
     const { errors: neg } = validateProjectYaml({ testing: { coverage: -1 } });
     expect(neg.some((e) => e.includes('coverage'))).toBe(true);
+  });
+
+  it('validates process.issueTracker enum values', () => {
+    expect(validateProjectYaml({ process: { issueTracker: 'github' } }).errors).toEqual([]);
+    expect(validateProjectYaml({ process: { issueTracker: 'linear' } }).errors).toEqual([]);
+    expect(validateProjectYaml({ process: { issueTracker: 'none' } }).errors).toEqual([]);
+
+    const { errors } = validateProjectYaml({ process: { issueTracker: 'jira' } });
+    expect(errors.some((e) => e.includes('process.issueTracker'))).toBe(true);
+  });
+
+  it('validates process.intake.cadence enum values', () => {
+    expect(validateProjectYaml({ process: { intake: { cadence: 'daily' } } }).errors).toEqual([]);
+    expect(validateProjectYaml({ process: { intake: { cadence: 'on-demand' } } }).errors).toEqual(
+      []
+    );
+
+    const { errors } = validateProjectYaml({ process: { intake: { cadence: 'hourly' } } });
+    expect(errors.some((e) => e.includes('process.intake.cadence'))).toBe(true);
+  });
+});
+
+describe('teams intake cross-references', () => {
+  it('fails when intake owner/operations teams are unknown', () => {
+    const errors = validateCrossReferences({
+      teams: {
+        teams: [{ id: 'backend' }, { id: 'product' }, { id: 'quality' }],
+        intake: {
+          ownerTeam: 'ghost',
+          operationsTeam: 'unknown',
+          routing: { api: 'backend' },
+          escalation: { securityCritical: ['backend'] },
+        },
+      },
+      commands: { commands: [] },
+      agents: { agents: {} },
+      rules: { rules: [] },
+    });
+
+    expect(errors.some((e) => e.includes('intake.ownerTeam'))).toBe(true);
+    expect(errors.some((e) => e.includes('intake.operationsTeam'))).toBe(true);
+  });
+
+  it('fails when intake routing references unknown team', () => {
+    const errors = validateCrossReferences({
+      teams: {
+        teams: [{ id: 'backend' }, { id: 'product' }, { id: 'quality' }],
+        intake: {
+          ownerTeam: 'product',
+          operationsTeam: 'quality',
+          routing: { api: 'ghost' },
+        },
+      },
+      commands: { commands: [] },
+      agents: { agents: {} },
+      rules: { rules: [] },
+    });
+
+    expect(errors.some((e) => e.includes('intake.routing.api'))).toBe(true);
   });
 });

--- a/.agentkit/engines/node/src/project-mapping.mjs
+++ b/.agentkit/engines/node/src/project-mapping.mjs
@@ -156,6 +156,10 @@ export const PROJECT_MAPPING = [
   { src: 'process.commitConvention', dest: 'commitConvention' },
   { src: 'process.codeReview', dest: 'codeReview' },
   { src: 'process.teamSize', dest: 'teamSize' },
+  { src: 'process.issueTracker', dest: 'issueTracker', check: 'not-none' },
+  { src: 'process.intake.ownerTeam', dest: 'intakeOwnerTeam', check: 'not-none' },
+  { src: 'process.intake.operationsTeam', dest: 'intakeOperationsTeam', check: 'not-none' },
+  { src: 'process.intake.cadence', dest: 'intakeCadence', check: 'not-none' },
 
   // Testing
   { src: 'testing.unit', dest: 'testingUnit', type: 'array-join' },

--- a/.agentkit/engines/node/src/spec-validator.mjs
+++ b/.agentkit/engines/node/src/spec-validator.mjs
@@ -258,6 +258,8 @@ const PROJECT_ENUMS = {
   commitConvention: ['conventional', 'semantic', 'none'],
   codeReview: ['required-pr', 'optional', 'none'],
   teamSize: ['solo', 'small', 'medium', 'large'],
+  issueTracker: ['github', 'linear', 'none'],
+  intakeCadence: ['daily', 'on-demand', 'weekly'],
   loggingFramework: [
     'serilog',
     'winston',
@@ -317,6 +319,21 @@ const PROJECT_ENUMS = {
   auditEventBus: ['service-bus', 'event-hub', 'sns', 'none'],
 };
 
+const teamsIntakeSchema = {
+  type: 'object',
+  properties: {
+    ownerTeam: { type: 'string', required: true, minLength: 1 },
+    operationsTeam: { type: 'string', required: true, minLength: 1 },
+    routing: { type: 'object' },
+    escalation: {
+      type: 'object',
+      properties: {
+        securityCritical: { type: 'array', items: { type: 'string' } },
+        blockedCrossTeam: { type: 'array', items: { type: 'string' } },
+      },
+    },
+  },
+};
 // ---------------------------------------------------------------------------
 // Schema: project.yaml
 // ---------------------------------------------------------------------------
@@ -441,6 +458,23 @@ const projectSchema = {
         commitConvention: { type: 'string', enum: PROJECT_ENUMS.commitConvention },
         codeReview: { type: 'string', enum: PROJECT_ENUMS.codeReview },
         teamSize: { type: 'string', enum: PROJECT_ENUMS.teamSize },
+        issueTracker: { type: 'string', enum: PROJECT_ENUMS.issueTracker },
+        intake: {
+          type: 'object',
+          properties: {
+            ownerTeam: { type: 'string', minLength: 1 },
+            operationsTeam: { type: 'string', minLength: 1 },
+            cadence: { type: 'string', enum: PROJECT_ENUMS.intakeCadence },
+            routing: { type: 'object' },
+            escalation: {
+              type: 'object',
+              properties: {
+                securityCritical: { type: 'array', items: { type: 'string' } },
+                blockedCrossTeam: { type: 'array', items: { type: 'string' } },
+              },
+            },
+          },
+        },
       },
     },
     testing: {
@@ -729,6 +763,60 @@ function validateCrossReferences(specs) {
     detectHandoffCycle(teamId);
   }
 
+  // Validate teams.intake ownership/routing references
+  const intake = teams?.intake;
+  if (intake && typeof intake === 'object' && !Array.isArray(intake)) {
+    const ownerTeam = intake.ownerTeam;
+    if (typeof ownerTeam === 'string' && ownerTeam && !teamIds.has(ownerTeam)) {
+      errors.push(`teams.yaml: intake.ownerTeam references unknown team "${ownerTeam}"`);
+    }
+
+    const operationsTeam = intake.operationsTeam;
+    if (typeof operationsTeam === 'string' && operationsTeam && !teamIds.has(operationsTeam)) {
+      errors.push(
+        `teams.yaml: intake.operationsTeam references unknown team "${operationsTeam}"`
+      );
+    }
+
+    const routing = intake.routing;
+    if (routing && typeof routing === 'object' && !Array.isArray(routing)) {
+      for (const [routeKey, routeTeam] of Object.entries(routing)) {
+        if (typeof routeTeam !== 'string') {
+          errors.push(`teams.yaml: intake.routing.${routeKey} must be a string team id`);
+          continue;
+        }
+        if (!teamIds.has(routeTeam)) {
+          errors.push(
+            `teams.yaml: intake.routing.${routeKey} references unknown team "${routeTeam}"`
+          );
+        }
+      }
+    }
+
+    const escalation = intake.escalation;
+    if (escalation && typeof escalation === 'object' && !Array.isArray(escalation)) {
+      for (const [escalationKey, escalationTeams] of Object.entries(escalation)) {
+        if (!Array.isArray(escalationTeams)) {
+          errors.push(`teams.yaml: intake.escalation.${escalationKey} must be an array`);
+          continue;
+        }
+        for (const escalationTeam of escalationTeams) {
+          if (typeof escalationTeam !== 'string') {
+            errors.push(
+              `teams.yaml: intake.escalation.${escalationKey} entries must be string team ids`
+            );
+            continue;
+          }
+          if (!teamIds.has(escalationTeam)) {
+            errors.push(
+              `teams.yaml: intake.escalation.${escalationKey} references unknown team "${escalationTeam}"`
+            );
+          }
+        }
+      }
+    }
+  }
+
   // Check for duplicate rule convention IDs
   const seenRuleIds = new Set();
   for (const domain of specs.rules?.rules || []) {
@@ -826,6 +914,9 @@ export function validateSpec(agentkitRoot) {
           );
         }
       }
+    }
+    if (teams.intake !== undefined && teams.intake !== null) {
+      errors.push(...validate(teams.intake, teamsIntakeSchema, 'teams.yaml.intake'));
     }
   }
 

--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -1021,6 +1021,7 @@ function buildCommandVars(cmd, vars) {
   return {
     ...vars,
     commandName: cmd.name,
+    isSyncBacklog: cmd.name === 'sync-backlog',
     commandDescription:
       typeof cmd.description === 'string' ? cmd.description.trim() : cmd.description || '',
     commandFlags: formatCommandFlags(cmd.flags),
@@ -1132,8 +1133,27 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
 
   // Template variables — start with project.yaml flat vars, then overlay with core vars
   const projectVars = projectSpec ? flattenProjectYaml(projectSpec, docsSpec) : {};
+  const teamsIntake = teamsSpec?.intake || {};
+  const processIntake = projectSpec?.process?.intake || {};
+  const intakeEscalation = processIntake.escalation || teamsIntake.escalation || {};
+  const securityEscalationTeams = Array.isArray(intakeEscalation.securityCritical)
+    ? intakeEscalation.securityCritical.join(', ')
+    : '';
+  const blockedEscalationTeams = Array.isArray(intakeEscalation.blockedCrossTeam)
+    ? intakeEscalation.blockedCrossTeam.join(', ')
+    : '';
   const vars = {
     ...projectVars,
+    issueTracker: projectVars.issueTracker || 'github',
+    intakeOwnerTeam: projectVars.intakeOwnerTeam || processIntake.ownerTeam || teamsIntake.ownerTeam || 'product',
+    intakeOperationsTeam:
+      projectVars.intakeOperationsTeam ||
+      processIntake.operationsTeam ||
+      teamsIntake.operationsTeam ||
+      'quality',
+    intakeCadence: projectVars.intakeCadence || processIntake.cadence || 'daily',
+    intakeSecurityEscalationTeams: securityEscalationTeams,
+    intakeBlockedEscalationTeams: blockedEscalationTeams,
     version,
     overlayTemplatesDir: resolve(overlayDir, 'templates'),
     repoName:

--- a/.agentkit/spec/commands.yaml
+++ b/.agentkit/spec/commands.yaml
@@ -157,18 +157,31 @@ commands:
   - name: sync-backlog
     type: workflow
     description: >
-      Synchronizes the local backlog with GitHub Issues and project boards.
-      Pulls open issues, maps them to teams, updates local tracking documents,
+      Synchronizes the local backlog with the configured issue tracker
+      (GitHub or Linear), maps findings to ownership teams, updates local
+      tracking documents,
       and identifies stale or unassigned work items.
     flags:
+      - name: --tracker
+        description: 'Override tracker for this run (github, linear)'
+        type: string
+        default: null
+        required: false
+        enum: [github, linear]
       - name: --direction
-        description: 'Sync direction: pull (from GitHub), push (to GitHub), or both'
+        description: 'Sync direction: pull (from tracker), push (to tracker), or both'
         type: string
         default: 'pull'
       - name: --labels
-        description: 'Filter by GitHub labels (comma-separated)'
+        description: 'Filter by labels/tags (comma-separated)'
         type: string
         default: null
+      - name: --owner-team
+        description: 'Override intake owner team for this run'
+        type: string
+        default: null
+        required: false
+        enum: [backend, frontend, data, infra, devops, testing, security, docs, product, quality]
       - name: --team
         description: 'Filter issues relevant to a specific team'
         type: string

--- a/.agentkit/spec/project.yaml
+++ b/.agentkit/spec/project.yaml
@@ -132,12 +132,18 @@ process:
   commitConvention: conventional # conventional | semantic | none
   codeReview: required-pr # required-pr | optional | none
   teamSize: solo # solo | small | medium | large
-  # Issue tracker used by review/project-review agents to file template or generated-format findings.
+  # Issue tracker used by review/project-review/sync-backlog workflows.
   # github   → gh issue create (requires gh CLI authenticated)
   # linear   → Linear MCP or linear CLI
-  # jira     → jira CLI or REST API via Bash
   # none     → log finding to events.log only, do not open external issue
-  issueTracker: github # github | linear | jira | none
+  issueTracker: github # github | linear | none
+  intake:
+    ownerTeam: product # primary triage owner
+    operationsTeam: quality # routing/hygiene executor
+    cadence: daily # daily | on-demand | weekly
+    escalation:
+      securityCritical: [security, devops]
+      blockedCrossTeam: [product]
 
 # Testing strategy
 testing:

--- a/.agentkit/spec/teams.yaml
+++ b/.agentkit/spec/teams.yaml
@@ -83,6 +83,24 @@ teams:
     accepts: [review, investigate]
     handoff-chain: []
 
+intake:
+  ownerTeam: product
+  operationsTeam: quality
+  routing:
+    backend: backend
+    frontend: frontend
+    data: data
+    infra: infra
+    devops: devops
+    testing: testing
+    security: security
+    docs: docs
+    product: product
+    quality: quality
+  escalation:
+    securityCritical: [security, devops]
+    blockedCrossTeam: [product]
+
 # =============================================================================
 # Tech Stack Definitions
 # Each stack declares build/test/lint/format commands and file detection patterns

--- a/.agentkit/templates/claude/commands/sync-backlog.md
+++ b/.agentkit/templates/claude/commands/sync-backlog.md
@@ -12,6 +12,17 @@ last_updated: '{{syncDate}}'
 
 You are the **Backlog Sync Agent**. Your job is to maintain `AGENT_BACKLOG.md` — the single source of truth for what work needs to be done. You synthesize information from multiple sources into a clean, prioritized, actionable backlog.
 
+## Intake Configuration (Source of Truth)
+
+- **Tracker:** `{{issueTracker}}`
+- **Intake owner:** `{{intakeOwnerTeam}}`
+- **Operations owner:** `{{intakeOperationsTeam}}`
+- **Cadence:** `{{intakeCadence}}`
+{{#if intakeSecurityEscalationTeams}}- **Security-critical escalation:** `{{intakeSecurityEscalationTeams}}`{{/if}}
+{{#if intakeBlockedEscalationTeams}}- **Blocked cross-team escalation:** `{{intakeBlockedEscalationTeams}}`{{/if}}
+
+Use these values as defaults unless the command flags override them for the current run.
+
 ## Input Sources
 
 Gather work items from all of the following sources:
@@ -138,6 +149,14 @@ When updating an existing backlog:
 3. **Preserve completed items.** Move them to the "Completed" section, do not delete them.
 4. **Re-prioritize based on current state.** A P2 item may become P0 if the build is now broken.
 5. **Preserve manually added items.** If an item does not match any automated source, keep it (it was likely added by a human).
+
+## Tracker Execution Rules
+
+1. Read `process.issueTracker` from `.agentkit/spec/project.yaml` unless `--tracker` is provided.
+2. For `github`, use `gh` issue/board commands and GitHub metadata.
+3. For `linear`, use configured Linear integration (MCP/CLI/API) with equivalent field mapping.
+4. If tracker is `none`, skip external create/update actions and only update local backlog + events.
+5. Keep team routing anchored to intake owner `{{intakeOwnerTeam}}` and operations owner `{{intakeOperationsTeam}}`.
 
 ## State Updates
 

--- a/.agentkit/templates/codex/skills/TEMPLATE/SKILL.md
+++ b/.agentkit/templates/codex/skills/TEMPLATE/SKILL.md
@@ -43,3 +43,16 @@ Invoke this skill when you need to perform the `{{commandName}}` operation.
 - Include tests for behavioral changes
 - Never expose secrets or credentials
 - Follow the project's established patterns
+
+{{#if isSyncBacklog}}
+## Intake Semantics
+
+- Tracker: `{{issueTracker}}`
+- Intake owner team: `{{intakeOwnerTeam}}`
+- Operations team: `{{intakeOperationsTeam}}`
+- Cadence: `{{intakeCadence}}`
+{{#if intakeSecurityEscalationTeams}}- Security-critical escalation: `{{intakeSecurityEscalationTeams}}`{{/if}}
+{{#if intakeBlockedEscalationTeams}}- Blocked cross-team escalation: `{{intakeBlockedEscalationTeams}}`{{/if}}
+
+For backlog sync, use tracker-neutral intake and ownership-aware routing based on configured intake values.
+{{/if}}

--- a/.agentkit/templates/copilot/prompts/TEMPLATE.prompt.md
+++ b/.agentkit/templates/copilot/prompts/TEMPLATE.prompt.md
@@ -44,3 +44,16 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+
+{{#if isSyncBacklog}}
+## Intake Semantics
+
+- Tracker: `{{issueTracker}}`
+- Intake owner team: `{{intakeOwnerTeam}}`
+- Operations team: `{{intakeOperationsTeam}}`
+- Cadence: `{{intakeCadence}}`
+{{#if intakeSecurityEscalationTeams}}- Security-critical escalation: `{{intakeSecurityEscalationTeams}}`{{/if}}
+{{#if intakeBlockedEscalationTeams}}- Blocked cross-team escalation: `{{intakeBlockedEscalationTeams}}`{{/if}}
+
+Apply tracker-neutral issue intake behavior and ownership-aware routing when running this command.
+{{/if}}

--- a/.agentkit/templates/cursor/commands/TEMPLATE.md
+++ b/.agentkit/templates/cursor/commands/TEMPLATE.md
@@ -29,3 +29,16 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - Every behavioral change must include tests
 - Never commit secrets or credentials
 - Follow the project's coding standards and quality gates
+
+{{#if isSyncBacklog}}
+## Intake Semantics
+
+- Tracker: `{{issueTracker}}`
+- Intake owner team: `{{intakeOwnerTeam}}`
+- Operations team: `{{intakeOperationsTeam}}`
+- Cadence: `{{intakeCadence}}`
+{{#if intakeSecurityEscalationTeams}}- Security-critical escalation: `{{intakeSecurityEscalationTeams}}`{{/if}}
+{{#if intakeBlockedEscalationTeams}}- Blocked cross-team escalation: `{{intakeBlockedEscalationTeams}}`{{/if}}
+
+Keep backlog sync tracker-neutral (GitHub/Linear) and ownership-aware using the configured intake values.
+{{/if}}

--- a/.agentkit/templates/windsurf/templates/command.md
+++ b/.agentkit/templates/windsurf/templates/command.md
@@ -31,3 +31,16 @@ Execute the steps defined in the corresponding command (`.windsurf/commands/{{co
 - `/plan` — Structured planning before implementation
 - `/project-review` — Comprehensive project audit
 - See `COMMAND_GUIDE.md` for when to choose each command
+
+{{#if isSyncBacklog}}
+## Intake Semantics
+
+- Tracker: `{{issueTracker}}`
+- Intake owner team: `{{intakeOwnerTeam}}`
+- Operations team: `{{intakeOperationsTeam}}`
+- Cadence: `{{intakeCadence}}`
+{{#if intakeSecurityEscalationTeams}}- Security-critical escalation: `{{intakeSecurityEscalationTeams}}`{{/if}}
+{{#if intakeBlockedEscalationTeams}}- Blocked cross-team escalation: `{{intakeBlockedEscalationTeams}}`{{/if}}
+
+Run sync-backlog against the configured tracker with ownership-based routing and escalation.
+{{/if}}

--- a/.github/agents/backend.agent.md
+++ b/.github/agents/backend.agent.md
@@ -23,6 +23,7 @@ Senior backend engineer responsible for API design, service architecture, core b
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/brand-guardian.agent.md
+++ b/.github/agents/brand-guardian.agent.md
@@ -1,6 +1,6 @@
 ---
 name: 'Brand Guardian'
-description: 'Brand consistency specialist ensuring all visual and written outputs align with the established brand identity, design tokens, and style guidelines across all touchpoints.'
+description: 'Brand consistency specialist ensuring all visual and written outputs align with the established brand identity, design tokens, and style guidelines across all touchpoints. The canonical brand source of truth is .agentkit/spec/brand.yaml; editor theming is configured in .agentkit/spec/editor-theme.yaml. Use /brand to validate, preview, scaffold, or regenerate brand assets.'
 generated_by: 'agentkit-forge'
 last_model: 'sync-engine'
 last_updated: '2026-03-04'
@@ -14,7 +14,7 @@ last_updated: '2026-03-04'
 
 # Brand Guardian
 
-Brand consistency specialist ensuring all visual and written outputs align with the established brand identity, design tokens, and style guidelines across all touchpoints.
+Brand consistency specialist ensuring all visual and written outputs align with the established brand identity, design tokens, and style guidelines across all touchpoints. The canonical brand source of truth is .agentkit/spec/brand.yaml; editor theming is configured in .agentkit/spec/editor-theme.yaml. Use /brand to validate, preview, scaffold, or regenerate brand assets.
 
 ## Repository Context
 
@@ -23,6 +23,7 @@ Brand consistency specialist ensuring all visual and written outputs align with 
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 
@@ -41,15 +42,23 @@ Scan the codebase within your focus area before making changes. Read `UNIFIED_AG
 - apps/marketing/**
 - public/assets/**
 - docs/brand/**
+- .agentkit/spec/brand.yaml
+- .agentkit/spec/editor-theme.yaml
+- .vscode/settings.json
+- .cursor/settings.json
+- .windsurf/settings.json
 
 ## Responsibilities
 
 - Enforce brand guidelines across all UI components and marketing pages
-- Maintain design token definitions (colors, typography, spacing)
-- Review visual changes for brand consistency
+- Maintain design token definitions (colors, typography, spacing) in brand.yaml
+- Review visual changes for brand consistency — cross-reference against brand.yaml
 - Ensure logo usage, color palette, and typography follow brand standards
-- Validate marketing materials and landing pages
-- Maintain brand documentation and style guides
+- Validate marketing materials and landing pages against brand palette
+- Maintain brand documentation and style guides in docs/brand/
+- Validate brand.yaml spec on changes (identity, colors, accessibility, darkMode)
+- Review editor-theme.yaml color mappings for correctness and contrast compliance
+- Ensure generated editor themes (.vscode, .cursor, .windsurf) match brand intent
 
 ## Tools
 
@@ -58,6 +67,60 @@ Scan the codebase within your focus area before making changes. Read `UNIFIED_AG
 - Edit
 - Glob
 - Grep
+- Bash
+
+## Domain Rules
+
+- .agentkit/spec/brand.yaml is the single source of truth for all brand colors, typography, and design tokens — never define colors outside this file
+- Editor themes are derived from brand.yaml via editor-theme.yaml mappings — the sync engine generates hex values in settings.json (this is expected), but never manually edit those generated hex values; always update brand.yaml or editor-theme.yaml and re-run sync
+- All color entries in brand.yaml support simple hex strings ("#RRGGBB") or detailed objects ({ hex, role, rationale, usage }) — the resolver handles both formats transparently
+- Brand colors must meet WCAG AA contrast ratios (4.5:1 body text, 3:1 large text / UI components) per the accessibility section in brand.yaml
+- Color changes in brand.yaml must propagate to all three editor targets (vscode, cursor, windsurf) via agentkit sync — never update one target manually
+
+## Agent Conventions
+
+- When reviewing PRs that touch styles, tokens, or CSS, always cross-reference color values against brand.yaml for consistency
+- Run /brand --validate after any change to brand.yaml or editor-theme.yaml to catch regressions
+- Use /brand --contrast to verify accessibility before approving visual changes
+- Prefer semantic color names (success, warning, error, info) over raw hex values in component styles
+
+## Examples
+
+### Valid brand.yaml color entry (simple hex)
+```
+colors:
+  primary:
+    brand: "#1976D2"
+    light: "#42A5F5"
+    dark: "#0D47A1"
+```
+
+### Valid brand.yaml color entry (detailed object)
+```
+colors:
+  semantic:
+    success:
+      hex: "#2E7D32"
+      role: "Positive outcomes, confirmations"
+      rationale: "Green with sufficient contrast on both light and dark surfaces"
+      usage: ["toast success", "form validation passed", "status badge"]
+```
+
+### Editor theme mapping (brand path reference)
+```
+mappings:
+  titleBar.activeBackground: colors.primary.dark
+  titleBar.activeForeground: colors.neutral.white
+  statusBar.background: colors.primary.brand
+  statusBar.foreground: colors.neutral.white
+```
+
+## Anti-Patterns
+
+- Hardcoding hex color values in CSS, JSX, or style files instead of referencing brand tokens from brand.yaml
+- Manually editing .vscode/settings.json workbench.colorCustomizations instead of updating brand.yaml + editor-theme.yaml and running sync
+- Defining new color tokens in component files without adding them to the canonical brand.yaml palette
+- Skipping WCAG contrast validation when introducing new foreground/background color pairs
 
 ## Conventions
 

--- a/.github/agents/content-strategist.agent.md
+++ b/.github/agents/content-strategist.agent.md
@@ -23,6 +23,7 @@ Content strategy specialist responsible for messaging, copy, documentation voice
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/coverage-tracker.agent.md
+++ b/.github/agents/coverage-tracker.agent.md
@@ -23,6 +23,7 @@ Test coverage analysis specialist monitoring code coverage metrics, identifying 
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/data.agent.md
+++ b/.github/agents/data.agent.md
@@ -23,6 +23,7 @@ Senior data engineer responsible for database design, migrations, data models, a
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/dependency-watcher.agent.md
+++ b/.github/agents/dependency-watcher.agent.md
@@ -23,6 +23,7 @@ Dependency management specialist responsible for monitoring, updating, and audit
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/devops.agent.md
+++ b/.github/agents/devops.agent.md
@@ -23,6 +23,7 @@ Senior DevOps engineer responsible for CI/CD pipelines, build automation, contai
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/environment-manager.agent.md
+++ b/.github/agents/environment-manager.agent.md
@@ -23,6 +23,7 @@ Environment configuration specialist ensuring consistent, secure, and documented
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/frontend.agent.md
+++ b/.github/agents/frontend.agent.md
@@ -23,6 +23,7 @@ Senior frontend engineer responsible for UI implementation, component architectu
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/growth-analyst.agent.md
+++ b/.github/agents/growth-analyst.agent.md
@@ -23,6 +23,7 @@ Growth and analytics specialist focused on user acquisition, activation, retenti
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/infra.agent.md
+++ b/.github/agents/infra.agent.md
@@ -23,6 +23,7 @@ Senior infrastructure engineer responsible for Infrastructure as Code, cloud res
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/integration-tester.agent.md
+++ b/.github/agents/integration-tester.agent.md
@@ -23,6 +23,7 @@ Integration and end-to-end test specialist responsible for testing cross-service
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/product-manager.agent.md
+++ b/.github/agents/product-manager.agent.md
@@ -23,6 +23,7 @@ Product management specialist responsible for feature definition, prioritization
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/project-shipper.agent.md
+++ b/.github/agents/project-shipper.agent.md
@@ -23,6 +23,7 @@ Delivery-focused project management specialist responsible for moving work throu
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -23,6 +23,7 @@ Release management specialist responsible for coordinating releases, managing ve
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/roadmap-tracker.agent.md
+++ b/.github/agents/roadmap-tracker.agent.md
@@ -23,6 +23,7 @@ Roadmap and milestone tracking specialist maintaining visibility into project pr
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/security-auditor.agent.md
+++ b/.github/agents/security-auditor.agent.md
@@ -23,6 +23,7 @@ Security audit specialist performing continuous security analysis, vulnerability
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/test-lead.agent.md
+++ b/.github/agents/test-lead.agent.md
@@ -23,6 +23,7 @@ Test strategy lead responsible for overall test architecture, test planning, and
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/agents/ui-designer.agent.md
+++ b/.github/agents/ui-designer.agent.md
@@ -23,6 +23,7 @@ UI/UX design specialist responsible for interaction patterns, component design, 
 - **Primary context docs:** `CLAUDE.md`, `UNIFIED_AGENT_TEAMS.md`, `AGENT_TEAMS.md`, `AGENT_BACKLOG.md`, `docs/`
   - **Tech stack:** javascript, yaml, markdown
   - **Architecture:** monolith
+  - **Brand:** AgentKit Forge (primary: `#1976D2`) — spec at `.agentkit/spec/brand.yaml`
 
 Scan the codebase within your focus area before making changes. Read `UNIFIED_AGENT_TEAMS.md` and `AGENT_TEAMS.md` first for ownership/escalation, then `AGENT_BACKLOG.md` and `CLAUDE.md` for current project context.
 

--- a/.github/prompts/build.prompt.md
+++ b/.github/prompts/build.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/check.prompt.md
+++ b/.github/prompts/check.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/cost.prompt.md
+++ b/.github/prompts/cost.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/deploy.prompt.md
+++ b/.github/prompts/deploy.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/discover.prompt.md
+++ b/.github/prompts/discover.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/doctor.prompt.md
+++ b/.github/prompts/doctor.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/format.prompt.md
+++ b/.github/prompts/format.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/handoff.prompt.md
+++ b/.github/prompts/handoff.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/healthcheck.prompt.md
+++ b/.github/prompts/healthcheck.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/orchestrate.prompt.md
+++ b/.github/prompts/orchestrate.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/preflight.prompt.md
+++ b/.github/prompts/preflight.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/project-review.prompt.md
+++ b/.github/prompts/project-review.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/scaffold.prompt.md
+++ b/.github/prompts/scaffold.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/security.prompt.md
+++ b/.github/prompts/security.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/sync-backlog.prompt.md
+++ b/.github/prompts/sync-backlog.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-description: 'Synchronizes the local backlog with GitHub Issues and project boards. Pulls open issues, maps them to teams, updates local tracking documents, and identifies stale or unassigned work items.'
+description: 'Synchronizes the local backlog with the configured issue tracker (GitHub or Linear), maps findings to ownership teams, updates local tracking documents, and identifies stale or unassigned work items.'
 generated_by: 'agentkit-forge'
 last_model: 'sync-engine'
 last_updated: '2026-03-04'
@@ -14,7 +14,7 @@ last_updated: '2026-03-04'
 
 # sync-backlog
 
-Synchronizes the local backlog with GitHub Issues and project boards. Pulls open issues, maps them to teams, updates local tracking documents, and identifies stale or unassigned work items.
+Synchronizes the local backlog with the configured issue tracker (GitHub or Linear), maps findings to ownership teams, updates local tracking documents, and identifies stale or unassigned work items.
 
 ## Instructions
 
@@ -48,3 +48,15 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+
+## Intake Semantics
+
+- Tracker: `github`
+- Intake owner team: `product`
+- Operations team: `quality`
+- Cadence: `daily`
+- Security-critical escalation: `security, devops`
+- Blocked cross-team escalation: `product`
+
+Apply tracker-neutral issue intake behavior and ownership-aware routing when running this command.
+

--- a/.github/prompts/test.prompt.md
+++ b/.github/prompts/test.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/.github/prompts/validate.prompt.md
+++ b/.github/prompts/validate.prompt.md
@@ -48,3 +48,4 @@ When invoked, follow the AgentKit Forge orchestration lifecycle:
 - See `AGENT_BACKLOG.md` for active work items
 - See `CLAUDE.md` for project context and workflow
 - See `docs/` for architecture, runbooks, and guides
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ Always run the full test suite before creating a pull request. Never disable or 
 - **API Spec**: `docs/04_api/`
 - **Technical Spec**: `docs/02_specs/`
 
+- **Brand Guide**: `.agentkit/spec/brand.yaml` — AgentKit Forge (primary: `#1976D2`)
+
 - **Quality Gates**: `QUALITY_GATES.md`
 - **Runbook**: `RUNBOOK_AI.md`
 

--- a/COMMAND_GUIDE.md
+++ b/COMMAND_GUIDE.md
@@ -187,6 +187,25 @@ This guide helps you choose the right command for your situation. Most workflow 
 
 ---
 
+### `/brand` — Brand spec management and auditing
+
+**Use when:**
+
+- You need to validate `brand.yaml` after editing colors, typography, or accessibility settings
+- You want to preview the full resolved color palette (`--palette`) or editor theme mapping (`--theme`)
+- You need to audit foreground/background contrast ratios for WCAG compliance (`--contrast`)
+- You're setting up a new project and need a brand spec scaffolded (`--init`)
+- You've changed brand.yaml and need to regenerate editor theme files (`--generate`)
+- You want a full brand audit in one pass (`--all`)
+
+**Not for:** Code review (use `/review`), general quality gates (use `/check`), project-wide audit (use `/project-review`).
+
+**Flags:** `--validate` (default), `--palette`, `--theme`, `--contrast`, `--init`, `--generate`, `--all`
+
+**Shared assets:** Reads `.agentkit/spec/brand.yaml`, `.agentkit/spec/editor-theme.yaml`. May write `.vscode/settings.json` (with `--generate`) or `.agentkit/spec/brand.yaml` (with `--init`).
+
+---
+
 ## Quick Decision Tree
 
 | Situation                       | Command                                        |
@@ -201,6 +220,7 @@ This guide helps you choose the right command for your situation. Most workflow 
 | Delegate work to a team         | `/delegate`                                    |
 | Generate scaffolded skeletons   | `/scaffold`                                    |
 | Run release readiness checks    | `/preflight`                                   |
+| Validate or audit brand spec    | `/brand` or `/brand --all`                     |
 | Review a PR or commit range     | `/review`                                      |
 | Update backlog from findings    | `/sync-backlog`                                |
 | End of session, hand off        | `/handoff`                                     |


### PR DESCRIPTION
## Summary

Implements issue #203 by rolling out first-class intake ownership and tracker flow across source-of-truth specs, validation, sync variable propagation, and generated platform artifacts.

Closes #203

## What changed

- Added intake configuration in `.agentkit/spec/project.yaml` under `process.intake` and tightened `process.issueTracker` to `github | linear | none`.
- Added team-level intake ownership/routing metadata in `.agentkit/spec/teams.yaml` (`intake.ownerTeam`, `operationsTeam`, `routing`, `escalation`).
- Updated `.agentkit/spec/commands.yaml` `sync-backlog` command to be tracker-neutral and ownership-aware (`--tracker`, `--owner-team`, updated semantics).
- Extended schema validation in `.agentkit/engines/node/src/spec-validator.mjs` and added tests in `.agentkit/engines/node/src/__tests__/spec-validator.test.mjs`.
- Propagated intake vars through sync rendering in `.agentkit/engines/node/src/project-mapping.mjs` and `.agentkit/engines/node/src/synchronize.mjs`.
- Added sync-backlog intake semantics blocks across Claude/Copilot/Cursor/Windsurf/Codex templates and regenerated outputs.

## Acceptance criteria evidence

- `pnpm -C .agentkit agentkit:spec-validate` passed
- `pnpm -C .agentkit agentkit:sync` then second sync with no unexpected drift
- `pnpm -C .agentkit agentkit:validate` passed
- Generated Claude/Copilot/Cursor/Windsurf/Codex outputs reflect consistent intake semantics