### PR TITLE
chore(ci): reduce CodeQL to weekly + manual only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,12 @@ name: CodeQL
 on:
   # Reduced to weekly + manual to cut GitHub Actions costs
   # Was running on every push/PR including Renovate bot
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:
@@ -18,6 +24,7 @@ concurrency:
 jobs:
   analyze:
     name: analyze-javascript
+    if: github.actor != 'renovate[bot]'
     runs-on: self-hosted
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,8 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  # Reduced to weekly + manual to cut GitHub Actions costs
+  # Was running on every push/PR including Renovate bot
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:
@@ -17,7 +15,6 @@ permissions:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
-
 jobs:
   analyze:
     name: analyze-javascript


### PR DESCRIPTION
## Summary
- Removes `push` and `pull_request` triggers from CodeQL workflow
- Keeps weekly schedule (Mon 6am UTC) and manual `workflow_dispatch`
- Reduces GitHub Actions costs from bot PRs triggering expensive scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)