### PR TITLE
fix(tests): isolate render target gating tests with fresh temp dirs

### DIFF
--- a/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
@@ -587,10 +587,10 @@ describe('syncRooRules (via runSync --only roo)', () => {
 describe('render target gating for new tools', () => {
   let projectRoot;
 
-  beforeAll(() => {
+  beforeEach(() => {
     projectRoot = makeTmpProject();
   });
-  afterAll(() => {
+  afterEach(() => {
     rmSync(projectRoot, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary

- Fix test isolation bug in `sync-integration.test.mjs` — the "render target gating" describe block shared a single temp directory between tests, causing `--only warp` test to find leftover `.claude/` files from the `--only claude` test

## Root Cause

`beforeAll`/`afterAll` created one temp directory for both tests. The sync engine only adds/updates files, never removes, so files from test 1 (`--only claude`) persisted into test 2 (`--only warp`), causing assertion `expected true to be false` on line 620-621.

## Fix

Changed `beforeAll`/`afterAll` to `beforeEach`/`afterEach` so each test gets a fresh temp directory.

## Test plan

- [x] `npx vitest run engines/node/src/__tests__/sync-integration.test.mjs -t "render target gating"` — both tests pass
- [x] `npx vitest run engines/node/src/__tests__/sync-integration.test.mjs -t "always-on"` — passes in isolation
- [ ] CI passes on this PR

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation in integration test suite by ensuring fresh test environments are created and cleaned up for each test case rather than once per test group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->