### PR TITLE
🧪 Testing Improvement: Add task-types.mjs tests

### DIFF
--- a/.agentkit/engines/node/src/__tests__/task-types.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/task-types.test.mjs
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { VALID_TASK_TYPES } from '../task-types.mjs';
+
+describe('VALID_TASK_TYPES', () => {
+  it('contains the expected core task types', () => {
+    expect(VALID_TASK_TYPES).toContain('implement');
+    expect(VALID_TASK_TYPES).toContain('review');
+    expect(VALID_TASK_TYPES).toContain('plan');
+    expect(VALID_TASK_TYPES).toContain('investigate');
+    expect(VALID_TASK_TYPES).toContain('test');
+    expect(VALID_TASK_TYPES).toContain('document');
+  });
+
+  it('is exactly the expected array', () => {
+    expect(VALID_TASK_TYPES).toEqual([
+      'implement',
+      'review',
+      'plan',
+      'investigate',
+      'test',
+      'document',
+    ]);
+  });
+
+  it('is frozen to prevent accidental modification', () => {
+    expect(Object.isFrozen(VALID_TASK_TYPES)).toBe(true);
+  });
+
+  it('throws an error when trying to mutate the array', () => {
+    expect(() => {
+      // @ts-expect-error - testing invalid mutation
+      VALID_TASK_TYPES.push('new-task');
+    }).toThrow(TypeError);
+
+    expect(() => {
+      // @ts-expect-error - testing invalid mutation
+      VALID_TASK_TYPES[0] = 'modified';
+    }).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `VALID_TASK_TYPES` array in `task-types.mjs` was missing tests to ensure it contained the expected contents and was properly frozen to prevent accidental modification.

📊 **Coverage:** What scenarios are now tested
Tests have been added to verify:
- The array contains the expected core task types ('implement', 'review', 'plan', 'investigate', 'test', 'document').
- The array matches the expected array exactly.
- `Object.isFrozen(VALID_TASK_TYPES)` returns true.
- Attempting to mutate the array (e.g., via `push` or assignment) throws a `TypeError`.

✨ **Result:** The improvement in test coverage
Test coverage for `task-types.mjs` is now established, ensuring the immutability and correctness of the shared task-type constants used by the runtime and spec validation.

---
*PR created automatically by Jules for task [13125647733445491585](https://jules.google.com/task/13125647733445491585) started by @JustAGhosT*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests to validate task type definitions and verify immutability protections against accidental modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->