### PR TITLE
fix(spec): correct githubSlug to phoenixvc/agentkit-forge

### DIFF
--- a/.agentkit/spec/project.yaml
+++ b/.agentkit/spec/project.yaml
@@ -14,7 +14,7 @@
 
 # Project identity
 name: agentkit-forge # e.g. "chaufher", "phoenix", "my-api"
-githubSlug: JustAGhosT/agentkit-forge # e.g. "my-org/my-repo" — used in GitHub URLs (security advisories, etc.)
+githubSlug: phoenixvc/agentkit-forge # e.g. "my-org/my-repo" — used in GitHub URLs (security advisories, etc.)
 description: AgentKit Forge framework for multi-tool AI agent team orchestration, sync generation, and quality-gated workflows.
 phase: active # greenfield | active | maintenance | legacy
 


### PR DESCRIPTION
## Summary
- Corrects `githubSlug` in `project.yaml` from `JustAGhosT/agentkit-forge` to `phoenixvc/agentkit-forge`

## Test plan
- [x] Sync produces no drift after change
- [x] Single-line spec fix, no generated output affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project repository configuration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->