### PR TITLE
fix(hooks): replace jq --arg with stdin to fix E2BIG on Windows Git Bash

### DIFF
--- a/.agentkit/templates/claude/hooks/pre-push-validate.sh
+++ b/.agentkit/templates/claude/hooks/pre-push-validate.sh
@@ -89,8 +89,8 @@ fi
 
 # -- Emit block decision if errors found ----------------------------------
 if [[ -n "$ERRORS" ]]; then
-    jq -n --arg reason "$(echo -e "$ERRORS")" \
-        '{ decision: "block", reason: $reason }'
+    # Pass reason via stdin to avoid E2BIG on Windows Git Bash (issue #453)
+    printf '%b' "$ERRORS" | jq -Rs '{"decision": "block", "reason": .}'
     exit 0
 fi
 

--- a/.agentkit/templates/claude/hooks/stop-build-check.sh
+++ b/.agentkit/templates/claude/hooks/stop-build-check.sh
@@ -48,6 +48,10 @@ run_check() {
 
 FAILURE_REASON=""
 
+# Helper: emit a block decision — passes reason via stdin to avoid E2BIG on
+# Windows Git Bash when $FAILURE_REASON contains large command output (issue #453).
+emit_block() { printf '%s' "$1" | jq -Rs '{"decision": "block", "reason": .}'; }
+
 # -- Check for spec-modified-without-sync (lightweight git check only) ------
 # Never re-runs agentkit sync here — that can take 30s+ and is too slow for a
 # stop hook. Instead, warn non-blockingly if spec files look dirty.
@@ -93,7 +97,7 @@ if [[ -n "$BRANCH" ]] && [[ "$BRANCH" != "$DEFAULT_BRANCH" ]]; then
 
     if [[ -n "$BAD_COMMITS" ]]; then
         FAILURE_REASON="Commits with non-conventional messages detected. PR titles must follow 'type(scope): description'.\nBad commits:\n${BAD_COMMITS}\nFix with: git rebase -i and reword, or ensure the PR title follows the format."
-        jq -n --arg reason "$FAILURE_REASON" '{ decision: "block", reason: $reason }'
+        emit_block "$FAILURE_REASON"
         exit 0
     fi
 fi
@@ -129,7 +133,7 @@ if [[ -f "${CWD}/package.json" ]] && _has_changed '\.(ts|tsx|js|jsx|mjs|cjs)$'; 
 
     if has_script "lint"; then
         if ! run_check "${pm} lint" "$pm" run lint; then
-            jq -n --arg reason "$FAILURE_REASON" '{ decision: "block", reason: $reason }'
+            emit_block "$FAILURE_REASON"
             exit 0
         fi
     fi
@@ -143,7 +147,7 @@ if _has_changed '\.(cs|csproj|fsproj|vbproj|sln)$'; then
     if [[ -n "$SLN_FILE" ]] && command -v dotnet &>/dev/null; then
         ran_check=true
         if ! run_check "dotnet build" dotnet build "$SLN_FILE" --nologo --verbosity quiet; then
-            jq -n --arg reason "$FAILURE_REASON" '{ decision: "block", reason: $reason }'
+            emit_block "$FAILURE_REASON"
             exit 0
         fi
     fi
@@ -156,7 +160,7 @@ if _has_changed '\.(rs)$|Cargo\.(toml|lock)$'; then
     if [[ -f "${CWD}/Cargo.toml" ]] && command -v cargo &>/dev/null; then
         ran_check=true
         if ! run_check "cargo check" cargo check --manifest-path "${CWD}/Cargo.toml" --quiet; then
-            jq -n --arg reason "$FAILURE_REASON" '{ decision: "block", reason: $reason }'
+            emit_block "$FAILURE_REASON"
             exit 0
         fi
     fi
@@ -169,7 +173,7 @@ if _has_changed '\.py$'; then
     ran_check=true
     if command -v ruff &>/dev/null; then
         if ! run_check "ruff check" ruff check "$CWD" --quiet; then
-            jq -n --arg reason "$FAILURE_REASON" '{ decision: "block", reason: $reason }'
+            emit_block "$FAILURE_REASON"
             exit 0
         fi
     fi

--- a/.claude/hooks/pre-push-validate.sh
+++ b/.claude/hooks/pre-push-validate.sh
@@ -92,8 +92,8 @@ fi
 
 # -- Emit block decision if errors found ----------------------------------
 if [[ -n "$ERRORS" ]]; then
-    jq -n --arg reason "$(echo -e "$ERRORS")" \
-        '{ decision: "block", reason: $reason }'
+    # Pass reason via stdin to avoid E2BIG on Windows Git Bash (issue #453)
+    printf '%b' "$ERRORS" | jq -Rs '{"decision": "block", "reason": .}'
     exit 0
 fi
 

--- a/.claude/hooks/stop-build-check.sh
+++ b/.claude/hooks/stop-build-check.sh
@@ -51,6 +51,10 @@ run_check() {
 
 FAILURE_REASON=""
 
+# Helper: emit a block decision — passes reason via stdin to avoid E2BIG on
+# Windows Git Bash when $FAILURE_REASON contains large command output (issue #453).
+emit_block() { printf '%s' "$1" | jq -Rs '{"decision": "block", "reason": .}'; }
+
 # -- Check for spec-modified-without-sync (lightweight git check only) ------
 # Never re-runs agentkit sync here — that can take 30s+ and is too slow for a
 # stop hook. Instead, warn non-blockingly if spec files look dirty.
@@ -84,7 +88,7 @@ if [[ -n "$BRANCH" ]] && [[ "$BRANCH" != "$DEFAULT_BRANCH" ]]; then
 
     if [[ -n "$BAD_COMMITS" ]]; then
         FAILURE_REASON="Commits with non-conventional messages detected. PR titles must follow 'type(scope): description'.\nBad commits:\n${BAD_COMMITS}\nFix with: git rebase -i and reword, or ensure the PR title follows the format."
-        jq -n --arg reason "$FAILURE_REASON" '{ decision: "block", reason: $reason }'
+        emit_block "$FAILURE_REASON"
         exit 0
     fi
 fi
@@ -117,7 +121,7 @@ if [[ -f "${CWD}/package.json" ]] && _has_changed '\.(ts|tsx|js|jsx|mjs|cjs)$'; 
 
     if has_script "lint"; then
         if ! run_check "${pm} lint" "$pm" run lint; then
-            jq -n --arg reason "$FAILURE_REASON" '{ decision: "block", reason: $reason }'
+            emit_block "$FAILURE_REASON"
             exit 0
         fi
     fi


### PR DESCRIPTION
## Summary

- Adds `emit_block()` helper to `stop-build-check.sh` that pipes the reason string via `printf '%s' | jq -Rs`, avoiding argv entirely
- Replaces all `jq -n --arg reason "$FAILURE_REASON"` calls in `stop-build-check.sh` with `emit_block "$FAILURE_REASON"`
- Replaces the `jq -n --arg reason "$(echo -e "$ERRORS")"` call in `pre-push-validate.sh` with the same stdin pattern
- Applied to both the generated `.claude/hooks/` files and the template sources in `.agentkit/templates/claude/hooks/`

## Why

On Windows Git Bash, passing strings exceeding ~128KB via command-line arguments raises `ENOMEM`/`E2BIG` ("Argument list too long"). When a lint or test run fails with hundreds of lines of output, `$FAILURE_REASON` can hold up to 3000 chars of truncated output — enough to trigger this limit. The hook crashed with:

```
/c/Users/.../.local/bin/jq: Argument list too long
```

Piping via stdin has no length limit and is the idiomatic jq pattern for variable-length strings.

## Test plan

- [ ] Trigger a lint failure with many error lines and verify the stop hook correctly emits a block decision instead of crashing
- [ ] Verify the hook still works normally when there are no failures (exits 0)
- [ ] Run on Windows Git Bash specifically to confirm E2BIG is gone

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined error response handling in validation hooks for improved code maintainability and consistency across build check processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->