### PR TITLE
fix(worktree): auto-create .agentkit-repo marker on worktree create

### DIFF
--- a/.agentkit/engines/node/src/cli.mjs
+++ b/.agentkit/engines/node/src/cli.mjs
@@ -89,6 +89,7 @@ const CLI_INTERNAL_FLAGS = {
   list: ['help'],
   features: ['verbose', 'help'],
   'analyze-agents': ['output', 'matrix', 'format', 'help'],
+  worktree: ['base', 'no-setup', 'dry-run', 'help'],
 };
 
 const CLI_INTERNAL_FLAG_TYPES = {
@@ -135,6 +136,9 @@ const CLI_INTERNAL_FLAG_TYPES = {
   output: 'string',
   matrix: 'string',
   format: 'string',
+  // worktree flags
+  base: 'string',
+  'no-setup': 'boolean',
 };
 
 /**
@@ -375,6 +379,13 @@ Backlog & Issue Tracking:
                   --since <date>      Only issues updated since ISO date
                   --limit <n>         Max issues to fetch
                   --force             Override autoImport gate
+
+Worktree Management:
+  worktree create <path> [branch]
+                  Create a git worktree and write .agentkit-repo marker
+                  --base <branch>     Branch to base the new worktree branch on
+                  --no-setup          Skip automatic pnpm install
+                  --dry-run           Preview without making changes
 
 Utility Commands:
   cost            Session cost and usage tracking
@@ -681,6 +692,11 @@ async function main() {
         console.log(
           `  ${graph.agents.length} agents, ${graph.teams.length} teams, ${graph.categories.length} categories`
         );
+        break;
+      }
+      case 'worktree': {
+        const { runWorktree } = await import('./worktree.mjs');
+        await runWorktree({ agentkitRoot: AGENTKIT_ROOT, projectRoot: PROJECT_ROOT, flags });
         break;
       }
       default: {

--- a/.agentkit/engines/node/src/commands-registry.mjs
+++ b/.agentkit/engines/node/src/commands-registry.mjs
@@ -33,6 +33,7 @@ export const VALID_COMMANDS = [
   'preflight',
   'analyze-agents',
   'cicd-optimize',
+  'worktree',
 ];
 
 /**
@@ -49,4 +50,5 @@ export const FRAMEWORK_COMMANDS = new Set([
   'delegate',
   'features',
   'init',
+  'worktree',
 ]);

--- a/.agentkit/engines/node/src/worktree.mjs
+++ b/.agentkit/engines/node/src/worktree.mjs
@@ -175,13 +175,9 @@ export async function runWorktree({ agentkitRoot, projectRoot, flags }) {
     // Strip the sub-action token from positionals so runWorktreeCreate sees
     // [path, branch?] as positionals[0] and positionals[1].
     const adjustedFlags =
-      subAction === 'create'
-        ? { ...flags, _args: (flags._args || []).slice(1) }
-        : flags;
+      subAction === 'create' ? { ...flags, _args: (flags._args || []).slice(1) } : flags;
     return runWorktreeCreate({ agentkitRoot, projectRoot, flags: adjustedFlags });
   }
 
-  throw new Error(
-    `Unknown worktree sub-action: "${subAction}". Available: create`
-  );
+  throw new Error(`Unknown worktree sub-action: "${subAction}". Available: create`);
 }

--- a/.agentkit/engines/node/src/worktree.mjs
+++ b/.agentkit/engines/node/src/worktree.mjs
@@ -1,0 +1,187 @@
+/**
+ * Retort — Worktree Command
+ * Wraps `git worktree add` and ensures the new worktree directory has an
+ * `.agentkit-repo` marker so the sync engine picks the correct overlay.
+ *
+ * Without the marker, `runSync` falls back to `__TEMPLATE__` (or infers from
+ * the directory name), causing an "overlay miss" that generates incorrect output.
+ * See: PRs #478 and #479 (required manual `.agentkit-repo` intervention).
+ *
+ * Usage:
+ *   retort worktree create <path> [branch] [--base <branch>] [--no-setup]
+ *
+ * Flags:
+ *   --base <branch>   Branch to create the new worktree branch from (default: HEAD)
+ *   --no-setup        Skip automatic pnpm install in the new worktree
+ *   --dry-run         Show what would happen without making changes
+ */
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { basename, resolve } from 'path';
+import { REPO_NAME_PATTERN } from './repo-name.mjs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the repo name from the `.agentkit-repo` marker in the given directory.
+ * Returns null if the marker is absent or contains an invalid repo name.
+ *
+ * @param {string} dir
+ * @returns {string|null}
+ */
+function readMarker(dir) {
+  const markerPath = resolve(dir, '.agentkit-repo');
+  if (!existsSync(markerPath)) return null;
+  const raw = readFileSync(markerPath, 'utf-8').trim();
+  if (!raw || !REPO_NAME_PATTERN.test(raw)) return null;
+  return raw;
+}
+
+/**
+ * Write `.agentkit-repo` to `worktreePath` with `repoName` as content.
+ *
+ * @param {string} worktreePath
+ * @param {string} repoName
+ */
+function writeMarker(worktreePath, repoName) {
+  const markerPath = resolve(worktreePath, '.agentkit-repo');
+  writeFileSync(markerPath, repoName + '\n', 'utf-8');
+}
+
+/**
+ * Run a git command from `cwd` and return its trimmed stdout.
+ * Throws with a clear message on non-zero exit.
+ *
+ * @param {string[]} args
+ * @param {string} cwd
+ * @returns {string}
+ */
+function git(args, cwd) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+// ---------------------------------------------------------------------------
+// Main command handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `retort worktree create`.
+ *
+ * @param {object} opts
+ * @param {string} opts.agentkitRoot
+ * @param {string} opts.projectRoot
+ * @param {object} opts.flags
+ */
+export async function runWorktreeCreate({ agentkitRoot, projectRoot, flags }) {
+  const dryRun = flags['dry-run'] || false;
+  const noSetup = flags['no-setup'] || false;
+  const base = typeof flags.base === 'string' ? flags.base : null;
+
+  // Positional args: [path, branchName?]
+  const positionals = Array.isArray(flags._args) ? flags._args : [];
+  const worktreeRelPath = positionals[0];
+  const branchArg = positionals[1] || null;
+
+  if (!worktreeRelPath) {
+    throw new Error(
+      'Usage: retort worktree create <path> [branch] [--base <branch>] [--no-setup] [--dry-run]'
+    );
+  }
+
+  const worktreePath = resolve(projectRoot, worktreeRelPath);
+
+  // Resolve repo name from the project root marker — this is what gets written
+  // into the new worktree so the sync engine uses the same overlay.
+  const repoName = readMarker(projectRoot);
+  if (!repoName) {
+    throw new Error(
+      'No valid .agentkit-repo marker found in project root. ' +
+        'Run "retort init" first to initialise the overlay.'
+    );
+  }
+
+  // Determine the branch name:
+  //   1. Explicit second positional arg
+  //   2. Last path segment of the worktree path
+  const branchName = branchArg || basename(worktreePath);
+
+  // Build the git worktree add command
+  const gitArgs = ['worktree', 'add', worktreePath, '-b', branchName];
+  if (base) {
+    gitArgs.push(base);
+  }
+
+  if (dryRun) {
+    console.log('[retort:worktree] DRY-RUN — no files will be created');
+    console.log(`  Would run: git ${gitArgs.join(' ')}`);
+    console.log(`  Would write: ${resolve(worktreePath, '.agentkit-repo')} → "${repoName}"`);
+    if (!noSetup && existsSync(resolve(projectRoot, 'package.json'))) {
+      console.log(`  Would run: pnpm install (in ${worktreePath})`);
+    }
+    return;
+  }
+
+  // Create the worktree
+  console.log(`[retort:worktree] Creating worktree at ${worktreePath} on branch "${branchName}"…`);
+  try {
+    git(gitArgs, projectRoot);
+  } catch (err) {
+    throw new Error(`git worktree add failed: ${err.message}`);
+  }
+
+  // Write the .agentkit-repo marker — this is the core fix.
+  // Without it the sync engine would fall back to __TEMPLATE__ or infer
+  // incorrectly from the directory name, producing the wrong overlay output.
+  writeMarker(worktreePath, repoName);
+  console.log(`[retort:worktree] Created .agentkit-repo marker (overlay: "${repoName}")`);
+
+  // Optional dependency install
+  if (!noSetup && existsSync(resolve(worktreePath, 'package.json'))) {
+    console.log(`[retort:worktree] Running pnpm install…`);
+    try {
+      execFileSync('pnpm', ['install'], {
+        cwd: worktreePath,
+        stdio: 'inherit',
+        windowsHide: true,
+      });
+    } catch {
+      console.warn(
+        '[retort:worktree] pnpm install failed (non-fatal). Run it manually before using the worktree.'
+      );
+    }
+  }
+
+  console.log(`[retort:worktree] Done. Worktree ready at ${worktreePath}`);
+  console.log(`  Branch:  ${branchName}`);
+  console.log(`  Overlay: ${repoName}`);
+  console.log(`  Tip: cd ${worktreePath} and run "retort sync" to generate configs.`);
+}
+
+/**
+ * Top-level worktree dispatcher. Routes sub-actions (create, list, remove).
+ *
+ * @param {object} opts
+ */
+export async function runWorktree({ agentkitRoot, projectRoot, flags }) {
+  const subAction = Array.isArray(flags._args) ? flags._args[0] : undefined;
+
+  if (!subAction || subAction === 'create') {
+    // Strip the sub-action token from positionals so runWorktreeCreate sees
+    // [path, branch?] as positionals[0] and positionals[1].
+    const adjustedFlags =
+      subAction === 'create'
+        ? { ...flags, _args: (flags._args || []).slice(1) }
+        : flags;
+    return runWorktreeCreate({ agentkitRoot, projectRoot, flags: adjustedFlags });
+  }
+
+  throw new Error(
+    `Unknown worktree sub-action: "${subAction}". Available: create`
+  );
+}

--- a/.agentkit/templates/claude/rules/worktree-isolation.md
+++ b/.agentkit/templates/claude/rules/worktree-isolation.md
@@ -73,6 +73,39 @@ When orchestrating manually rather than via Agent tool dispatches:
 The worktree is **automatically cleaned up** if no files were changed. If changes
 were made, the worktree path and branch name are returned so you can create a PR.
 
+## `.agentkit-repo` Marker in Worktrees
+
+Every worktree root **must** contain a `.agentkit-repo` file with the overlay name
+(e.g. `retort`). The sync engine reads this file to select the correct overlay when
+generating AI-tool configuration inside a worktree. If the marker is absent, the
+engine falls back to `__TEMPLATE__` and produces incorrect output — this was the root
+cause of the "overlay miss" issues reported in PRs #478 and #479.
+
+**Correct approach:** Use `retort worktree create` instead of `git worktree add`
+directly. The CLI command creates the worktree and writes the marker automatically:
+
+```bash
+# Creates the worktree AND writes .agentkit-repo
+retort worktree create .worktrees/my-feature feat/my-feature
+
+# Equivalent with explicit base branch
+retort worktree create .worktrees/my-feature feat/my-feature --base dev
+```
+
+**If you used `git worktree add` directly** (or `EnterWorktree`) and the marker is
+missing, create it manually before running any sync command:
+
+```bash
+# From inside the new worktree directory:
+echo "retort" > .agentkit-repo          # replace "retort" with the repo overlay name
+
+# Or use the project root's marker as the source of truth:
+cp <project-root>/.agentkit-repo <worktree-root>/.agentkit-repo
+```
+
+The marker file contains **only the overlay name** (one line, no trailing whitespace
+other than a newline).
+
 ## Exemptions
 
 The following scenarios are exempt from worktree isolation:

--- a/.claude/agents/REGISTRY.md
+++ b/.claude/agents/REGISTRY.md
@@ -1,4 +1,4 @@
-<!-- generated_by: retort | last_model: sync-engine | last_updated: 2026-03-28 -->
+<!-- generated_by: retort | last_model: sync-engine | content_hash: 816fa8ae -->
 # Agent Registry
 
 | ID | Name | Category | Accepts | Role |

--- a/.claude/rules/worktree-isolation.md
+++ b/.claude/rules/worktree-isolation.md
@@ -73,6 +73,39 @@ When orchestrating manually rather than via Agent tool dispatches:
 The worktree is **automatically cleaned up** if no files were changed. If changes
 were made, the worktree path and branch name are returned so you can create a PR.
 
+## `.agentkit-repo` Marker in Worktrees
+
+Every worktree root **must** contain a `.agentkit-repo` file with the overlay name
+(e.g. `retort`). The sync engine reads this file to select the correct overlay when
+generating AI-tool configuration inside a worktree. If the marker is absent, the
+engine falls back to `__TEMPLATE__` and produces incorrect output — this was the root
+cause of the "overlay miss" issues reported in PRs #478 and #479.
+
+**Correct approach:** Use `retort worktree create` instead of `git worktree add`
+directly. The CLI command creates the worktree and writes the marker automatically:
+
+```bash
+# Creates the worktree AND writes .agentkit-repo
+retort worktree create .worktrees/my-feature feat/my-feature
+
+# Equivalent with explicit base branch
+retort worktree create .worktrees/my-feature feat/my-feature --base dev
+```
+
+**If you used `git worktree add` directly** (or `EnterWorktree`) and the marker is
+missing, create it manually before running any sync command:
+
+```bash
+# From inside the new worktree directory:
+echo "retort" > .agentkit-repo          # replace "retort" with the repo overlay name
+
+# Or use the project root's marker as the source of truth:
+cp <project-root>/.agentkit-repo <worktree-root>/.agentkit-repo
+```
+
+The marker file contains **only the overlay name** (one line, no trailing whitespace
+other than a newline).
+
 ## Exemptions
 
 The following scenarios are exempt from worktree isolation:

--- a/.cursor/commands/analyze-agents.md
+++ b/.cursor/commands/analyze-agents.md
@@ -18,7 +18,6 @@ When invoked, follow the Retort orchestration lifecycle:
 3. **Execute** the task following project conventions
 4. **Validate** the output meets quality gates
 5. **Report** results clearly
-   
 
 ## Project Context
 
@@ -33,4 +32,3 @@ When invoked, follow the Retort orchestration lifecycle:
 - Every behavioral change must include tests
 - Never commit secrets or credentials
 - Follow the project's coding standards and quality gates
-

--- a/.cursor/commands/analyze-agents.md
+++ b/.cursor/commands/analyze-agents.md
@@ -18,6 +18,7 @@ When invoked, follow the Retort orchestration lifecycle:
 3. **Execute** the task following project conventions
 4. **Validate** the output meets quality gates
 5. **Report** results clearly
+   
 
 ## Project Context
 
@@ -32,3 +33,4 @@ When invoked, follow the Retort orchestration lifecycle:
 - Every behavioral change must include tests
 - Never commit secrets or credentials
 - Follow the project's coding standards and quality gates
+


### PR DESCRIPTION
## Summary

- Adds `retort worktree create <path> [branch]` command that wraps `git worktree add` and writes `.agentkit-repo` to the new worktree root
- Reads repo name from the project root's `.agentkit-repo` marker and copies it to the new worktree — ensuring the sync engine always uses the correct overlay
- Documents the marker file in `worktree-isolation.md` template (generated to all AI tool targets on next sync)

## Root Cause

PRs #478 and #479 both required manual `.agentkit-repo` creation because agent worktrees were created with `git worktree add` directly, bypassing any marker setup. The sync engine then fell back to `__TEMPLATE__` overlay, producing incorrect output.

## New Command

```bash
retort worktree create <path> [branch] [--base <branch>] [--no-setup] [--dry-run]
```

Flags:
- `--base <branch>` — branch to base the new worktree branch on (default: HEAD)
- `--no-setup` — skip automatic `pnpm install` in the new worktree
- `--dry-run` — preview without making changes

## Test Plan

- [ ] `pnpm -C .agentkit test` passes
- [ ] `retort worktree create --dry-run .claude/worktrees/test-wt` shows expected output without creating files
- [ ] `retort worktree create .claude/worktrees/test-wt` creates worktree + `.agentkit-repo` with correct repo name
- [ ] Running `retort sync` inside the new worktree picks the correct overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `worktree create` command for creating Git worktrees with automatic project configuration and optional dependency installation.
  * Supported flags: `--base` (base branch), `--no-setup` (skip installation), and `--dry-run` (preview changes).

* **Documentation**
  * Added worktree isolation best practices and marker file requirements for ensuring correct project overlay selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->