### PR TITLE
🧹 Remove unused import: readFileSync in handoff.mjs

### DIFF
--- a/.agentkit/engines/node/src/handoff.mjs
+++ b/.agentkit/engines/node/src/handoff.mjs
@@ -3,7 +3,7 @@
  * Creates a structured session handoff document with git state,
  * orchestrator state, and recent activity.
  */
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync, writeFileSync, mkdirSync } from 'fs';
 import { resolve } from 'path';
 import { execCommand, formatTimestamp } from './runner.mjs';
 import { appendEvent, readEvents } from './events.mjs';


### PR DESCRIPTION
This change removes an unused import of `readFileSync` from the `fs` module in `.agentkit/engines/node/src/handoff.mjs`. This is a minor code health improvement that reduces clutter and improves maintainability without affecting functionality.

🎯 **What:** Removed unused `readFileSync` import.
💡 **Why:** Improves code cleanliness and maintainability.
✅ **Verification:** Manually verified that the import is removed and the file still contains the other necessary `fs` imports. Attempts to run the full test suite were hindered by sandbox environment issues (network timeouts), but the change is extremely low risk.
✨ **Result:** Cleaner code in the handoff generator.

---
*PR created automatically by Jules for task [4495348125723187498](https://jules.google.com/task/4495348125723187498) started by @JustAGhosT*