### PR TITLE
fix(sync): queue formatting-only files for post-sync Prettier

### DIFF
--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -3051,6 +3051,9 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
           normalizeForComparison(existingContent.toString('utf-8')) ===
           normalizeForComparison(newContent)
         ) {
+          // Still queue for Prettier even though we skip the write — the file on
+          // disk may be unformatted from a previous sync that predates this guard.
+          writtenFiles.push(destFile);
           logVerbose(`  unchanged ${normalizedRel} (formatting-only diff, skipping write)`);
           return;
         }


### PR DESCRIPTION
## Summary

- One-line fix in the content-hash guard's formatting-only early-return path
- Files that skip the write due to a formatting-only diff were not added to `writtenFiles`, so the post-sync Prettier step never ran on them

## Root Cause

The content-hash guard at `synchronize.mjs:3049–3056` detects when the only difference between the existing file and the new template output is whitespace/table-cell padding, and skips the write. That's correct. But it returned without pushing `destFile` into `writtenFiles`, so the post-sync Prettier formatter (step 10, lines 3204–3234) never saw the file.

Result: files that had been previously formatted by Prettier stayed formatted on disk, but on the *next* sync run (e.g. in CI) Prettier would flag them again — because the template still emits unformatted content and the guard skips the write every time.

This was the root cause of the `prettier --check` CI failures on PRs #478 and #479 (required manual `prettier --write` runs on 7–8 generated files each time).

## Fix

```js
// Before
if (normalizeForComparison(...) === normalizeForComparison(...)) {
  logVerbose(`  unchanged ${normalizedRel} (formatting-only diff, skipping write)`);
  return;
}

// After
if (normalizeForComparison(...) === normalizeForComparison(...)) {
  writtenFiles.push(destFile); // ← queue for Prettier even when skipping write
  logVerbose(`  unchanged ${normalizedRel} (formatting-only diff, skipping write)`);
  return;
}
```

## Test Plan

- [ ] `pnpm -C .agentkit test` passes
- [ ] Run sync on a repo with previously-formatted generated files — confirm no Prettier drift on next CI run
- [ ] Verify `writtenFiles` count increases in verbose output for formatting-only files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file formatting to ensure scaffolded files with formatting-only differences are now included in the post-synchronization formatting batch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->