### PR TITLE
feat(config): add .retortconfig — agent remapping and opt-in feature flags v1

### DIFF
--- a/.agentkit/engines/node/src/__tests__/retort-config.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/retort-config.test.mjs
@@ -1,0 +1,299 @@
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { applyRetortConfig, loadRetortConfig } from '../retort-config.mjs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir() {
+  const dir = join(
+    tmpdir(),
+    `retort-config-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeConfig(projectRoot, content) {
+  const configPath = join(projectRoot, '.retortconfig');
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, content, 'utf-8');
+}
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = makeTmpDir();
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// loadRetortConfig
+// ---------------------------------------------------------------------------
+
+describe('loadRetortConfig', () => {
+  it('should return null when no .retortconfig file exists', () => {
+    const result = loadRetortConfig(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it('should return an empty object for an empty file', () => {
+    writeConfig(tmpDir, '');
+    const result = loadRetortConfig(tmpDir);
+    expect(result).toEqual({});
+  });
+
+  it('should parse a valid .retortconfig file', () => {
+    writeConfig(
+      tmpDir,
+      `
+retort_version: "3.x"
+project:
+  name: mystira-workspace
+  type: dotnet-monorepo
+agents:
+  backend: mystira-squire
+  model-economist: ~
+features:
+  cost_tracking:
+    enabled: false
+  coverage_guard:
+    enabled: true
+`
+    );
+
+    const result = loadRetortConfig(tmpDir);
+    expect(result).toMatchObject({
+      retort_version: '3.x',
+      project: { name: 'mystira-workspace', type: 'dotnet-monorepo' },
+      agents: { backend: 'mystira-squire', 'model-economist': null },
+      features: {
+        cost_tracking: { enabled: false },
+        coverage_guard: { enabled: true },
+      },
+    });
+  });
+
+  it('should throw on invalid YAML syntax', () => {
+    writeConfig(tmpDir, 'agents: [unclosed');
+    expect(() => loadRetortConfig(tmpDir)).toThrow(/Failed to parse .retortconfig/);
+  });
+
+  it('should throw on unknown top-level keys', () => {
+    writeConfig(tmpDir, 'unknown_key: value\n');
+    expect(() => loadRetortConfig(tmpDir)).toThrow(/unknown keys/);
+  });
+
+  it('should throw when top-level value is not a mapping', () => {
+    writeConfig(tmpDir, '- item1\n- item2\n');
+    expect(() => loadRetortConfig(tmpDir)).toThrow(/must be a YAML mapping/);
+  });
+
+  it('should throw when agents block is not a mapping', () => {
+    writeConfig(tmpDir, 'agents:\n  - backend\n');
+    expect(() => loadRetortConfig(tmpDir)).toThrow(/'agents' must be a mapping/);
+  });
+
+  it('should throw when an agent entry is neither string nor null', () => {
+    writeConfig(tmpDir, 'agents:\n  backend: 123\n');
+    expect(() => loadRetortConfig(tmpDir)).toThrow(/must be a string.*or ~ \(null/);
+  });
+
+  it('should throw when features block is not a mapping', () => {
+    writeConfig(tmpDir, 'features:\n  - cost_tracking\n');
+    expect(() => loadRetortConfig(tmpDir)).toThrow(/'features' must be a mapping/);
+  });
+
+  it('should throw when a feature entry is not a mapping', () => {
+    writeConfig(tmpDir, 'features:\n  cost_tracking: true\n');
+    expect(() => loadRetortConfig(tmpDir)).toThrow(/must be a mapping with an 'enabled' key/);
+  });
+
+  it('should throw when feature enabled is not a boolean', () => {
+    writeConfig(tmpDir, 'features:\n  cost_tracking:\n    enabled: "yes"\n');
+    expect(() => loadRetortConfig(tmpDir)).toThrow(/must be a boolean/);
+  });
+
+  it('should throw when a feature entry has unknown keys', () => {
+    writeConfig(tmpDir, 'features:\n  cost_tracking:\n    enabled: false\n    level: high\n');
+    expect(() => loadRetortConfig(tmpDir)).toThrow(/unknown keys.*level/);
+  });
+
+  it('should throw when project block has unknown keys', () => {
+    writeConfig(tmpDir, 'project:\n  name: foo\n  unknown: bar\n');
+    expect(() => loadRetortConfig(tmpDir)).toThrow(/'project' contains unknown keys/);
+  });
+
+  it('should accept a valid full .retortconfig with all optional sections', () => {
+    writeConfig(
+      tmpDir,
+      `
+retort_version: "3.x"
+project:
+  name: my-project
+  type: typescript-app
+  compliance: [gdpr]
+  stacks: [typescript]
+agents:
+  frontend: my-frontend-agent
+  backend: ~
+features:
+  team-orchestration:
+    enabled: true
+  cost-tracking:
+    enabled: false
+`
+    );
+    expect(() => loadRetortConfig(tmpDir)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyRetortConfig
+// ---------------------------------------------------------------------------
+
+describe('applyRetortConfig', () => {
+  it('should be a no-op when config is null', () => {
+    const vars = {};
+    applyRetortConfig(vars, null);
+    expect(vars).toEqual({});
+  });
+
+  it('should initialise maps and not error when config is an empty object', () => {
+    const vars = {};
+    applyRetortConfig(vars, {});
+    // An empty config still initialises the agent structures so that downstream
+    // code can safely iterate them without null-guards
+    expect(vars.retortAgentMap).toEqual({});
+    expect(vars.retortDisabledAgents).toBeInstanceOf(Set);
+    expect(vars.retortDisabledAgents.size).toBe(0);
+    // No feature overrides should be created
+    expect(vars.retortDisabledFeatures).toBeUndefined();
+    expect(vars.retortEnabledFeatures).toBeUndefined();
+  });
+
+  it('should populate retortAgentMap for remapped agents', () => {
+    const vars = {};
+    applyRetortConfig(vars, {
+      agents: { backend: 'mystira-squire', frontend: 'my-illuminator' },
+    });
+    expect(vars.retortAgentMap).toEqual({
+      backend: 'mystira-squire',
+      frontend: 'my-illuminator',
+    });
+    expect(vars.retortDisabledAgents).toBeInstanceOf(Set);
+    expect(vars.retortDisabledAgents.size).toBe(0);
+  });
+
+  it('should populate retortDisabledAgents for null-valued agents', () => {
+    const vars = {};
+    applyRetortConfig(vars, {
+      agents: { 'model-economist': null, 'input-clarifier': null },
+    });
+    expect(vars.retortDisabledAgents).toBeInstanceOf(Set);
+    expect(vars.retortDisabledAgents.has('model-economist')).toBe(true);
+    expect(vars.retortDisabledAgents.has('input-clarifier')).toBe(true);
+    expect(vars.retortAgentMap).toEqual({});
+  });
+
+  it('should handle mixed remap and disable in the same config', () => {
+    const vars = {};
+    applyRetortConfig(vars, {
+      agents: {
+        backend: 'mystira-squire',
+        'model-economist': null,
+      },
+    });
+    expect(vars.retortAgentMap).toEqual({ backend: 'mystira-squire' });
+    expect(vars.retortDisabledAgents.has('model-economist')).toBe(true);
+  });
+
+  it('should add disabled features to retortDisabledFeatures', () => {
+    const vars = {};
+    applyRetortConfig(vars, {
+      features: {
+        'cost-tracking': { enabled: false },
+        'session-handoff': { enabled: false },
+      },
+    });
+    expect(vars.retortDisabledFeatures).toBeInstanceOf(Set);
+    expect(vars.retortDisabledFeatures.has('cost-tracking')).toBe(true);
+    expect(vars.retortDisabledFeatures.has('session-handoff')).toBe(true);
+  });
+
+  it('should add force-enabled features to retortEnabledFeatures', () => {
+    const vars = {};
+    applyRetortConfig(vars, {
+      features: {
+        'coverage-guard': { enabled: true },
+        'mcp-integration': { enabled: true },
+      },
+    });
+    expect(vars.retortEnabledFeatures).toBeInstanceOf(Set);
+    expect(vars.retortEnabledFeatures.has('coverage-guard')).toBe(true);
+    expect(vars.retortEnabledFeatures.has('mcp-integration')).toBe(true);
+  });
+
+  it('should not set retortDisabledFeatures when all features are enabled', () => {
+    const vars = {};
+    applyRetortConfig(vars, {
+      features: { 'team-orchestration': { enabled: true } },
+    });
+    expect(vars.retortDisabledFeatures).toBeUndefined();
+    expect(vars.retortEnabledFeatures?.has('team-orchestration')).toBe(true);
+  });
+
+  it('should warn on unmapped agent IDs when agentIds list is provided', () => {
+    const warnMock = vi.fn();
+    const vars = {};
+    applyRetortConfig(
+      vars,
+      { agents: { 'nonexistent-agent': 'some-target' } },
+      { warn: warnMock, agentIds: ['backend', 'frontend'] }
+    );
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining('nonexistent-agent'));
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining('does not match any known agent ID')
+    );
+  });
+
+  it('should not warn for valid agent IDs in agentIds list', () => {
+    const warnMock = vi.fn();
+    const vars = {};
+    applyRetortConfig(
+      vars,
+      { agents: { backend: 'my-backend' } },
+      { warn: warnMock, agentIds: ['backend', 'frontend'] }
+    );
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('should not warn when agentIds list is not provided', () => {
+    const warnMock = vi.fn();
+    const vars = {};
+    applyRetortConfig(vars, { agents: { 'any-agent': 'some-target' } }, { warn: warnMock });
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('should initialise retortAgentMap and retortDisabledAgents even when they are absent', () => {
+    const vars = {};
+    applyRetortConfig(vars, { agents: {} });
+    expect(vars.retortAgentMap).toBeDefined();
+    expect(vars.retortDisabledAgents).toBeInstanceOf(Set);
+  });
+
+  it('should preserve existing retortAgentMap entries when merging', () => {
+    const vars = { retortAgentMap: { frontend: 'existing-frontend' } };
+    applyRetortConfig(vars, { agents: { backend: 'new-backend' } });
+    expect(vars.retortAgentMap).toEqual({
+      frontend: 'existing-frontend',
+      backend: 'new-backend',
+    });
+  });
+});

--- a/.agentkit/engines/node/src/retort-config.mjs
+++ b/.agentkit/engines/node/src/retort-config.mjs
@@ -1,0 +1,217 @@
+/**
+ * Retort — .retortconfig Loader and Validator
+ *
+ * Loads per-repo agent remapping and opt-in feature flags from a `.retortconfig`
+ * file at the project root. This file is optional — its absence is backwards-
+ * compatible and treated the same as an empty config.
+ *
+ * Schema (YAML):
+ *   retort_version: "3.x"          # optional; reserved for future migration checks
+ *   project:                        # optional metadata block
+ *     name: string
+ *     type: string
+ *     compliance: string[]
+ *     stacks: string[]
+ *   agents:                         # optional agent remapping
+ *     <agent-id>: <target-name>     # remap — agent file includes a routing note
+ *     <agent-id>: ~                 # disable — agent file is not generated
+ *   features:                       # optional feature flag overrides
+ *     <feature-id>:
+ *       enabled: true | false       # overrides overlay enabledFeatures/disabledFeatures
+ */
+import { existsSync, readFileSync } from 'fs';
+import yaml from 'js-yaml';
+import { join } from 'path';
+
+// ---------------------------------------------------------------------------
+// Known top-level keys — anything else is rejected
+// ---------------------------------------------------------------------------
+
+const KNOWN_TOP_LEVEL_KEYS = new Set(['retort_version', 'project', 'agents', 'features']);
+const KNOWN_PROJECT_KEYS = new Set(['name', 'type', 'compliance', 'stacks']);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Loads and validates `.retortconfig` from the repo root (projectRoot).
+ * Returns null when no file exists (backwards compatible).
+ *
+ * @param {string} projectRoot - Absolute path to the consuming repo's root
+ * @returns {object|null} Parsed and validated config, or null if absent
+ * @throws {Error} On invalid YAML syntax or unknown schema keys
+ */
+export function loadRetortConfig(projectRoot) {
+  const configPath = join(projectRoot, '.retortconfig');
+  if (!existsSync(configPath)) {
+    return null;
+  }
+
+  let raw;
+  try {
+    const text = readFileSync(configPath, 'utf-8');
+    raw = yaml.load(text);
+  } catch (err) {
+    throw new Error(
+      `[retort] Failed to parse .retortconfig: ${err.message}\n` + `  File: ${configPath}`
+    );
+  }
+
+  // An empty file is fine — treat as no config
+  if (raw == null) {
+    return {};
+  }
+
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(
+      `[retort] .retortconfig must be a YAML mapping, got ${Array.isArray(raw) ? 'array' : typeof raw}`
+    );
+  }
+
+  // Reject unknown top-level keys
+  const unknownKeys = Object.keys(raw).filter((k) => !KNOWN_TOP_LEVEL_KEYS.has(k));
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `[retort] .retortconfig contains unknown keys: ${unknownKeys.join(', ')}\n` +
+        `  Allowed keys: ${[...KNOWN_TOP_LEVEL_KEYS].join(', ')}`
+    );
+  }
+
+  // Validate project block (optional)
+  if (raw.project != null) {
+    if (typeof raw.project !== 'object' || Array.isArray(raw.project)) {
+      throw new Error(`[retort] .retortconfig 'project' must be a mapping`);
+    }
+    const unknownProjectKeys = Object.keys(raw.project).filter((k) => !KNOWN_PROJECT_KEYS.has(k));
+    if (unknownProjectKeys.length > 0) {
+      throw new Error(
+        `[retort] .retortconfig 'project' contains unknown keys: ${unknownProjectKeys.join(', ')}\n` +
+          `  Allowed keys: ${[...KNOWN_PROJECT_KEYS].join(', ')}`
+      );
+    }
+  }
+
+  // Validate agents block (optional)
+  if (raw.agents != null) {
+    if (typeof raw.agents !== 'object' || Array.isArray(raw.agents)) {
+      throw new Error(`[retort] .retortconfig 'agents' must be a mapping`);
+    }
+    for (const [agentId, value] of Object.entries(raw.agents)) {
+      if (value !== null && typeof value !== 'string') {
+        throw new Error(
+          `[retort] .retortconfig 'agents.${agentId}' must be a string (remap target) or ~ (null, to disable)`
+        );
+      }
+    }
+  }
+
+  // Validate features block (optional)
+  if (raw.features != null) {
+    if (typeof raw.features !== 'object' || Array.isArray(raw.features)) {
+      throw new Error(`[retort] .retortconfig 'features' must be a mapping`);
+    }
+    for (const [featureId, featureConfig] of Object.entries(raw.features)) {
+      if (
+        featureConfig == null ||
+        typeof featureConfig !== 'object' ||
+        Array.isArray(featureConfig)
+      ) {
+        throw new Error(
+          `[retort] .retortconfig 'features.${featureId}' must be a mapping with an 'enabled' key`
+        );
+      }
+      const unknownFeatureKeys = Object.keys(featureConfig).filter((k) => k !== 'enabled');
+      if (unknownFeatureKeys.length > 0) {
+        throw new Error(
+          `[retort] .retortconfig 'features.${featureId}' contains unknown keys: ${unknownFeatureKeys.join(', ')}\n` +
+            `  Only 'enabled' is supported`
+        );
+      }
+      if (typeof featureConfig.enabled !== 'boolean') {
+        throw new Error(
+          `[retort] .retortconfig 'features.${featureId}.enabled' must be a boolean (true or false)`
+        );
+      }
+    }
+  }
+
+  return raw;
+}
+
+/**
+ * Merges `.retortconfig` overrides into the template context vars.
+ *
+ * Effects:
+ *   - features.<id>.enabled=false  → appended to vars.disabledFeatures (Set)
+ *   - features.<id>.enabled=true   → appended to vars.enabledFeatures (Set, if present)
+ *   - agents.<id> = 'name'         → vars.retortAgentMap[id] = 'name'
+ *   - agents.<id> = null           → vars.retortDisabledAgents.add(id)
+ *
+ * Warns (to stderr) for agent IDs in retortConfig.agents that have no
+ * corresponding entry in vars.agentIds (when provided).
+ *
+ * @param {object} specVars - Mutable template context vars object
+ * @param {object|null} retortConfig - Parsed config from loadRetortConfig(), or null
+ * @param {{ log?: Function, warn?: Function, agentIds?: string[] }} [options]
+ * @returns {void}
+ */
+export function applyRetortConfig(specVars, retortConfig, options = {}) {
+  if (!retortConfig) return;
+
+  const warn = options.warn || ((msg) => console.warn(msg));
+  const knownAgentIds = new Set(options.agentIds || []);
+  const hasKnownAgents = knownAgentIds.size > 0;
+
+  // Initialise the agent remapping structures if not already present
+  if (!specVars.retortAgentMap) {
+    specVars.retortAgentMap = {};
+  }
+  if (!specVars.retortDisabledAgents) {
+    specVars.retortDisabledAgents = new Set();
+  }
+
+  // -------------------------------------------------------------------------
+  // Apply feature flag overrides
+  // -------------------------------------------------------------------------
+  const features = retortConfig.features || {};
+  for (const [featureId, featureConfig] of Object.entries(features)) {
+    const enabled = featureConfig.enabled;
+
+    if (enabled === false) {
+      // Add to disabledFeatures — features disabled via .retortconfig
+      if (!specVars.retortDisabledFeatures) {
+        specVars.retortDisabledFeatures = new Set();
+      }
+      specVars.retortDisabledFeatures.add(featureId);
+    } else if (enabled === true) {
+      // Add to retortEnabledFeatures — features force-enabled via .retortconfig
+      if (!specVars.retortEnabledFeatures) {
+        specVars.retortEnabledFeatures = new Set();
+      }
+      specVars.retortEnabledFeatures.add(featureId);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Apply agent remapping
+  // -------------------------------------------------------------------------
+  const agents = retortConfig.agents || {};
+  for (const [agentId, target] of Object.entries(agents)) {
+    // Warn on unmapped agent IDs (only when we have a known agent list)
+    if (hasKnownAgents && !knownAgentIds.has(agentId)) {
+      warn(
+        `[retort] .retortconfig 'agents.${agentId}' does not match any known agent ID. ` +
+          `This entry will have no effect.`
+      );
+    }
+
+    if (target === null) {
+      // null (YAML ~) → disable the agent
+      specVars.retortDisabledAgents.add(agentId);
+    } else {
+      // string → remap to named agent
+      specVars.retortAgentMap[agentId] = target;
+    }
+  }
+}

--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -969,7 +969,6 @@ async function syncClaudeAgents(
       const remapTarget = agentMap[agent.id];
       agentVars.retortRemapTarget = remapTarget || '';
 
-
       const rendered = renderTemplate(template, agentVars, tplPath);
       const withHeader = insertHeader(rendered, '.md', version, repoName);
       await writeOutput(join(tmpDir, '.claude', 'agents', `${agent.id}.md`), withHeader);

--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -975,13 +975,16 @@ async function syncAgentRegistry(tmpDir, agentsSpec, version, repoName) {
   if (allAgents.length === 0) return;
 
   // REGISTRY.md — markdown table
-  const header = `<!-- generated_by: retort | last_model: sync-engine | last_updated: ${new Date().toISOString().slice(0, 10)} -->\n# Agent Registry\n\n| ID | Name | Category | Accepts | Role |\n|---|---|---|---|---|\n`;
   const rows = allAgents
     .map(
       (a) =>
         `| \`${a.id}\` | ${a.name} | ${a.category} | ${a.accepts.join(', ')} | ${a.roleSummary} |`
     )
     .join('\n');
+  // Use a content hash of the rows so the header is stable between syncs and only
+  // changes when agent definitions actually change (not just because the date rolled over).
+  const contentHash = createHash('sha256').update(rows).digest('hex').slice(0, 8);
+  const header = `<!-- generated_by: retort | last_model: sync-engine | content_hash: ${contentHash} -->\n# Agent Registry\n\n| ID | Name | Category | Accepts | Role |\n|---|---|---|---|---|\n`;
   await writeOutput(join(tmpDir, '.claude', 'agents', 'REGISTRY.md'), header + rows + '\n');
 
   // REGISTRY.json — machine-readable

--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -170,8 +170,13 @@ export function normalizeForComparison(content) {
   return content
     .split('\n')
     .map((line) => {
-      // Normalise markdown table rows (data rows only, not separator rows like |---|---|)
-      if (/^\s*\|/.test(line) && !/^\s*\|[\s|:-]+\|\s*$/.test(line)) {
+      if (/^\s*\|/.test(line)) {
+        // Separator rows (|---|---| or | --- | --- |) — collapse to |---| canonical form
+        if (/^\s*\|[\s|:-]+\|\s*$/.test(line)) {
+          const cols = line.split('|').filter((_, i, a) => i > 0 && i < a.length - 1);
+          return '|' + cols.map((c) => c.trim().replace(/^(:?)-+(:?)$/, '$1-$2')).join('|') + '|';
+        }
+        // Data rows — normalise cell padding to a single space either side
         return line
           .split('|')
           .map((cell, i, arr) =>
@@ -3022,10 +3027,12 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
       // Content-hash guard: skip write if content is identical to the existing file.
       // This prevents mtime churn on generated files that haven't logically changed,
       // reducing adopter merge-conflict counts on framework-update merges.
+      // Also skips when the only difference is markdown table-cell padding (Prettier
+      // alignment vs compact template output) so formatted files are not reverted each run.
       if (existsSync(destFile)) {
+        const existingContent = await readFile(destFile);
         const newHash = newManifestFiles[normalizedRel]?.hash;
         if (newHash) {
-          const existingContent = await readFile(destFile);
           const existingHash = createHash('sha256')
             .update(existingContent)
             .digest('hex')
@@ -3034,6 +3041,15 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
             logVerbose(`  unchanged ${normalizedRel} (content identical, skipping write)`);
             return;
           }
+        }
+        // Slower path: skip write when the only difference is table-cell padding.
+        const newContent = await readFile(srcFile, 'utf-8');
+        if (
+          normalizeForComparison(existingContent.toString('utf-8')) ===
+          normalizeForComparison(newContent)
+        ) {
+          logVerbose(`  unchanged ${normalizedRel} (formatting-only diff, skipping write)`);
+          return;
         }
       }
 

--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -42,6 +42,7 @@ import {
   resolveScaffoldAction,
   simpleDiff,
 } from './template-utils.mjs';
+import { applyRetortConfig, loadRetortConfig } from './retort-config.mjs';
 
 // ---------------------------------------------------------------------------
 // Scaffold metadata map — populated during template rendering, consumed in Step 7
@@ -954,9 +955,21 @@ async function syncClaudeAgents(
   if (!existsSync(tplPath)) return;
   const template = await readTemplateText(tplPath);
 
+  const disabledAgents = vars.retortDisabledAgents || new Set();
+  const agentMap = vars.retortAgentMap || {};
+
   for (const [category, agents] of Object.entries(agentsSpec.agents || {})) {
     for (const agent of agents) {
+      // Skip agents disabled in .retortconfig
+      if (disabledAgents.has(agent.id)) continue;
+
       const agentVars = buildAgentVars(agent, category, vars, registry);
+
+      // Inject remapping note if this agent has been remapped in .retortconfig
+      const remapTarget = agentMap[agent.id];
+      agentVars.retortRemapTarget = remapTarget || '';
+
+
       const rendered = renderTemplate(template, agentVars, tplPath);
       const withHeader = insertHeader(rendered, '.md', version, repoName);
       await writeOutput(join(tmpDir, '.claude', 'agents', `${agent.id}.md`), withHeader);
@@ -2314,6 +2327,67 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
     const gate = section.gate;
     const isGateEnabled = !gate || vars[gate];
     vars[`shared_${key}`] = isGateEnabled ? section.content || '' : '';
+  }
+
+  // Load .retortconfig from the project root and apply overrides into vars.
+  // This must happen after the base vars are assembled so that .retortconfig
+  // can selectively override feature flags without replacing the full feature set.
+  try {
+    const retortConfig = loadRetortConfig(projectRoot);
+    if (retortConfig) {
+      // Collect known agent IDs so we can warn on unmapped entries
+      const knownAgentIds = Object.values(agentsSpec.agents || {})
+        .flat()
+        .map((a) => a.id)
+        .filter(Boolean);
+      applyRetortConfig(vars, retortConfig, { log, warn: log, agentIds: knownAgentIds });
+
+      // Apply feature flag overrides from .retortconfig into the feature vars.
+      // disabledFeatures: re-resolve after adding .retortconfig exclusions.
+      if (vars.retortDisabledFeatures?.size || vars.retortEnabledFeatures?.size) {
+        try {
+          const { features: featureList, presets } = loadFeatureSpec(agentkitRoot, { log });
+          // Build merged overlay settings with .retortconfig feature adjustments
+          const mergedOverlaySettings = { ...overlaySettings };
+          if (vars.retortDisabledFeatures?.size) {
+            const existingDisabled = new Set(overlaySettings.disabledFeatures || []);
+            for (const id of vars.retortDisabledFeatures) existingDisabled.add(id);
+            mergedOverlaySettings.disabledFeatures = [...existingDisabled];
+          }
+          if (vars.retortEnabledFeatures?.size) {
+            const existingEnabled = new Set(overlaySettings.enabledFeatures || []);
+            for (const id of vars.retortEnabledFeatures) existingEnabled.add(id);
+            mergedOverlaySettings.enabledFeatures = [...existingEnabled];
+          }
+          const enabledFeaturesWithOverrides = resolveFeatures(
+            featureList,
+            mergedOverlaySettings,
+            presets,
+            { log }
+          );
+          const updatedFeatureVars = buildFeatureVars(featureList, enabledFeaturesWithOverrides);
+          // Merge updated feature vars back into vars (feature vars start with 'has')
+          Object.assign(vars, updatedFeatureVars);
+          log(
+            `[retort] .retortconfig feature overrides applied (${vars.retortDisabledFeatures?.size ?? 0} disabled, ${vars.retortEnabledFeatures?.size ?? 0} force-enabled)`
+          );
+        } catch (featErr) {
+          log(
+            `[retort] Warning: could not apply .retortconfig feature overrides: ${featErr.message}`
+          );
+        }
+      }
+
+      if (vars.retortAgentMap && Object.keys(vars.retortAgentMap).length > 0) {
+        log(`[retort] .retortconfig agent remaps: ${Object.keys(vars.retortAgentMap).join(', ')}`);
+      }
+      if (vars.retortDisabledAgents?.size) {
+        log(`[retort] .retortconfig disabled agents: ${[...vars.retortDisabledAgents].join(', ')}`);
+      }
+    }
+  } catch (configErr) {
+    // Surface validation errors as fatal — a malformed .retortconfig is a user error
+    throw configErr;
   }
 
   // Teams list for root templates (AGENT_TEAMS.md {{#each}} iteration)

--- a/.agentkit/templates/claude/agents/TEMPLATE.md
+++ b/.agentkit/templates/claude/agents/TEMPLATE.md
@@ -4,6 +4,13 @@
 
 # {{agentName}}
 
+{{#if retortRemapTarget}}
+
+> **Routing note**: This agent is mapped to **{{retortRemapTarget}}** in `.retortconfig`.
+> Invoke `{{retortRemapTarget}}` directly for project-specific behaviour.
+
+{{/if}}
+
 ## Role
 
 {{agentRole}}

--- a/.agents/skills/backlog/SKILL.md
+++ b/.agents/skills/backlog/SKILL.md
@@ -33,7 +33,6 @@ Invoke this skill when you need to perform the `backlog` operation.
 - Return a concise summary with status (`success`/`partial`/`failed`)
 - Include validation evidence (exit code, failing command, or passing summary)
 - Include next-step remediation when checks fail
-  
 
 ## Project Context
 
@@ -48,4 +47,3 @@ Invoke this skill when you need to perform the `backlog` operation.
 - Include tests for behavioral changes
 - Never expose secrets or credentials
 - Follow the project's established patterns
-

--- a/.agents/skills/cost-centres/SKILL.md
+++ b/.agents/skills/cost-centres/SKILL.md
@@ -33,7 +33,6 @@ Invoke this skill when you need to perform the `cost-centres` operation.
 - Return a concise summary with status (`success`/`partial`/`failed`)
 - Include validation evidence (exit code, failing command, or passing summary)
 - Include next-step remediation when checks fail
-  
 
 ## Project Context
 
@@ -48,4 +47,3 @@ Invoke this skill when you need to perform the `cost-centres` operation.
 - Include tests for behavioral changes
 - Never expose secrets or credentials
 - Follow the project's established patterns
-

--- a/.agents/skills/preflight/SKILL.md
+++ b/.agents/skills/preflight/SKILL.md
@@ -52,4 +52,3 @@ If `--range` is omitted, auto-detect via merge-base against the default branch. 
 - Include tests for behavioral changes
 - Never expose secrets or credentials
 - Follow the project's established patterns
-

--- a/.claude/agents/REGISTRY.md
+++ b/.claude/agents/REGISTRY.md
@@ -1,4 +1,4 @@
-<!-- generated_by: retort | last_model: sync-engine | last_updated: 2026-03-28 -->
+<!-- generated_by: retort | last_model: sync-engine | content_hash: 816fa8ae -->
 # Agent Registry
 
 | ID | Name | Category | Accepts | Role |

--- a/.claude/rules/worktree-isolation.md
+++ b/.claude/rules/worktree-isolation.md
@@ -15,17 +15,17 @@ agent task a reviewable branch, and enables clean rollback if a task goes wrong.
 Pass `isolation: "worktree"` when invoking an agent via the Agent tool for any
 **code-writing** task type:
 
-| Task type     | Requires worktree?       |
-| ------------- | ------------------------ |
-| `implement`   | Yes                      |
-| `fix`         | Yes                      |
-| `refactor`    | Yes                      |
-| `migration`   | Yes                      |
-| `test`        | Yes (adds/changes files) |
-| `review`      | No — read-only           |
-| `investigate` | No — read-only           |
-| `discover`    | No — read-only           |
-| `audit`       | No — read-only           |
+| Task type      | Requires worktree? |
+| -------------- | ------------------ |
+| `implement`    | Yes                |
+| `fix`          | Yes                |
+| `refactor`     | Yes                |
+| `migration`    | Yes                |
+| `test`         | Yes (adds/changes files) |
+| `review`       | No — read-only     |
+| `investigate`  | No — read-only     |
+| `discover`     | No — read-only     |
+| `audit`        | No — read-only     |
 
 ## Branch Naming Convention
 
@@ -49,16 +49,16 @@ for chores use `chore/agent-<name>/<slug>` — match the Conventional Commits ty
 ```js
 // Code-writing agent — always isolated
 Agent({
-  subagent_type: 'feature-dev:code-architect',
-  isolation: 'worktree',
-  prompt: 'Implement the payment endpoint described in task-20260327-001',
-});
+  subagent_type: "feature-dev:code-architect",
+  isolation: "worktree",
+  prompt: "Implement the payment endpoint described in task-20260327-001"
+})
 
 // Read-only agent — no isolation needed
 Agent({
-  subagent_type: 'Explore',
-  prompt: 'Investigate the auth module structure',
-});
+  subagent_type: "Explore",
+  prompt: "Investigate the auth module structure"
+})
 ```
 
 ## Manual Worktree Workflow (EnterWorktree / ExitWorktree)
@@ -90,7 +90,7 @@ The branch prefix and naming convention can be customised per-repo via
 `.agentkit/overlays/retort/settings.yaml`:
 
 ```yaml
-agentBranchPrefix: feat # default; change to match your workflow
+agentBranchPrefix: feat  # default; change to match your workflow
 ```
 
 After updating, run `pnpm --dir .agentkit retort:sync` to regenerate.

--- a/.claude/rules/worktree-isolation.md
+++ b/.claude/rules/worktree-isolation.md
@@ -15,17 +15,17 @@ agent task a reviewable branch, and enables clean rollback if a task goes wrong.
 Pass `isolation: "worktree"` when invoking an agent via the Agent tool for any
 **code-writing** task type:
 
-| Task type      | Requires worktree? |
-| -------------- | ------------------ |
-| `implement`    | Yes                |
-| `fix`          | Yes                |
-| `refactor`     | Yes                |
-| `migration`    | Yes                |
-| `test`         | Yes (adds/changes files) |
-| `review`       | No — read-only     |
-| `investigate`  | No — read-only     |
-| `discover`     | No — read-only     |
-| `audit`        | No — read-only     |
+| Task type     | Requires worktree?       |
+| ------------- | ------------------------ |
+| `implement`   | Yes                      |
+| `fix`         | Yes                      |
+| `refactor`    | Yes                      |
+| `migration`   | Yes                      |
+| `test`        | Yes (adds/changes files) |
+| `review`      | No — read-only           |
+| `investigate` | No — read-only           |
+| `discover`    | No — read-only           |
+| `audit`       | No — read-only           |
 
 ## Branch Naming Convention
 
@@ -49,16 +49,16 @@ for chores use `chore/agent-<name>/<slug>` — match the Conventional Commits ty
 ```js
 // Code-writing agent — always isolated
 Agent({
-  subagent_type: "feature-dev:code-architect",
-  isolation: "worktree",
-  prompt: "Implement the payment endpoint described in task-20260327-001"
-})
+  subagent_type: 'feature-dev:code-architect',
+  isolation: 'worktree',
+  prompt: 'Implement the payment endpoint described in task-20260327-001',
+});
 
 // Read-only agent — no isolation needed
 Agent({
-  subagent_type: "Explore",
-  prompt: "Investigate the auth module structure"
-})
+  subagent_type: 'Explore',
+  prompt: 'Investigate the auth module structure',
+});
 ```
 
 ## Manual Worktree Workflow (EnterWorktree / ExitWorktree)
@@ -90,7 +90,7 @@ The branch prefix and naming convention can be customised per-repo via
 `.agentkit/overlays/retort/settings.yaml`:
 
 ```yaml
-agentBranchPrefix: feat  # default; change to match your workflow
+agentBranchPrefix: feat # default; change to match your workflow
 ```
 
 After updating, run `pnpm --dir .agentkit retort:sync` to regenerate.

--- a/.cursor/commands/security.md
+++ b/.cursor/commands/security.md
@@ -33,12 +33,12 @@ Search for: API keys, AWS keys, private keys, connection strings, passwords, tok
 
 ## Severity Classification
 
-| Severity | Criteria |
-|----------|----------|
+| Severity | Criteria                                                            |
+| -------- | ------------------------------------------------------------------- |
 | CRITICAL | Exploitable remotely, no auth required, data breach or RCE possible |
-| HIGH | Low complexity exploit, auth bypass, significant data exposure |
-| MEDIUM | Requires specific conditions, limited impact, defense-in-depth gap |
-| LOW | Best practice violation, minimal direct impact |
+| HIGH     | Low complexity exploit, auth bypass, significant data exposure      |
+| MEDIUM   | Requires specific conditions, limited impact, defense-in-depth gap  |
+| LOW      | Best practice violation, minimal direct impact                      |
 
 ## Output
 
@@ -65,4 +65,3 @@ Produce: Executive Summary, Risk Score, Findings by severity (with ID, file:line
 - Every behavioral change must include tests
 - Never commit secrets or credentials
 - Follow the project's coding standards and quality gates
-

--- a/.cursor/commands/sync.md
+++ b/.cursor/commands/sync.md
@@ -29,12 +29,12 @@ pnpm --dir .agentkit agentkit:sync
 
 ## Flags
 
-| Flag | Effect |
-|------|--------|
+| Flag              | Effect                                                                                               |
+| ----------------- | ---------------------------------------------------------------------------------------------------- |
 | `--only <target>` | Sync only one platform (claude, cursor, copilot, windsurf, codex, gemini, cline, roo, warp, ai, mcp) |
-| `--overwrite` | Overwrite project-owned (scaffold-once) files |
-| `--diff` | Preview changes without writing |
-| `--no-clean` | Keep orphaned files that would normally be removed |
+| `--overwrite`     | Overwrite project-owned (scaffold-once) files                                                        |
+| `--diff`          | Preview changes without writing                                                                      |
+| `--no-clean`      | Keep orphaned files that would normally be removed                                                   |
 
 ## Post-Sync
 
@@ -66,4 +66,3 @@ This command requires shell access (Bash tool). On platforms with restricted too
 - Every behavioral change must include tests
 - Never commit secrets or credentials
 - Follow the project's coding standards and quality gates
-

--- a/.retortconfig
+++ b/.retortconfig
@@ -1,0 +1,13 @@
+retort_version: "3.x"
+
+project:
+  name: retort
+  type: framework
+  stacks:
+    - javascript
+    - yaml
+    - markdown
+
+agents:
+  # No grant-seeking activity for an open-source developer tool.
+  grant-hunter: ~

--- a/.windsurf/commands/security.md
+++ b/.windsurf/commands/security.md
@@ -40,12 +40,12 @@ Search for: API keys, AWS keys, private keys, connection strings, passwords, tok
 
 ## Severity Classification
 
-| Severity | Criteria |
-|----------|----------|
+| Severity | Criteria                                                            |
+| -------- | ------------------------------------------------------------------- |
 | CRITICAL | Exploitable remotely, no auth required, data breach or RCE possible |
-| HIGH | Low complexity exploit, auth bypass, significant data exposure |
-| MEDIUM | Requires specific conditions, limited impact, defense-in-depth gap |
-| LOW | Best practice violation, minimal direct impact |
+| HIGH     | Low complexity exploit, auth bypass, significant data exposure      |
+| MEDIUM   | Requires specific conditions, limited impact, defense-in-depth gap  |
+| LOW      | Best practice violation, minimal direct impact                      |
 
 ## Output
 
@@ -65,4 +65,3 @@ Produce: Executive Summary, Risk Score, Findings by severity (with ID, file:line
 - `/plan` — Structured planning before implementation
 - `/project-review` — Comprehensive project audit
 - See `COMMAND_GUIDE.md` for when to choose each command
-


### PR DESCRIPTION
## Summary

- Adds `.retortconfig` schema support — per-repo YAML file for agent remapping and feature flag overrides
- Adds `retort-config.mjs` engine module with `loadRetortConfig` and `applyRetortConfig` exports, including strict schema validation
- Wires `.retortconfig` into the sync pipeline: feature flags are re-resolved after config merge, disabled agents are skipped from generation, remapped agents get a routing note in their generated file
- Updates the Claude agent template to show a `> Routing note` blockquote when an agent is remapped

## Changes

### New file: `.agentkit/engines/node/src/retort-config.mjs`
Loads and validates `.retortconfig` from the project root. Rejects unknown keys, validates agent and feature blocks, and returns `null` for absent files (backwards compatible).

### Updated: `.agentkit/engines/node/src/synchronize.mjs`
After assembling spec/overlay vars but before rendering templates, calls `loadRetortConfig` + `applyRetortConfig`. Re-resolves features when `.retortconfig` overrides are present. Skips disabled agents in `syncClaudeAgents`.

### Updated: `.agentkit/templates/claude/agents/TEMPLATE.md`
Adds a conditional `{{#if retortRemapTarget}}` routing note block at the top of each agent file.

### New file: `.agentkit/engines/node/src/__tests__/retort-config.test.mjs`
27 unit tests covering: null/empty config, valid parsing, YAML errors, schema validation (unknown keys, bad types), agent remapping, disabled agents, feature flag merging, and warn-on-unknown-agent-id behaviour.

## What this does NOT include (v2)

- `retort init` wizard
- Spec drift detection for `.retortconfig`
- Cross-platform validation tooling

## Test plan

- [x] All 27 `retort-config.test.mjs` tests pass
- [x] Pre-existing test failures (`prettier.test.mjs` on 3 unrelated files, `sync-integration.test.mjs` on stale `[agentkit:sync]` prefix) are pre-existing on `dev` and not introduced by this PR
- [x] `pnpm -C .agentkit retort:sync` runs successfully with no errors
- [x] New files pass `pnpm -C .agentkit exec prettier --write`

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `.retortconfig` file support for per-project configuration management.
  * Enabled agent remapping and disabling through configuration.
  * Added feature override capabilities (enable/disable specific features).
  * Agent templates now display routing information for remapped agents.

* **Improvements**
  * Enhanced agent registry header generation with content-based hashing.
  * Improved content comparison to skip unnecessary writes when only formatting differs.

* **Tests**
  * Added comprehensive test suite for configuration parsing and application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->