### PR TITLE
🔒 fix regular expression injection in create-doc scripts

### DIFF
--- a/scripts/create-doc.ps1
+++ b/scripts/create-doc.ps1
@@ -88,15 +88,15 @@ if (-not (Test-Path $TemplateSrc)) {
 
 $PrRef = if ($PrNumber) { "#$PrNumber" } else { '[#PR-Number]' }
 
-(Get-Content $TemplateSrc -Raw) `
-  -replace '\[Feature\/Change Name\]', $Title `
-  -replace '\[Bug Description\]',      $Title `
-  -replace '\[Feature Name\]',         $Title `
-  -replace '\[Migration Name\]',       $Title `
-  -replace '\[Issue Title\]',          $Title `
-  -replace '\[Lesson Title\]',         $Title `
-  -replace '\[YYYY-MM-DD\]',           $Date  `
-  -replace '\[#PR-Number\]',           $PrRef |
+(Get-Content $TemplateSrc -Raw).
+  Replace('[Feature/Change Name]', $Title).
+  Replace('[Bug Description]',      $Title).
+  Replace('[Feature Name]',         $Title).
+  Replace('[Migration Name]',       $Title).
+  Replace('[Issue Title]',          $Title).
+  Replace('[Lesson Title]',         $Title).
+  Replace('[YYYY-MM-DD]',           $Date).
+  Replace('[#PR-Number]',           $PrRef) |
   Set-Content -Encoding UTF8 $DestFile
 
 # ---------------------------------------------------------------------------

--- a/scripts/create-doc.sh
+++ b/scripts/create-doc.sh
@@ -101,16 +101,30 @@ fi
 
 PR_REF="${PR_NUMBER:+#${PR_NUMBER}}"
 
-sed \
-  -e "s/\[Feature\/Change Name\]/$TITLE/g" \
-  -e "s/\[Bug Description\]/$TITLE/g" \
-  -e "s/\[Feature Name\]/$TITLE/g" \
-  -e "s/\[Migration Name\]/$TITLE/g" \
-  -e "s/\[Issue Title\]/$TITLE/g" \
-  -e "s/\[Lesson Title\]/$TITLE/g" \
-  -e "s/\[YYYY-MM-DD\]/$DATE/g" \
-  -e "s/\[#PR-Number\]/${PR_REF:-[#PR-Number]}/g" \
-  "$TEMPLATE_SRC" > "$DEST_FILE"
+# Perform literal replacements using Node.js to avoid sed injection
+TITLE_VAL="$TITLE" DATE_VAL="$DATE" PR_REF_VAL="${PR_REF:-[#PR-Number]}" \
+node - "$TEMPLATE_SRC" "$DEST_FILE" << 'NODEEOF'
+  const fs = require('fs');
+  const [,, src, dest] = process.argv;
+  let content = fs.readFileSync(src, 'utf8');
+
+  const replacements = {
+    '[Feature/Change Name]': process.env.TITLE_VAL,
+    '[Bug Description]':      process.env.TITLE_VAL,
+    '[Feature Name]':         process.env.TITLE_VAL,
+    '[Migration Name]':       process.env.TITLE_VAL,
+    '[Issue Title]':          process.env.TITLE_VAL,
+    '[Lesson Title]':         process.env.TITLE_VAL,
+    '[YYYY-MM-DD]':           process.env.DATE_VAL,
+    '[#PR-Number]':           process.env.PR_REF_VAL
+  };
+
+  for (const [placeholder, value] of Object.entries(replacements)) {
+    content = content.split(placeholder).join(value);
+  }
+
+  fs.writeFileSync(dest, content, 'utf8');
+NODEEOF
 
 # ---------------------------------------------------------------------------
 # Update index


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
This patch addresses a Regular Expression Injection vulnerability in `scripts/create-doc.ps1` and a potential `sed` injection vulnerability in `scripts/create-doc.sh`.

### ⚠️ Risk: The potential impact if left unfixed
Unescaped user input (such as the document title or PR number) was being used directly in regex-based replacement operations. In PowerShell's `-replace`, special characters like `$` could be interpreted by the regex engine. In the Bash script's `sed` command, characters like `/` or `&` could break the command or lead to unintended text substitution or command execution.

### 🛡️ Solution: How the fix addresses the vulnerability
- In `scripts/create-doc.ps1`, the regex-based `-replace` operator has been replaced with the literal `.Replace()` string method.
- In `scripts/create-doc.sh`, the `sed` command has been replaced with a Node.js-based replacement logic that uses environment variables to pass user input and performs literal string substitution.

---
*PR created automatically by Jules for task [15105542791051393312](https://jules.google.com/task/15105542791051393312) started by @JustAGhosT*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal documentation generation scripts with simplified placeholder replacement mechanisms, improving maintainability and reducing dependency on complex pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->