### PR TITLE
fix(sync): stop managed-file table-alignment churn (#476)

### DIFF
--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -154,6 +154,38 @@ function threeWayMerge(oursContent, baseContent, theirsContent) {
 }
 
 // ---------------------------------------------------------------------------
+// Normalize content for semantic comparison (ignores table-cell padding)
+// ---------------------------------------------------------------------------
+
+/**
+ * Strips trailing whitespace and normalises markdown table-cell padding so
+ * that a Prettier-aligned table and a compact table compare as equal when
+ * the cell *values* are identical.  Used to detect whether a disk file
+ * differs from the scaffold cache for reasons other than whitespace.
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+export function normalizeForComparison(content) {
+  return content
+    .split('\n')
+    .map((line) => {
+      // Normalise markdown table rows (data rows only, not separator rows like |---|---|)
+      if (/^\s*\|/.test(line) && !/^\s*\|[\s|:-]+\|\s*$/.test(line)) {
+        return line
+          .split('|')
+          .map((cell, i, arr) =>
+            i === 0 || i === arr.length - 1 ? cell.trimEnd() : ` ${cell.trim()} `
+          )
+          .join('|');
+      }
+      return line.trimEnd();
+    })
+    .join('\n')
+    .trimEnd();
+}
+
+// ---------------------------------------------------------------------------
 // I/O helpers
 // ---------------------------------------------------------------------------
 
@@ -2906,51 +2938,65 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
           const prevHash = previousManifest?.files?.[normalizedRel]?.hash;
 
           if (prevHash && diskHash !== prevHash) {
-            // User edited this file — attempt three-way merge
             const cachePath = resolve(scaffoldCacheDir, relPath);
             const newContent = await readFile(srcFile, 'utf-8');
 
             if (existsSync(cachePath)) {
               const baseContent = readFileSync(cachePath, 'utf-8');
               const diskText = diskContent.toString('utf-8');
-              const result = threeWayMerge(diskText, baseContent, newContent);
 
-              if (result) {
-                // Write merged result
-                await ensureDir(dirname(destFile));
-                await writeFile(destFile, result.merged, 'utf-8');
-                // Update scaffold cache with new generated content
-                await ensureDir(dirname(cachePath));
-                await writeFile(cachePath, newContent, 'utf-8');
-                count++;
+              // Check whether the disk differs from the cache for reasons other
+              // than table-cell padding (Prettier alignment).  If the normalised
+              // forms are identical the file contains no real user edits — fall
+              // through to the pristine overwrite path below.
+              if (normalizeForComparison(diskText) !== normalizeForComparison(baseContent)) {
+                // Real user edit — attempt three-way merge
+                const result = threeWayMerge(diskText, baseContent, newContent);
 
-                writtenFiles.push(destFile);
-                if (result.hasConflicts) {
-                  scaffoldResults.managedConflicts.push(normalizedRel);
-                  console.warn(
-                    `[retort:sync] CONFLICT in ${normalizedRel} — resolve <<<< markers manually`
-                  );
-                } else {
-                  scaffoldResults.managedMerged.push(normalizedRel);
-                  logVerbose(`  merged ${normalizedRel} (user edits + template changes combined)`);
+                if (result) {
+                  // Write merged result
+                  await ensureDir(dirname(destFile));
+                  await writeFile(destFile, result.merged, 'utf-8');
+                  // Update scaffold cache with new generated content
+                  await ensureDir(dirname(cachePath));
+                  await writeFile(cachePath, newContent, 'utf-8');
+                  count++;
+
+                  writtenFiles.push(destFile);
+                  if (result.hasConflicts) {
+                    scaffoldResults.managedConflicts.push(normalizedRel);
+                    console.warn(
+                      `[retort:sync] CONFLICT in ${normalizedRel} — resolve <<<< markers manually`
+                    );
+                  } else {
+                    scaffoldResults.managedMerged.push(normalizedRel);
+                    logVerbose(
+                      `  merged ${normalizedRel} (user edits + template changes combined)`
+                    );
+                  }
+                  return;
                 }
+                // git merge-file unavailable — skip and preserve user edits
+                skippedScaffold++;
+                scaffoldResults.managedPreserved.push(normalizedRel);
+                logVerbose(
+                  `  skipped ${normalizedRel} (user edits detected, hash: ${prevHash} → ${diskHash})`
+                );
                 return;
               }
-              // git merge-file unavailable — fall back to skip
-            }
-
-            // No cache or git unavailable — skip and preserve user edits
-            skippedScaffold++;
-            scaffoldResults.managedPreserved.push(normalizedRel);
-            if (!existsSync(resolve(scaffoldCacheDir, relPath))) {
+              // Formatting-only diff — fall through to pristine overwrite
+            } else {
+              // No cache — skip and preserve user edits
+              skippedScaffold++;
+              scaffoldResults.managedPreserved.push(normalizedRel);
               scaffoldResults.managedNoCache.push(normalizedRel);
+              logVerbose(
+                `  skipped ${normalizedRel} (user edits detected, hash: ${prevHash} → ${diskHash})`
+              );
+              return;
             }
-            logVerbose(
-              `  skipped ${normalizedRel} (user edits detected, hash: ${prevHash} → ${diskHash})`
-            );
-            return;
           }
-          // Hash matches or no previous hash — safe to overwrite (pristine)
+          // Hash matches, no previous hash, or formatting-only diff — safe to overwrite (pristine)
           scaffoldResults.managedRegenerated.push(normalizedRel);
         } else {
           // action === 'write' for scaffold: always

--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -2950,7 +2950,20 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
               // forms are identical the file contains no real user edits — fall
               // through to the pristine overwrite path below.
               if (normalizeForComparison(diskText) !== normalizeForComparison(baseContent)) {
-                // Real user edit — attempt three-way merge
+                // Real user edit.  Only attempt a three-way merge when the template
+                // has actually changed since the last sync (base ≠ theirs after
+                // normalisation).  When the template is unchanged the merge would
+                // be a no-op (result === disk) — skip it to stop the churn loop.
+                if (normalizeForComparison(baseContent) === normalizeForComparison(newContent)) {
+                  // Template unchanged — preserve user edits, no write needed
+                  skippedScaffold++;
+                  scaffoldResults.managedPreserved.push(normalizedRel);
+                  logVerbose(
+                    `  skipped ${normalizedRel} (user edits preserved, template unchanged)`
+                  );
+                  return;
+                }
+
                 const result = threeWayMerge(diskText, baseContent, newContent);
 
                 if (result) {

--- a/.agents/skills/backlog/SKILL.md
+++ b/.agents/skills/backlog/SKILL.md
@@ -33,6 +33,7 @@ Invoke this skill when you need to perform the `backlog` operation.
 - Return a concise summary with status (`success`/`partial`/`failed`)
 - Include validation evidence (exit code, failing command, or passing summary)
 - Include next-step remediation when checks fail
+  
 
 ## Project Context
 
@@ -47,3 +48,4 @@ Invoke this skill when you need to perform the `backlog` operation.
 - Include tests for behavioral changes
 - Never expose secrets or credentials
 - Follow the project's established patterns
+

--- a/.agents/skills/cost-centres/SKILL.md
+++ b/.agents/skills/cost-centres/SKILL.md
@@ -33,6 +33,7 @@ Invoke this skill when you need to perform the `cost-centres` operation.
 - Return a concise summary with status (`success`/`partial`/`failed`)
 - Include validation evidence (exit code, failing command, or passing summary)
 - Include next-step remediation when checks fail
+  
 
 ## Project Context
 
@@ -47,3 +48,4 @@ Invoke this skill when you need to perform the `cost-centres` operation.
 - Include tests for behavioral changes
 - Never expose secrets or credentials
 - Follow the project's established patterns
+

--- a/.agents/skills/preflight/SKILL.md
+++ b/.agents/skills/preflight/SKILL.md
@@ -52,3 +52,4 @@ If `--range` is omitted, auto-detect via merge-base against the default branch. 
 - Include tests for behavioral changes
 - Never expose secrets or credentials
 - Follow the project's established patterns
+

--- a/.cursor/commands/security.md
+++ b/.cursor/commands/security.md
@@ -33,12 +33,12 @@ Search for: API keys, AWS keys, private keys, connection strings, passwords, tok
 
 ## Severity Classification
 
-| Severity | Criteria                                                            |
-| -------- | ------------------------------------------------------------------- |
+| Severity | Criteria |
+|----------|----------|
 | CRITICAL | Exploitable remotely, no auth required, data breach or RCE possible |
-| HIGH     | Low complexity exploit, auth bypass, significant data exposure      |
-| MEDIUM   | Requires specific conditions, limited impact, defense-in-depth gap  |
-| LOW      | Best practice violation, minimal direct impact                      |
+| HIGH | Low complexity exploit, auth bypass, significant data exposure |
+| MEDIUM | Requires specific conditions, limited impact, defense-in-depth gap |
+| LOW | Best practice violation, minimal direct impact |
 
 ## Output
 
@@ -65,3 +65,4 @@ Produce: Executive Summary, Risk Score, Findings by severity (with ID, file:line
 - Every behavioral change must include tests
 - Never commit secrets or credentials
 - Follow the project's coding standards and quality gates
+

--- a/.cursor/commands/sync.md
+++ b/.cursor/commands/sync.md
@@ -29,12 +29,12 @@ pnpm --dir .agentkit agentkit:sync
 
 ## Flags
 
-| Flag              | Effect                                                                                               |
-| ----------------- | ---------------------------------------------------------------------------------------------------- |
+| Flag | Effect |
+|------|--------|
 | `--only <target>` | Sync only one platform (claude, cursor, copilot, windsurf, codex, gemini, cline, roo, warp, ai, mcp) |
-| `--overwrite`     | Overwrite project-owned (scaffold-once) files                                                        |
-| `--diff`          | Preview changes without writing                                                                      |
-| `--no-clean`      | Keep orphaned files that would normally be removed                                                   |
+| `--overwrite` | Overwrite project-owned (scaffold-once) files |
+| `--diff` | Preview changes without writing |
+| `--no-clean` | Keep orphaned files that would normally be removed |
 
 ## Post-Sync
 
@@ -66,3 +66,4 @@ This command requires shell access (Bash tool). On platforms with restricted too
 - Every behavioral change must include tests
 - Never commit secrets or credentials
 - Follow the project's coding standards and quality gates
+

--- a/.windsurf/commands/security.md
+++ b/.windsurf/commands/security.md
@@ -40,12 +40,12 @@ Search for: API keys, AWS keys, private keys, connection strings, passwords, tok
 
 ## Severity Classification
 
-| Severity | Criteria                                                            |
-| -------- | ------------------------------------------------------------------- |
+| Severity | Criteria |
+|----------|----------|
 | CRITICAL | Exploitable remotely, no auth required, data breach or RCE possible |
-| HIGH     | Low complexity exploit, auth bypass, significant data exposure      |
-| MEDIUM   | Requires specific conditions, limited impact, defense-in-depth gap  |
-| LOW      | Best practice violation, minimal direct impact                      |
+| HIGH | Low complexity exploit, auth bypass, significant data exposure |
+| MEDIUM | Requires specific conditions, limited impact, defense-in-depth gap |
+| LOW | Best practice violation, minimal direct impact |
 
 ## Output
 
@@ -65,3 +65,4 @@ Produce: Executive Summary, Risk Score, Findings by severity (with ID, file:line
 - `/plan` — Structured planning before implementation
 - `/project-review` — Comprehensive project audit
 - See `COMMAND_GUIDE.md` for when to choose each command
+


### PR DESCRIPTION
## Summary

- Adds `normalizeForComparison()` that strips markdown table-cell padding before comparing disk content against the scaffold cache
- When disk and cache differ only in Prettier-alignment (not real content), the file is treated as pristine and overwritten cleanly
- When disk has real user edits but the template hasn't changed since the last sync, the merge is skipped entirely — this stops the infinite loop where post-merge cache (compact) vs disk (aligned + user edits) would re-trigger a no-op three-way merge on every run

## Root cause

Two related loops were churning managed files:

1. **Table padding loop** — Prettier aligns table cells; the manifest stores hash(compact template). On next sync disk hash ≠ manifest hash → triggers merge → aligned output written → same hash mismatch next run
2. **Post-merge preservation loop** — After a legitimate merge, cache is set to `newContent` (template). Disk has user edits. On every subsequent sync: normalised forms differ → merge triggered → base==theirs → no-op result written → loop

## Fix

Both are resolved in the `check-hash` branch of `resolveScaffoldAction`:

1. Compare `normalizeForComparison(disk)` vs `normalizeForComparison(cache)` before deciding there's a user edit
2. If there IS a real user edit, compare `normalizeForComparison(cache)` vs `normalizeForComparison(newContent)` — if equal, template unchanged → skip (preserve user edits, no write)

## Test plan

- [x] Two consecutive sync runs produce identical output (verified locally: `17 managed regenerated, 12 preserved` both runs)
- [x] `normalizeForComparison` exported for unit testing
- [ ] Unit tests — delegating to `/team-testing` per delegation rules

Closes #476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file synchronization logic to intelligently distinguish between genuine user edits and cosmetic whitespace alignment differences in Markdown content, reducing unnecessary merge conflicts.

* **Documentation**
  * Corrected formatting in skill and command documentation files for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->