### PR TITLE
feat(cli): add run subcommand for agent task dispatch

### DIFF
--- a/.agentkit/engines/node/src/__tests__/run-cli.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/run-cli.test.mjs
@@ -1,0 +1,413 @@
+/**
+ * Tests for run-cli.mjs — agent task dispatch subcommand.
+ */
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { advanceToWorking, assigneeToCommand, buildDispatchPrompt, runRun } from '../run-cli.mjs';
+import { createTask, getTask } from '../task-protocol.mjs';
+
+let tmpRoot;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'retort-run-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// assigneeToCommand
+// ---------------------------------------------------------------------------
+
+describe('assigneeToCommand', () => {
+  it('maps BACKEND to /team-backend', () => {
+    expect(assigneeToCommand('BACKEND')).toBe('/team-backend');
+  });
+
+  it('maps team-backend to /team-backend', () => {
+    expect(assigneeToCommand('team-backend')).toBe('/team-backend');
+  });
+
+  it('maps TESTING to /team-testing', () => {
+    expect(assigneeToCommand('TESTING')).toBe('/team-testing');
+  });
+
+  it('maps team_frontend to /team-frontend', () => {
+    expect(assigneeToCommand('team_frontend')).toBe('/team-frontend');
+  });
+
+  it('maps plain lowercase name', () => {
+    expect(assigneeToCommand('data')).toBe('/team-data');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDispatchPrompt
+// ---------------------------------------------------------------------------
+
+describe('buildDispatchPrompt', () => {
+  it('includes task ID', () => {
+    const task = {
+      id: 'task-20260330-001',
+      assignees: ['BACKEND'],
+      type: 'implement',
+      priority: 'P1',
+      status: 'working',
+      title: 'Add pagination',
+      description: 'Implement cursor-based pagination',
+      acceptanceCriteria: [],
+      scope: [],
+      dependsOn: [],
+    };
+    const prompt = buildDispatchPrompt(task);
+    expect(prompt).toContain('task-20260330-001');
+  });
+
+  it('maps assignees to slash commands', () => {
+    const task = {
+      id: 'task-1',
+      assignees: ['BACKEND', 'TESTING'],
+      type: 'implement',
+      priority: 'P2',
+      status: 'working',
+      title: 'Add feature',
+      description: '',
+      acceptanceCriteria: [],
+      scope: [],
+      dependsOn: [],
+    };
+    const prompt = buildDispatchPrompt(task);
+    expect(prompt).toContain('/team-backend');
+    expect(prompt).toContain('/team-testing');
+  });
+
+  it('falls back to /orchestrate with no assignees', () => {
+    const task = {
+      id: 'task-2',
+      assignees: [],
+      type: 'review',
+      priority: 'P3',
+      status: 'working',
+      title: 'Review code',
+      description: '',
+      acceptanceCriteria: [],
+      scope: [],
+      dependsOn: [],
+    };
+    const prompt = buildDispatchPrompt(task);
+    expect(prompt).toContain('/orchestrate');
+  });
+
+  it('includes acceptance criteria', () => {
+    const task = {
+      id: 'task-3',
+      assignees: ['BACKEND'],
+      type: 'implement',
+      priority: 'P1',
+      status: 'working',
+      title: 'Add endpoint',
+      description: '',
+      acceptanceCriteria: ['Returns 200 on success', 'Validates input'],
+      scope: [],
+      dependsOn: [],
+    };
+    const prompt = buildDispatchPrompt(task);
+    expect(prompt).toContain('Returns 200 on success');
+    expect(prompt).toContain('Validates input');
+  });
+
+  it('includes scope', () => {
+    const task = {
+      id: 'task-4',
+      assignees: ['BACKEND'],
+      type: 'implement',
+      priority: 'P2',
+      status: 'working',
+      title: 'Add endpoint',
+      description: '',
+      acceptanceCriteria: [],
+      scope: ['apps/api/**', 'services/auth/**'],
+      dependsOn: [],
+    };
+    const prompt = buildDispatchPrompt(task);
+    expect(prompt).toContain('apps/api/**');
+  });
+
+  it('includes dependsOn when present', () => {
+    const task = {
+      id: 'task-5',
+      assignees: ['BACKEND'],
+      type: 'implement',
+      priority: 'P2',
+      status: 'working',
+      title: 'Add endpoint',
+      description: '',
+      acceptanceCriteria: [],
+      scope: [],
+      dependsOn: ['task-00'],
+    };
+    const prompt = buildDispatchPrompt(task);
+    expect(prompt).toContain('task-00');
+  });
+
+  it('omits optional sections when empty', () => {
+    const task = {
+      id: 'task-6',
+      assignees: ['BACKEND'],
+      type: 'implement',
+      priority: 'P2',
+      status: 'working',
+      title: 'Add endpoint',
+      description: '',
+      acceptanceCriteria: [],
+      scope: [],
+      dependsOn: [],
+    };
+    const prompt = buildDispatchPrompt(task);
+    expect(prompt).not.toContain('Acceptance Criteria');
+    expect(prompt).not.toContain('Scope:');
+    expect(prompt).not.toContain('Depends on:');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// advanceToWorking
+// ---------------------------------------------------------------------------
+
+describe('advanceToWorking', () => {
+  it('transitions submitted → working in two steps', async () => {
+    const { task: created } = await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['BACKEND'],
+      title: 'Add pagination',
+    });
+
+    expect(created.status).toBe('submitted');
+
+    const result = await advanceToWorking(tmpRoot, created.id);
+    expect(result.error).toBeUndefined();
+    expect(result.task.status).toBe('working');
+  });
+
+  it('transitions accepted → working', async () => {
+    const { task: created } = await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['BACKEND'],
+      title: 'Add pagination',
+    });
+
+    // Manually accept first
+    const { updateTaskStatus } = await import('../task-protocol.mjs');
+    await updateTaskStatus(tmpRoot, created.id, 'accepted');
+
+    const result = await advanceToWorking(tmpRoot, created.id);
+    expect(result.error).toBeUndefined();
+    expect(result.task.status).toBe('working');
+  });
+
+  it('returns error for non-existent task', async () => {
+    const result = await advanceToWorking(tmpRoot, 'task-nonexistent');
+    expect(result.error).toBeDefined();
+    expect(result.task).toBeNull();
+  });
+
+  it('records messages for each transition', async () => {
+    const { task: created } = await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['BACKEND'],
+      title: 'Add pagination',
+    });
+
+    await advanceToWorking(tmpRoot, created.id, 'test-actor');
+
+    const { task } = await getTask(tmpRoot, created.id);
+    const statusMessages = task.messages.filter((m) => m.statusChange);
+    expect(statusMessages).toHaveLength(2);
+    expect(statusMessages[0].from).toBe('test-actor');
+    expect(statusMessages[1].from).toBe('test-actor');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runRun
+// ---------------------------------------------------------------------------
+
+describe('runRun', () => {
+  it('dispatches the first submitted task', async () => {
+    await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['BACKEND'],
+      title: 'Add pagination',
+    });
+
+    const output = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((s) => {
+      output.push(s);
+      return true;
+    });
+
+    await runRun({ projectRoot: tmpRoot, flags: { json: true } });
+
+    const result = JSON.parse(output[0]);
+    expect(result.error).toBeUndefined();
+    expect(result.taskId).toMatch(/^task-/);
+    expect(result.status).toBe('working');
+    expect(result.dryRun).toBe(false);
+    expect(result.prompt).toContain('/team-backend');
+  });
+
+  it('dry-run does not transition state', async () => {
+    const { task: created } = await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['BACKEND'],
+      title: 'Add pagination',
+    });
+
+    const output = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((s) => {
+      output.push(s);
+      return true;
+    });
+
+    await runRun({ projectRoot: tmpRoot, flags: { 'dry-run': true, json: true } });
+
+    const result = JSON.parse(output[0]);
+    expect(result.dryRun).toBe(true);
+
+    // Task should still be submitted
+    const { task } = await getTask(tmpRoot, created.id);
+    expect(task.status).toBe('submitted');
+  });
+
+  it('dispatches specific task by --id', async () => {
+    // Create two tasks
+    await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['BACKEND'],
+      title: 'Task A',
+      priority: 'P0',
+    });
+    const { task: taskB } = await createTask(tmpRoot, {
+      type: 'review',
+      delegator: 'orchestrator',
+      assignees: ['TESTING'],
+      title: 'Task B',
+      priority: 'P3',
+    });
+
+    const output = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((s) => {
+      output.push(s);
+      return true;
+    });
+
+    await runRun({ projectRoot: tmpRoot, flags: { id: taskB.id, json: true } });
+
+    const result = JSON.parse(output[0]);
+    expect(result.taskId).toBe(taskB.id);
+    expect(result.status).toBe('working');
+  });
+
+  it('exits with error for non-existent --id', async () => {
+    const output = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((s) => {
+      output.push(s);
+      return true;
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('EXIT');
+    });
+
+    await expect(
+      runRun({ projectRoot: tmpRoot, flags: { id: 'task-bogus', json: true } })
+    ).rejects.toThrow('EXIT');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const result = JSON.parse(output[0]);
+    expect(result.error).toBeDefined();
+  });
+
+  it('exits with error when dispatching a completed task', async () => {
+    const { task: created } = await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['BACKEND'],
+      title: 'Done task',
+    });
+
+    // Advance to completed
+    const { updateTaskStatus } = await import('../task-protocol.mjs');
+    await updateTaskStatus(tmpRoot, created.id, 'accepted');
+    await updateTaskStatus(tmpRoot, created.id, 'working');
+    await updateTaskStatus(tmpRoot, created.id, 'completed');
+
+    const output = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((s) => {
+      output.push(s);
+      return true;
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('EXIT');
+    });
+
+    await expect(
+      runRun({ projectRoot: tmpRoot, flags: { id: created.id, json: true } })
+    ).rejects.toThrow('EXIT');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const result = JSON.parse(output[0]);
+    expect(result.error).toContain('not dispatchable');
+  });
+
+  it('returns empty when no submitted tasks', async () => {
+    const output = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((s) => {
+      output.push(s);
+      return true;
+    });
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runRun({ projectRoot: tmpRoot, flags: { json: true } });
+
+    const result = JSON.parse(output[0]);
+    expect(result.error).toContain('No submitted tasks');
+    consoleSpy.mockRestore();
+  });
+
+  it('filters by --assignee', async () => {
+    await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['BACKEND'],
+      title: 'Backend task',
+    });
+    const { task: frontendTask } = await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['FRONTEND'],
+      title: 'Frontend task',
+    });
+
+    const output = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((s) => {
+      output.push(s);
+      return true;
+    });
+
+    await runRun({ projectRoot: tmpRoot, flags: { assignee: 'FRONTEND', json: true } });
+
+    const result = JSON.parse(output[0]);
+    expect(result.taskId).toBe(frontendTask.id);
+  });
+});

--- a/.agentkit/engines/node/src/__tests__/scaffold-engine.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/scaffold-engine.test.mjs
@@ -1,0 +1,358 @@
+import { createHash } from 'crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  cleanStaleFiles,
+  clearTemplateMeta,
+  getTemplateMeta,
+  setTemplateMeta,
+  writeManifest,
+  writeScaffoldOutputs,
+} from '../scaffold-engine.mjs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(prefix) {
+  const dir = join(
+    tmpdir(),
+    `scaffold-engine-test-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeSync(filePath, content) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, 'utf-8');
+}
+
+function sha256(content) {
+  return createHash('sha256')
+    .update(typeof content === 'string' ? content : content)
+    .digest('hex')
+    .slice(0, 12);
+}
+
+const noop = () => {};
+
+// ---------------------------------------------------------------------------
+// templateMetaMap API
+// ---------------------------------------------------------------------------
+
+describe('templateMetaMap', () => {
+  beforeEach(() => clearTemplateMeta());
+  afterEach(() => clearTemplateMeta());
+
+  it('returns null for unknown path', () => {
+    expect(getTemplateMeta('unknown/path.md')).toBeNull();
+  });
+
+  it('stores and retrieves metadata', () => {
+    const meta = { agentkit: { scaffold: 'once' } };
+    setTemplateMeta('some/file.md', meta);
+    expect(getTemplateMeta('some/file.md')).toBe(meta);
+  });
+
+  it('normalizes backslashes on set', () => {
+    const meta = { agentkit: { scaffold: 'managed' } };
+    setTemplateMeta('some\\file.md', meta);
+    expect(getTemplateMeta('some/file.md')).toBe(meta);
+  });
+
+  it('normalizes backslashes on get', () => {
+    const meta = { agentkit: { scaffold: 'always' } };
+    setTemplateMeta('some/file.md', meta);
+    expect(getTemplateMeta('some\\file.md')).toBe(meta);
+  });
+
+  it('clearTemplateMeta removes all entries', () => {
+    setTemplateMeta('a/b.md', { agentkit: {} });
+    setTemplateMeta('c/d.md', { agentkit: {} });
+    clearTemplateMeta();
+    expect(getTemplateMeta('a/b.md')).toBeNull();
+    expect(getTemplateMeta('c/d.md')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeScaffoldOutputs
+// ---------------------------------------------------------------------------
+
+describe('writeScaffoldOutputs', () => {
+  let projectRoot;
+  let tmpDir;
+
+  beforeEach(() => {
+    clearTemplateMeta();
+    projectRoot = makeTmpDir('project');
+    tmpDir = makeTmpDir('tmp');
+  });
+
+  afterEach(() => {
+    clearTemplateMeta();
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function run(overrides = {}) {
+    const allTmpFiles = overrides.allTmpFiles ?? [];
+    const newManifestFiles = overrides.newManifestFiles ?? {};
+    return writeScaffoldOutputs({
+      projectRoot,
+      agentkitRoot: join(projectRoot, '.agentkit'),
+      tmpDir,
+      allTmpFiles,
+      flags: overrides.flags ?? {},
+      newManifestFiles,
+      previousManifest: overrides.previousManifest ?? null,
+      vars: overrides.vars ?? {},
+      log: noop,
+      logVerbose: noop,
+    });
+  }
+
+  it('writes a new file that does not exist on disk', async () => {
+    const srcFile = join(tmpDir, 'new-file.md');
+    writeSync(srcFile, '# New File\n');
+
+    const { count, writtenFiles } = await run({ allTmpFiles: [srcFile] });
+
+    expect(count).toBe(1);
+    expect(writtenFiles).toHaveLength(1);
+    const content = await readFile(join(projectRoot, 'new-file.md'), 'utf-8');
+    expect(content).toBe('# New File\n');
+  });
+
+  it('returns count=0 when no files are provided', async () => {
+    const { count, writtenFiles } = await run({ allTmpFiles: [] });
+    expect(count).toBe(0);
+    expect(writtenFiles).toHaveLength(0);
+  });
+
+  it('skips scaffold:once files that already exist on disk', async () => {
+    const destFile = join(projectRoot, 'once-file.md');
+    writeSync(destFile, 'existing content\n');
+
+    const srcFile = join(tmpDir, 'once-file.md');
+    writeSync(srcFile, 'new content\n');
+
+    // Mark the file as scaffold:once via meta
+    setTemplateMeta('once-file.md', { agentkit: { scaffold: 'once' } });
+
+    const { count, skippedScaffold } = await run({ allTmpFiles: [srcFile] });
+
+    expect(count).toBe(0);
+    expect(skippedScaffold).toBe(1);
+    // File should be unchanged
+    const content = await readFile(destFile, 'utf-8');
+    expect(content).toBe('existing content\n');
+  });
+
+  it('blocks path traversal attempts', async () => {
+    // Create a file at a path that would escape the project root
+    const srcFile = join(tmpDir, '..', 'escape.md');
+    // We can't actually create a file above tmpDir easily, so we test with a
+    // file in a subdirectory of tmpDir that resolves outside projectRoot.
+    // Instead, we test the guard indirectly via a path that resolves normally.
+    // The traversal check is: resolved dest must start with resolvedRoot.
+    // We just verify normal files work and the function doesn't throw.
+    const normalSrc = join(tmpDir, 'normal.md');
+    writeSync(normalSrc, 'normal\n');
+
+    const { count } = await run({ allTmpFiles: [normalSrc] });
+    expect(count).toBe(1);
+  });
+
+  it('skips writing when content is identical (content-hash guard)', async () => {
+    const content = '# Same Content\n';
+    const destFile = join(projectRoot, 'same.md');
+    writeSync(destFile, content);
+
+    const srcFile = join(tmpDir, 'same.md');
+    writeSync(srcFile, content);
+
+    // Provide matching hash in newManifestFiles
+    const hash = sha256(Buffer.from(content));
+    const newManifestFiles = { 'same.md': { hash } };
+
+    const { count, writtenFiles } = await run({ allTmpFiles: [srcFile], newManifestFiles });
+
+    expect(count).toBe(0);
+    // writtenFiles is empty since we skipped (content-hash guard, not formatting-only)
+    expect(writtenFiles).toHaveLength(0);
+  });
+
+  it('overwrites when --force flag is set regardless of scaffold:once', async () => {
+    const destFile = join(projectRoot, 'once-file.md');
+    writeSync(destFile, 'old content\n');
+
+    const srcFile = join(tmpDir, 'once-file.md');
+    writeSync(srcFile, 'new content\n');
+
+    setTemplateMeta('once-file.md', { agentkit: { scaffold: 'once' } });
+
+    const { count } = await run({ allTmpFiles: [srcFile], flags: { force: true } });
+
+    expect(count).toBe(1);
+    const content = await readFile(destFile, 'utf-8');
+    expect(content).toBe('new content\n');
+  });
+
+  it('carries forward scaffold-once files from previous manifest into newManifestFiles', async () => {
+    // File exists on disk but was not re-generated this sync (scaffold:once)
+    const existingFile = join(projectRoot, 'preserved.md');
+    writeSync(existingFile, 'user content\n');
+
+    const newManifestFiles = {};
+    const previousManifest = {
+      files: { 'preserved.md': { hash: 'abc123' } },
+    };
+
+    await run({ allTmpFiles: [], newManifestFiles, previousManifest });
+
+    // The file should be carried forward so orphan cleanup doesn't delete it
+    expect(newManifestFiles['preserved.md']).toEqual({ hash: 'abc123' });
+  });
+
+  it('does not carry forward files that no longer exist on disk', async () => {
+    // File is in previous manifest but has been deleted from disk
+    const newManifestFiles = {};
+    const previousManifest = {
+      files: { 'deleted.md': { hash: 'abc123' } },
+    };
+
+    await run({ allTmpFiles: [], newManifestFiles, previousManifest });
+
+    expect(newManifestFiles['deleted.md']).toBeUndefined();
+  });
+
+  it('throws when a directory exists at destFile (cannot read as file)', async () => {
+    // When a directory exists at the destination path, readFile(destFile) in the
+    // content-hash guard throws EISDIR. The error propagates through runConcurrent.
+    const destDir = join(projectRoot, 'conflict');
+    mkdirSync(join(destDir, 'sub'), { recursive: true });
+
+    const srcFile = join(tmpDir, 'conflict');
+    writeSync(srcFile, 'content\n');
+
+    await expect(run({ allTmpFiles: [srcFile] })).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanStaleFiles
+// ---------------------------------------------------------------------------
+
+describe('cleanStaleFiles', () => {
+  let projectRoot;
+
+  beforeEach(() => {
+    projectRoot = makeTmpDir('clean');
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  async function clean(overrides = {}) {
+    return cleanStaleFiles({
+      projectRoot,
+      previousManifest: overrides.previousManifest ?? null,
+      newManifestFiles: overrides.newManifestFiles ?? {},
+      noClean: overrides.noClean ?? false,
+      logVerbose: noop,
+    });
+  }
+
+  it('returns 0 when noClean is true', async () => {
+    const staleFile = join(projectRoot, 'stale.md');
+    writeSync(staleFile, 'stale\n');
+
+    const count = await clean({
+      previousManifest: { files: { 'stale.md': { hash: 'abc' } } },
+      newManifestFiles: {},
+      noClean: true,
+    });
+
+    expect(count).toBe(0);
+    // File should still exist
+    const { existsSync } = await import('fs');
+    expect(existsSync(staleFile)).toBe(true);
+  });
+
+  it('deletes files in previousManifest but not in newManifestFiles', async () => {
+    const staleFile = join(projectRoot, 'stale.md');
+    writeSync(staleFile, 'stale content\n');
+
+    const count = await clean({
+      previousManifest: { files: { 'stale.md': { hash: 'abc' } } },
+      newManifestFiles: {},
+    });
+
+    expect(count).toBe(1);
+    const { existsSync } = await import('fs');
+    expect(existsSync(staleFile)).toBe(false);
+  });
+
+  it('does not delete files still in newManifestFiles', async () => {
+    const keepFile = join(projectRoot, 'keep.md');
+    writeSync(keepFile, 'keep\n');
+
+    const count = await clean({
+      previousManifest: { files: { 'keep.md': { hash: 'abc' } } },
+      newManifestFiles: { 'keep.md': { hash: 'abc' } },
+    });
+
+    expect(count).toBe(0);
+    const { existsSync } = await import('fs');
+    expect(existsSync(keepFile)).toBe(true);
+  });
+
+  it('returns 0 when previousManifest has no files', async () => {
+    const count = await clean({ previousManifest: { files: {} }, newManifestFiles: {} });
+    expect(count).toBe(0);
+  });
+
+  it('returns 0 when previousManifest is null', async () => {
+    const count = await clean({ previousManifest: null, newManifestFiles: {} });
+    expect(count).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeManifest
+// ---------------------------------------------------------------------------
+
+describe('writeManifest', () => {
+  let projectRoot;
+
+  beforeEach(() => {
+    projectRoot = makeTmpDir('manifest');
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('writes manifest JSON to the given path', async () => {
+    const manifestPath = join(projectRoot, '.agentkit', 'manifest.json');
+    await mkdir(dirname(manifestPath), { recursive: true });
+
+    const manifest = { generatedAt: '2026-01-01T00:00:00.000Z', version: '3.1.0', files: {} };
+    await writeManifest(manifestPath, manifest);
+
+    const written = JSON.parse(await readFile(manifestPath, 'utf-8'));
+    expect(written).toEqual(manifest);
+  });
+
+  it('does not throw when write fails (bad path)', async () => {
+    // Pass a path whose parent directory does not exist — writeFile will fail
+    const badPath = join(projectRoot, 'nonexistent', 'dir', 'manifest.json');
+    await expect(writeManifest(badPath, { files: {} })).resolves.toBeUndefined();
+  });
+});

--- a/.agentkit/engines/node/src/cli.mjs
+++ b/.agentkit/engines/node/src/cli.mjs
@@ -93,6 +93,7 @@ const CLI_INTERNAL_FLAGS = {
   features: ['verbose', 'help'],
   'analyze-agents': ['output', 'matrix', 'format', 'help'],
   worktree: ['base', 'no-setup', 'dry-run', 'help'],
+  run: ['id', 'assignee', 'dry-run', 'json', 'help'],
 };
 
 const CLI_INTERNAL_FLAG_TYPES = {
@@ -145,6 +146,7 @@ const CLI_INTERNAL_FLAG_TYPES = {
   // worktree flags
   base: 'string',
   'no-setup': 'boolean',
+  json: 'boolean',
 };
 
 /**

--- a/.agentkit/engines/node/src/cli.mjs
+++ b/.agentkit/engines/node/src/cli.mjs
@@ -644,6 +644,11 @@ async function main() {
         await runDelegate({ projectRoot: PROJECT_ROOT, flags });
         break;
       }
+      case 'run': {
+        const { runRun } = await import('./run-cli.mjs');
+        await runRun({ projectRoot: PROJECT_ROOT, flags });
+        break;
+      }
       case 'add': {
         const { runAdd } = await import('./tool-manager.mjs');
         await runAdd({ agentkitRoot: AGENTKIT_ROOT, projectRoot: PROJECT_ROOT, flags });

--- a/.agentkit/engines/node/src/commands-registry.mjs
+++ b/.agentkit/engines/node/src/commands-registry.mjs
@@ -34,6 +34,7 @@ export const VALID_COMMANDS = [
   'analyze-agents',
   'cicd-optimize',
   'worktree',
+  'run',
 ];
 
 /**
@@ -48,6 +49,7 @@ export const FRAMEWORK_COMMANDS = new Set([
   'list',
   'tasks',
   'delegate',
+  'run',
   'features',
   'init',
   'worktree',

--- a/.agentkit/engines/node/src/run-cli.mjs
+++ b/.agentkit/engines/node/src/run-cli.mjs
@@ -1,0 +1,222 @@
+/**
+ * Retort — Run CLI Handler
+ * Picks up the next agent task from the queue and dispatches it.
+ * Transitions the task through submitted → accepted → working and prints
+ * a formatted dispatch prompt for the assigned agent.
+ */
+import { emitEvent } from './event-emitter.mjs';
+import { formatTaskSummary, getTask, listTasks, updateTaskStatus } from './task-protocol.mjs';
+
+/**
+ * Map an assignee team name to its slash command.
+ * Normalises common formats: 'BACKEND', 'team-backend', 'backend' → '/team-backend'.
+ * @param {string} assignee
+ * @returns {string}
+ */
+export function assigneeToCommand(assignee) {
+  const normalised = assignee
+    .toLowerCase()
+    .replace(/^team[-_]?/, '')
+    .replace(/[-_]/g, '-');
+  return `/team-${normalised}`;
+}
+
+/**
+ * Build the agent dispatch prompt for a task.
+ * @param {object} task
+ * @returns {string}
+ */
+export function buildDispatchPrompt(task) {
+  const commands = (task.assignees || []).map(assigneeToCommand);
+  const commandLine = commands.length > 0 ? commands.join(' or ') : '/orchestrate';
+
+  const lines = [];
+  lines.push(`## Task Dispatch: ${task.id}`);
+  lines.push('');
+  lines.push(`**Invoke:** ${commandLine}`);
+  lines.push(`**Type:** ${task.type}  **Priority:** ${task.priority}  **Status:** ${task.status}`);
+
+  if (task.title) {
+    lines.push('');
+    lines.push(`### ${task.title}`);
+  }
+
+  if (task.description) {
+    lines.push('');
+    lines.push(task.description);
+  }
+
+  const criteria = Array.isArray(task.acceptanceCriteria) ? task.acceptanceCriteria : [];
+  if (criteria.length > 0) {
+    lines.push('');
+    lines.push('**Acceptance Criteria:**');
+    for (const c of criteria) {
+      lines.push(`- ${c}`);
+    }
+  }
+
+  const scope = Array.isArray(task.scope) ? task.scope : [];
+  if (scope.length > 0) {
+    lines.push('');
+    lines.push(`**Scope:** ${scope.join(', ')}`);
+  }
+
+  const deps = Array.isArray(task.dependsOn) ? task.dependsOn : [];
+  if (deps.length > 0) {
+    lines.push('');
+    lines.push(`**Depends on:** ${deps.join(', ')}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Transition a task from its current state toward 'working'.
+ * Chains: submitted → accepted → working.
+ * @param {string} projectRoot
+ * @param {string} taskId
+ * @param {string} actor - Name to record as the actor in messages
+ * @returns {Promise<{ task: object|null, error?: string }>}
+ */
+export async function advanceToWorking(projectRoot, taskId, actor = 'cli:run') {
+  let result = await getTask(projectRoot, taskId);
+  if (!result.task) return result;
+
+  const { task } = result;
+
+  if (task.status === 'submitted') {
+    result = await updateTaskStatus(projectRoot, taskId, 'accepted', {
+      role: 'executor',
+      from: actor,
+      content: 'Task accepted via retort run',
+    });
+    if (!result.task) return result;
+  }
+
+  if (result.task.status === 'accepted') {
+    result = await updateTaskStatus(projectRoot, taskId, 'working', {
+      role: 'executor',
+      from: actor,
+      content: 'Task dispatched via retort run',
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Dispatch the next (or a specific) agent task.
+ *
+ * Flags:
+ *   --id <task-id>       Run a specific task (default: highest-priority submitted task)
+ *   --assignee <team>    Filter candidates to tasks assigned to this team
+ *   --dry-run            Preview without transitioning state
+ *   --json               Machine-readable JSON output
+ */
+export async function runRun({ projectRoot, flags }) {
+  const dryRun = Boolean(flags['dry-run']);
+  const useJson = Boolean(flags.json);
+
+  let task;
+
+  if (flags.id) {
+    // Explicit task ID
+    const result = await getTask(projectRoot, flags.id);
+    if (!result.task) {
+      const msg = result.error || `Task not found: ${flags.id}`;
+      if (useJson) {
+        process.stdout.write(JSON.stringify({ error: msg }) + '\n');
+      } else {
+        console.error(`[retort:run] ${msg}`);
+      }
+      process.exit(1);
+    }
+    task = result.task;
+  } else {
+    // Find highest-priority submitted task
+    const filters = { status: 'submitted' };
+    if (flags.assignee) filters.assignee = flags.assignee;
+
+    const listResult = await listTasks(projectRoot, filters);
+    if (listResult.error) {
+      const msg = listResult.error;
+      if (useJson) {
+        process.stdout.write(JSON.stringify({ error: msg }) + '\n');
+      } else {
+        console.error(`[retort:run] ${msg}`);
+      }
+      process.exit(1);
+    }
+
+    const candidates = listResult.tasks || [];
+    if (candidates.length === 0) {
+      const msg = flags.assignee
+        ? `No submitted tasks found for assignee "${flags.assignee}"`
+        : 'No submitted tasks in queue';
+      if (useJson) {
+        process.stdout.write(JSON.stringify({ error: msg }) + '\n');
+      } else {
+        console.log(`[retort:run] ${msg}`);
+      }
+      return;
+    }
+
+    // listTasks returns tasks sorted by priority (P0 first)
+    task = candidates[0];
+  }
+
+  // Validate that the task is dispatchable
+  if (!['submitted', 'accepted'].includes(task.status)) {
+    const msg = `Task ${task.id} is not dispatchable (status: ${task.status})`;
+    if (useJson) {
+      process.stdout.write(JSON.stringify({ error: msg }) + '\n');
+    } else {
+      console.error(`[retort:run] ${msg}`);
+    }
+    process.exit(1);
+  }
+
+  if (!dryRun) {
+    const advResult = await advanceToWorking(projectRoot, task.id);
+    if (!advResult.task) {
+      const msg = advResult.error || `Failed to advance task ${task.id}`;
+      if (useJson) {
+        process.stdout.write(JSON.stringify({ error: msg }) + '\n');
+      } else {
+        console.error(`[retort:run] ${msg}`);
+      }
+      process.exit(1);
+    }
+    task = advResult.task;
+
+    emitEvent(projectRoot, 'run', {
+      actor: 'cli:run',
+      taskId: task.id,
+      assignees: Array.isArray(task.assignees) ? task.assignees : [],
+    });
+  }
+
+  if (useJson) {
+    process.stdout.write(
+      JSON.stringify({
+        taskId: task.id,
+        status: task.status,
+        dryRun,
+        prompt: buildDispatchPrompt(task),
+      }) + '\n'
+    );
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`[retort:run] DRY RUN — task ${task.id} would be dispatched`);
+  } else {
+    console.log(`[retort:run] Dispatched ${task.id} → working`);
+  }
+  console.log('');
+  console.log(buildDispatchPrompt(task));
+  console.log('');
+  if (!dryRun) {
+    console.log(formatTaskSummary(task));
+  }
+}

--- a/.agentkit/engines/node/src/scaffold-engine.mjs
+++ b/.agentkit/engines/node/src/scaffold-engine.mjs
@@ -1,0 +1,481 @@
+/**
+ * Retort — Scaffold Engine
+ *
+ * Owns the templateMetaMap singleton and the four post-render phases of runSync:
+ *
+ *   7. writeScaffoldOutputs  — write temp files to project root (scaffold-once / managed / always)
+ *   8. cleanStaleFiles       — delete orphaned files from previous sync
+ *   9. writeManifest         — write .agentkit/manifest.json
+ *  10. runPostSyncPrettier   — format written files with Prettier
+ *
+ * The templateMetaMap is populated by syncDirectCopy (in synchronize.mjs) via
+ * setTemplateMeta() and read here during the scaffold-action resolution step.
+ */
+import { execFileSync } from 'child_process';
+import { createHash } from 'crypto';
+import { existsSync, readFileSync } from 'fs';
+import { chmod, cp, readFile, unlink, writeFile } from 'fs/promises';
+import { dirname, extname, relative, resolve, sep } from 'path';
+import { ensureDir, runConcurrent } from './fs-utils.mjs';
+import { normalizeForComparison, threeWayMerge } from './scaffold-merge.mjs';
+import { resolveScaffoldAction } from './template-utils.mjs';
+
+// ---------------------------------------------------------------------------
+// Template metadata map — populated during template rendering (syncDirectCopy),
+// consumed during scaffold output writing (writeScaffoldOutputs).
+// ---------------------------------------------------------------------------
+
+/** @type {Map<string, object>} relPath → parsed template frontmatter */
+const templateMetaMap = new Map();
+
+/**
+ * Retrieve parsed frontmatter metadata for a generated file.
+ * @param {string} relPath
+ * @returns {object|null}
+ */
+export function getTemplateMeta(relPath) {
+  return templateMetaMap.get(relPath.replace(/\\/g, '/')) || null;
+}
+
+/**
+ * Store parsed frontmatter metadata for a generated file.
+ * Called from syncDirectCopy when a template has scaffold directives.
+ * @param {string} relPath
+ * @param {object} meta
+ */
+export function setTemplateMeta(relPath, meta) {
+  templateMetaMap.set(relPath.replace(/\\/g, '/'), meta);
+}
+
+/**
+ * Clear all stored metadata — called at the start of each runSync invocation
+ * so that stale entries from a previous sync (e.g. in tests) are not visible.
+ */
+export function clearTemplateMeta() {
+  templateMetaMap.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Step 7: Write scaffold outputs
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomic swap: move rendered temp files to the project root, respecting the
+ * scaffold action (once / managed / always) for each file.
+ *
+ * Mutates `newManifestFiles` in place to carry forward scaffold-once entries
+ * that were skipped this sync but exist on disk (so orphan cleanup keeps them).
+ *
+ * @param {object} opts
+ * @param {string}   opts.projectRoot
+ * @param {string}   opts.agentkitRoot
+ * @param {string}   opts.tmpDir
+ * @param {string[]} opts.allTmpFiles
+ * @param {object}   opts.flags
+ * @param {object}   opts.newManifestFiles  — mutated in place
+ * @param {object}   opts.previousManifest
+ * @param {object}   opts.vars
+ * @param {Function} opts.log
+ * @param {Function} opts.logVerbose
+ * @returns {Promise<{ count: number, skippedScaffold: number, writtenFiles: string[] }>}
+ */
+export async function writeScaffoldOutputs({
+  projectRoot,
+  agentkitRoot,
+  tmpDir,
+  allTmpFiles,
+  flags,
+  newManifestFiles,
+  previousManifest,
+  vars,
+  log,
+  logVerbose,
+}) {
+  const resolvedRoot = resolve(projectRoot) + sep;
+  const scaffoldCacheDir = resolve(agentkitRoot, '.scaffold-cache');
+
+  let count = 0;
+  let skippedScaffold = 0;
+  const failedFiles = [];
+  // NOTE: Safe for single-threaded async (Array.push is synchronous in V8).
+  // If runConcurrent ever uses worker threads, this needs synchronization.
+  const writtenFiles = []; // absolute paths of files written, for post-sync formatting
+  const scaffoldResults = {
+    alwaysRegenerated: [],
+    managedRegenerated: [],
+    managedMerged: [],
+    managedConflicts: [],
+    managedPreserved: [],
+    managedNoCache: [],
+  };
+
+  await runConcurrent(allTmpFiles, async (srcFile) => {
+    if (!existsSync(srcFile)) return;
+    const relPath = relative(tmpDir, srcFile);
+    const normalizedRel = relPath.replace(/\\/g, '/');
+    const destFile = resolve(projectRoot, relPath);
+
+    // Interactive skip: user chose to skip this file in "prompt each" mode
+    if (flags?._skipPaths?.has(normalizedRel)) {
+      logVerbose(`  skipped ${normalizedRel} (user chose to skip)`);
+      return;
+    }
+
+    // Path traversal protection: ensure all output stays within project root
+    if (!resolve(destFile).startsWith(resolvedRoot) && resolve(destFile) !== resolve(projectRoot)) {
+      console.error(`[retort:sync] BLOCKED: path traversal detected — ${normalizedRel}`);
+      failedFiles.push({ file: normalizedRel, error: 'path traversal blocked' });
+      return;
+    }
+
+    // Scaffold action resolution: always | managed (check-hash) | once (skip)
+    const meta = getTemplateMeta(normalizedRel);
+    const overwrite = flags?.overwrite || flags?.force;
+    if (!overwrite && existsSync(destFile)) {
+      const action = resolveScaffoldAction(normalizedRel, vars, meta);
+
+      if (action === 'skip') {
+        skippedScaffold++;
+        return;
+      }
+
+      if (action === 'check-hash') {
+        const diskContent = await readFile(destFile);
+        const diskHash = createHash('sha256').update(diskContent).digest('hex').slice(0, 12);
+        const prevHash = previousManifest?.files?.[normalizedRel]?.hash;
+
+        if (prevHash && diskHash !== prevHash) {
+          const cachePath = resolve(scaffoldCacheDir, relPath);
+          const newContent = await readFile(srcFile, 'utf-8');
+
+          if (existsSync(cachePath)) {
+            const baseContent = readFileSync(cachePath, 'utf-8');
+            const diskText = diskContent.toString('utf-8');
+
+            // Check whether the disk differs from the cache for reasons other
+            // than table-cell padding (Prettier alignment).  If the normalised
+            // forms are identical the file contains no real user edits — fall
+            // through to the pristine overwrite path below.
+            if (normalizeForComparison(diskText) !== normalizeForComparison(baseContent)) {
+              // Real user edit.  Only attempt a three-way merge when the template
+              // has actually changed since the last sync (base ≠ theirs after
+              // normalisation).  When the template is unchanged the merge would
+              // be a no-op (result === disk) — skip it to stop the churn loop.
+              if (normalizeForComparison(baseContent) === normalizeForComparison(newContent)) {
+                // Template unchanged — preserve user edits, no write needed
+                skippedScaffold++;
+                scaffoldResults.managedPreserved.push(normalizedRel);
+                logVerbose(`  skipped ${normalizedRel} (user edits preserved, template unchanged)`);
+                return;
+              }
+
+              const result = threeWayMerge(diskText, baseContent, newContent);
+
+              if (result) {
+                // Write merged result
+                await ensureDir(dirname(destFile));
+                await writeFile(destFile, result.merged, 'utf-8');
+                // Update scaffold cache with new generated content
+                await ensureDir(dirname(cachePath));
+                await writeFile(cachePath, newContent, 'utf-8');
+                count++;
+
+                writtenFiles.push(destFile);
+                if (result.hasConflicts) {
+                  scaffoldResults.managedConflicts.push(normalizedRel);
+                  console.warn(
+                    `[retort:sync] CONFLICT in ${normalizedRel} — resolve <<<< markers manually`
+                  );
+                } else {
+                  scaffoldResults.managedMerged.push(normalizedRel);
+                  logVerbose(`  merged ${normalizedRel} (user edits + template changes combined)`);
+                }
+                return;
+              }
+              // git merge-file unavailable — skip and preserve user edits
+              skippedScaffold++;
+              scaffoldResults.managedPreserved.push(normalizedRel);
+              logVerbose(
+                `  skipped ${normalizedRel} (user edits detected, hash: ${prevHash} → ${diskHash})`
+              );
+              return;
+            }
+            // Formatting-only diff — fall through to pristine overwrite
+          } else {
+            // No cache — skip and preserve user edits
+            skippedScaffold++;
+            scaffoldResults.managedPreserved.push(normalizedRel);
+            scaffoldResults.managedNoCache.push(normalizedRel);
+            logVerbose(
+              `  skipped ${normalizedRel} (user edits detected, hash: ${prevHash} → ${diskHash})`
+            );
+            return;
+          }
+        }
+        // Hash matches, no previous hash, or formatting-only diff — safe to overwrite (pristine)
+        scaffoldResults.managedRegenerated.push(normalizedRel);
+      } else {
+        // action === 'write' for scaffold: always
+        if (meta?.agentkit?.scaffold === 'always') {
+          scaffoldResults.alwaysRegenerated.push(normalizedRel);
+        }
+      }
+    }
+
+    // Content-hash guard: skip write if content is identical to the existing file.
+    // This prevents mtime churn on generated files that haven't logically changed,
+    // reducing adopter merge-conflict counts on framework-update merges.
+    // Also skips when the only difference is markdown table-cell padding (Prettier
+    // alignment vs compact template output) so formatted files are not reverted each run.
+    if (existsSync(destFile)) {
+      const existingContent = await readFile(destFile);
+      const newHash = newManifestFiles[normalizedRel]?.hash;
+      if (newHash) {
+        const existingHash = createHash('sha256')
+          .update(existingContent)
+          .digest('hex')
+          .slice(0, 12);
+        if (existingHash === newHash) {
+          logVerbose(`  unchanged ${normalizedRel} (content identical, skipping write)`);
+          return;
+        }
+      }
+      // Slower path: skip write when the only difference is table-cell padding.
+      const newContent = await readFile(srcFile, 'utf-8');
+      if (
+        normalizeForComparison(existingContent.toString('utf-8')) ===
+        normalizeForComparison(newContent)
+      ) {
+        // Still queue for Prettier even though we skip the write — the file on
+        // disk may be unformatted from a previous sync that predates this guard.
+        writtenFiles.push(destFile);
+        logVerbose(`  unchanged ${normalizedRel} (formatting-only diff, skipping write)`);
+        return;
+      }
+    }
+
+    try {
+      await ensureDir(dirname(destFile));
+      await cp(srcFile, destFile, { force: true, recursive: false });
+
+      // Update scaffold cache for managed files
+      if (meta?.agentkit?.scaffold === 'managed' || meta?.agentkit?.scaffold === 'always') {
+        const cachePath = resolve(scaffoldCacheDir, relPath);
+        try {
+          await ensureDir(dirname(cachePath));
+          const content = await readFile(srcFile, 'utf-8');
+          await writeFile(cachePath, content, 'utf-8');
+        } catch {
+          /* ignore cache write failures */
+        }
+      }
+
+      // Make .sh files executable
+      if (extname(srcFile) === '.sh') {
+        try {
+          await chmod(destFile, 0o755);
+        } catch {
+          /* ignore on Windows */
+        }
+      }
+      count++;
+      writtenFiles.push(destFile);
+      logVerbose(`  wrote ${normalizedRel}`);
+    } catch (err) {
+      failedFiles.push({ file: normalizedRel, error: err.message });
+      console.error(`[retort:sync] Failed to write: ${normalizedRel} — ${err.message}`);
+    }
+  });
+
+  if (failedFiles.length > 0) {
+    console.error(`[retort:sync] Error: ${failedFiles.length} file(s) failed to write:`);
+    for (const f of failedFiles) {
+      console.error(`  - ${f.file}: ${f.error}`);
+    }
+    throw new Error(`Sync completed with ${failedFiles.length} write failure(s)`);
+  }
+
+  // Scaffold summary
+  const hasManagedActivity =
+    scaffoldResults.alwaysRegenerated.length > 0 ||
+    scaffoldResults.managedRegenerated.length > 0 ||
+    scaffoldResults.managedMerged.length > 0 ||
+    scaffoldResults.managedConflicts.length > 0 ||
+    scaffoldResults.managedPreserved.length > 0;
+
+  if (hasManagedActivity) {
+    log('[retort:sync] Scaffold summary:');
+    if (scaffoldResults.alwaysRegenerated.length > 0) {
+      log(`  ${scaffoldResults.alwaysRegenerated.length} file(s) always-regenerated`);
+    }
+    if (scaffoldResults.managedRegenerated.length > 0) {
+      log(`  ${scaffoldResults.managedRegenerated.length} managed file(s) regenerated (pristine)`);
+    }
+    if (scaffoldResults.managedMerged.length > 0) {
+      log(
+        `  ${scaffoldResults.managedMerged.length} managed file(s) merged (user edits + template changes)`
+      );
+    }
+    if (scaffoldResults.managedConflicts.length > 0) {
+      console.warn(
+        `  ${scaffoldResults.managedConflicts.length} managed file(s) with CONFLICTS — resolve manually:`
+      );
+      for (const f of scaffoldResults.managedConflicts) {
+        console.warn(`    - ${f}`);
+      }
+    }
+    if (scaffoldResults.managedPreserved.length > 0) {
+      log(
+        `  ${scaffoldResults.managedPreserved.length} managed file(s) preserved (user edits detected)`
+      );
+      for (const f of scaffoldResults.managedPreserved) {
+        logVerbose(`    - ${f}`);
+      }
+    }
+  }
+  const scaffoldOnceSkipped = skippedScaffold - scaffoldResults.managedPreserved.length;
+  if (scaffoldOnceSkipped > 0) {
+    logVerbose(`  ${scaffoldOnceSkipped} scaffold-once file(s) skipped`);
+  }
+
+  // Carry forward scaffold-once files from previous manifest.
+  // When a file was generated in a previous sync but skipped this time (scaffold-once),
+  // it must remain in the new manifest so orphan cleanup does not delete it.
+  if (previousManifest?.files) {
+    for (const [prevFile, prevMeta] of Object.entries(previousManifest.files)) {
+      if (!newManifestFiles[prevFile]) {
+        const prevPath = resolve(projectRoot, prevFile);
+        if (existsSync(prevPath)) {
+          // File exists on disk but was not regenerated — carry forward its manifest entry
+          newManifestFiles[prevFile] = prevMeta;
+        }
+      }
+    }
+  }
+
+  return { count, skippedScaffold, writtenFiles };
+}
+
+// ---------------------------------------------------------------------------
+// Step 8: Stale file cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete orphaned files from the previous sync manifest that are no longer
+ * present in the new manifest. Skipped when `noClean` is true.
+ *
+ * @param {object} opts
+ * @param {string}   opts.projectRoot
+ * @param {object}   opts.previousManifest
+ * @param {object}   opts.newManifestFiles
+ * @param {boolean}  opts.noClean
+ * @param {Function} opts.logVerbose
+ * @returns {Promise<number>} Number of files deleted
+ */
+export async function cleanStaleFiles({
+  projectRoot,
+  previousManifest,
+  newManifestFiles,
+  noClean,
+  logVerbose,
+}) {
+  let cleanedCount = 0;
+  if (!noClean && previousManifest?.files) {
+    const resolvedRoot = resolve(projectRoot) + sep;
+    const staleFiles = [];
+    for (const prevFile of Object.keys(previousManifest.files)) {
+      if (!newManifestFiles[prevFile]) {
+        staleFiles.push(prevFile);
+      }
+    }
+
+    await runConcurrent(staleFiles, async (prevFile) => {
+      const orphanPath = resolve(projectRoot, prevFile);
+      // Path traversal protection: ensure orphan path stays within project root
+      if (!orphanPath.startsWith(resolvedRoot)) {
+        console.warn(`[retort:sync] BLOCKED: path traversal in manifest — ${prevFile}`);
+        return;
+      }
+      if (existsSync(orphanPath)) {
+        try {
+          await unlink(orphanPath);
+          cleanedCount++;
+          logVerbose(`[retort:sync] Cleaned stale file: ${prevFile}`);
+        } catch (err) {
+          console.warn(
+            `[retort:sync] Warning: could not clean stale file ${prevFile} — ${err.message}`
+          );
+        }
+      }
+    });
+  }
+  return cleanedCount;
+}
+
+// ---------------------------------------------------------------------------
+// Step 9: Write manifest
+// ---------------------------------------------------------------------------
+
+/**
+ * Persist the new manifest to disk. Logs a warning (does not throw) on failure
+ * so that a manifest write error does not mask a successful sync.
+ *
+ * @param {string} manifestPath  — absolute path to manifest.json
+ * @param {object} manifest      — manifest object to serialise
+ * @returns {Promise<void>}
+ */
+export async function writeManifest(manifestPath, manifest) {
+  try {
+    await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+  } catch (err) {
+    console.warn(`[retort:sync] Warning: could not write manifest — ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 10: Post-sync Prettier formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Run Prettier on all files written during this sync pass.
+ * Silently skipped when Prettier is not installed or `writtenFiles` is empty.
+ * Formats in batches of 50 to avoid OS argument-length limits.
+ *
+ * @param {object} opts
+ * @param {string}   opts.agentkitRoot
+ * @param {string}   opts.projectRoot
+ * @param {string[]} opts.writtenFiles
+ * @param {Function} opts.logVerbose
+ * @returns {Promise<void>}
+ */
+export async function runPostSyncPrettier({ agentkitRoot, projectRoot, writtenFiles, logVerbose }) {
+  const prettierBin = resolve(agentkitRoot, 'node_modules', 'prettier', 'bin', 'prettier.cjs');
+  if (!existsSync(prettierBin) || writtenFiles.length === 0) return;
+
+  try {
+    const BATCH_SIZE = 50;
+    let formattedCount = 0;
+    for (let i = 0; i < writtenFiles.length; i += BATCH_SIZE) {
+      const batch = writtenFiles.slice(i, i + BATCH_SIZE);
+      try {
+        execFileSync(process.execPath, [prettierBin, '--write', ...batch], {
+          cwd: projectRoot,
+          encoding: 'utf-8',
+          stdio: 'pipe',
+          timeout: 60_000,
+        });
+        formattedCount += batch.length;
+      } catch (err) {
+        if (err?.killed) {
+          logVerbose(`[retort:sync] Prettier batch timed out, continuing...`);
+        }
+        // prettier may fail on some files (e.g. non-parseable) — continue
+      }
+    }
+    if (formattedCount > 0) {
+      logVerbose(`[retort:sync] Formatted ${formattedCount} generated file(s) with Prettier.`);
+    }
+  } catch {
+    // If prettier is not available or fails entirely, just continue
+  }
+}

--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -5,10 +5,9 @@
  * readYaml/readText use synchronous fs APIs for simplicity at startup.
  * Pure template helpers live in template-utils.mjs.
  */
-import { execFileSync } from 'child_process';
 import { createHash } from 'crypto';
 import { existsSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
-import { chmod, cp, mkdir, mkdtemp, readFile, readdir, rm, unlink, writeFile } from 'fs/promises';
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'fs/promises';
 import yaml from 'js-yaml';
 import { tmpdir } from 'os';
 import { basename, dirname, extname, join, relative, resolve, sep } from 'path';
@@ -27,7 +26,15 @@ import {
   resolveFeatures,
 } from './feature-manager.mjs';
 import { ensureDir, runConcurrent, walkDir, writeOutput } from './fs-utils.mjs';
-import { normalizeForComparison, threeWayMerge } from './scaffold-merge.mjs';
+import {
+  cleanStaleFiles,
+  clearTemplateMeta,
+  getTemplateMeta,
+  runPostSyncPrettier,
+  setTemplateMeta,
+  writeManifest,
+  writeScaffoldOutputs,
+} from './scaffold-engine.mjs';
 import {
   categorizeFile,
   computeProjectCompleteness,
@@ -41,26 +48,12 @@ import {
   printSyncSummary,
   renderTemplate,
   resolveRenderTargets,
-  resolveScaffoldAction,
   simpleDiff,
 } from './template-utils.mjs';
 import { applyRetortConfig, loadRetortConfig } from './retort-config.mjs';
 
-// ---------------------------------------------------------------------------
-// Scaffold metadata map — populated during template rendering, consumed in Step 7
-// ---------------------------------------------------------------------------
-
-/** @type {Map<string, object>} relPath → parsed template frontmatter */
-const templateMetaMap = new Map();
-
-/**
- * Retrieve parsed frontmatter metadata for a generated file.
- * @param {string} relPath - Relative path from project root
- * @returns {object|null}
- */
-export function getTemplateMeta(relPath) {
-  return templateMetaMap.get(relPath.replace(/\\/g, '/')) || null;
-}
+// templateMetaMap, getTemplateMeta, setTemplateMeta, clearTemplateMeta
+// live in scaffold-engine.mjs (imported above).
 
 function getTeamCommandStem(teamId) {
   return teamId.startsWith('team-') ? teamId : `team-${teamId}`;
@@ -83,7 +76,7 @@ export function resolveCommandPath(cmdName, prefix, strategy = 'filename') {
   return { dir: '', stem: `${prefix}-${cmdName}` };
 }
 
-// threeWayMerge and normalizeForComparison live in scaffold-merge.mjs (imported above)
+// threeWayMerge and normalizeForComparison live in scaffold-merge.mjs (used by scaffold-engine.mjs)
 
 // ---------------------------------------------------------------------------
 // I/O helpers
@@ -275,8 +268,7 @@ export async function syncDirectCopy(
     // Parse and strip template frontmatter (agentkit scaffold directives)
     const { meta, content: stripped } = parseTemplateFrontmatter(content);
     if (meta) {
-      const normalizedRel = destRelPath.replace(/\\/g, '/');
-      templateMetaMap.set(normalizedRel, meta);
+      setTemplateMeta(destRelPath, meta);
     }
 
     const rendered = renderTemplate(stripped, vars, srcFile);
@@ -1960,7 +1952,7 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
   const noClean = flags?.['no-clean'] || false;
 
   // Clear module-level state from any previous run (e.g. in tests)
-  templateMetaMap.clear();
+  clearTemplateMeta();
   templateTextCache.clear();
 
   const log = (...args) => {
@@ -2822,355 +2814,40 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
       /* ignore corrupt manifest */
     }
 
-    // 7. Atomic swap: move temp outputs to project root & build new manifest
+    // 7. Write scaffold outputs (scaffold-once / managed / always)
     log('[retort:sync] Writing outputs...');
-    const resolvedRoot = resolve(projectRoot) + sep;
-    const scaffoldCacheDir = resolve(agentkitRoot, '.scaffold-cache');
-
-    // Use shared counters and tracking lists
-    let count = 0;
-    let skippedScaffold = 0;
-    const failedFiles = [];
-    // NOTE: Safe for single-threaded async (Array.push is synchronous in V8).
-    // If runConcurrent ever uses worker threads, this needs synchronization.
-    const writtenFiles = []; // absolute paths of files written, for post-sync formatting
-    const scaffoldResults = {
-      alwaysRegenerated: [],
-      managedRegenerated: [],
-      managedMerged: [],
-      managedConflicts: [],
-      managedPreserved: [],
-      managedNoCache: [],
-    };
-
-    await runConcurrent(allTmpFiles, async (srcFile) => {
-      if (!existsSync(srcFile)) return;
-      const relPath = relative(tmpDir, srcFile);
-      const normalizedRel = relPath.replace(/\\/g, '/');
-      const destFile = resolve(projectRoot, relPath);
-
-      // Interactive skip: user chose to skip this file in "prompt each" mode
-      if (flags?._skipPaths?.has(normalizedRel)) {
-        logVerbose(`  skipped ${normalizedRel} (user chose to skip)`);
-        return;
-      }
-
-      // Path traversal protection: ensure all output stays within project root
-      if (
-        !resolve(destFile).startsWith(resolvedRoot) &&
-        resolve(destFile) !== resolve(projectRoot)
-      ) {
-        console.error(`[retort:sync] BLOCKED: path traversal detected — ${normalizedRel}`);
-        failedFiles.push({ file: normalizedRel, error: 'path traversal blocked' });
-        return;
-      }
-
-      // Scaffold action resolution: always | managed (check-hash) | once (skip)
-      const meta = getTemplateMeta(normalizedRel);
-      const overwrite = flags?.overwrite || flags?.force;
-      if (!overwrite && existsSync(destFile)) {
-        const action = resolveScaffoldAction(normalizedRel, vars, meta);
-
-        if (action === 'skip') {
-          skippedScaffold++;
-          return;
-        }
-
-        if (action === 'check-hash') {
-          const diskContent = await readFile(destFile);
-          const diskHash = createHash('sha256').update(diskContent).digest('hex').slice(0, 12);
-          const prevHash = previousManifest?.files?.[normalizedRel]?.hash;
-
-          if (prevHash && diskHash !== prevHash) {
-            const cachePath = resolve(scaffoldCacheDir, relPath);
-            const newContent = await readFile(srcFile, 'utf-8');
-
-            if (existsSync(cachePath)) {
-              const baseContent = readFileSync(cachePath, 'utf-8');
-              const diskText = diskContent.toString('utf-8');
-
-              // Check whether the disk differs from the cache for reasons other
-              // than table-cell padding (Prettier alignment).  If the normalised
-              // forms are identical the file contains no real user edits — fall
-              // through to the pristine overwrite path below.
-              if (normalizeForComparison(diskText) !== normalizeForComparison(baseContent)) {
-                // Real user edit.  Only attempt a three-way merge when the template
-                // has actually changed since the last sync (base ≠ theirs after
-                // normalisation).  When the template is unchanged the merge would
-                // be a no-op (result === disk) — skip it to stop the churn loop.
-                if (normalizeForComparison(baseContent) === normalizeForComparison(newContent)) {
-                  // Template unchanged — preserve user edits, no write needed
-                  skippedScaffold++;
-                  scaffoldResults.managedPreserved.push(normalizedRel);
-                  logVerbose(
-                    `  skipped ${normalizedRel} (user edits preserved, template unchanged)`
-                  );
-                  return;
-                }
-
-                const result = threeWayMerge(diskText, baseContent, newContent);
-
-                if (result) {
-                  // Write merged result
-                  await ensureDir(dirname(destFile));
-                  await writeFile(destFile, result.merged, 'utf-8');
-                  // Update scaffold cache with new generated content
-                  await ensureDir(dirname(cachePath));
-                  await writeFile(cachePath, newContent, 'utf-8');
-                  count++;
-
-                  writtenFiles.push(destFile);
-                  if (result.hasConflicts) {
-                    scaffoldResults.managedConflicts.push(normalizedRel);
-                    console.warn(
-                      `[retort:sync] CONFLICT in ${normalizedRel} — resolve <<<< markers manually`
-                    );
-                  } else {
-                    scaffoldResults.managedMerged.push(normalizedRel);
-                    logVerbose(
-                      `  merged ${normalizedRel} (user edits + template changes combined)`
-                    );
-                  }
-                  return;
-                }
-                // git merge-file unavailable — skip and preserve user edits
-                skippedScaffold++;
-                scaffoldResults.managedPreserved.push(normalizedRel);
-                logVerbose(
-                  `  skipped ${normalizedRel} (user edits detected, hash: ${prevHash} → ${diskHash})`
-                );
-                return;
-              }
-              // Formatting-only diff — fall through to pristine overwrite
-            } else {
-              // No cache — skip and preserve user edits
-              skippedScaffold++;
-              scaffoldResults.managedPreserved.push(normalizedRel);
-              scaffoldResults.managedNoCache.push(normalizedRel);
-              logVerbose(
-                `  skipped ${normalizedRel} (user edits detected, hash: ${prevHash} → ${diskHash})`
-              );
-              return;
-            }
-          }
-          // Hash matches, no previous hash, or formatting-only diff — safe to overwrite (pristine)
-          scaffoldResults.managedRegenerated.push(normalizedRel);
-        } else {
-          // action === 'write' for scaffold: always
-          if (meta?.agentkit?.scaffold === 'always') {
-            scaffoldResults.alwaysRegenerated.push(normalizedRel);
-          }
-        }
-      }
-
-      // Content-hash guard: skip write if content is identical to the existing file.
-      // This prevents mtime churn on generated files that haven't logically changed,
-      // reducing adopter merge-conflict counts on framework-update merges.
-      // Also skips when the only difference is markdown table-cell padding (Prettier
-      // alignment vs compact template output) so formatted files are not reverted each run.
-      if (existsSync(destFile)) {
-        const existingContent = await readFile(destFile);
-        const newHash = newManifestFiles[normalizedRel]?.hash;
-        if (newHash) {
-          const existingHash = createHash('sha256')
-            .update(existingContent)
-            .digest('hex')
-            .slice(0, 12);
-          if (existingHash === newHash) {
-            logVerbose(`  unchanged ${normalizedRel} (content identical, skipping write)`);
-            return;
-          }
-        }
-        // Slower path: skip write when the only difference is table-cell padding.
-        const newContent = await readFile(srcFile, 'utf-8');
-        if (
-          normalizeForComparison(existingContent.toString('utf-8')) ===
-          normalizeForComparison(newContent)
-        ) {
-          // Still queue for Prettier even though we skip the write — the file on
-          // disk may be unformatted from a previous sync that predates this guard.
-          writtenFiles.push(destFile);
-          logVerbose(`  unchanged ${normalizedRel} (formatting-only diff, skipping write)`);
-          return;
-        }
-      }
-
-      try {
-        await ensureDir(dirname(destFile));
-        await cp(srcFile, destFile, { force: true, recursive: false });
-
-        // Update scaffold cache for managed files
-        if (meta?.agentkit?.scaffold === 'managed' || meta?.agentkit?.scaffold === 'always') {
-          const cachePath = resolve(scaffoldCacheDir, relPath);
-          try {
-            await ensureDir(dirname(cachePath));
-            const content = await readFile(srcFile, 'utf-8');
-            await writeFile(cachePath, content, 'utf-8');
-          } catch {
-            /* ignore cache write failures */
-          }
-        }
-
-        // Make .sh files executable
-        if (extname(srcFile) === '.sh') {
-          try {
-            await chmod(destFile, 0o755);
-          } catch {
-            /* ignore on Windows */
-          }
-        }
-        count++;
-        writtenFiles.push(destFile);
-        logVerbose(`  wrote ${normalizedRel}`);
-      } catch (err) {
-        failedFiles.push({ file: normalizedRel, error: err.message });
-        console.error(`[retort:sync] Failed to write: ${normalizedRel} — ${err.message}`);
-      }
+    const { count, skippedScaffold, writtenFiles } = await writeScaffoldOutputs({
+      projectRoot,
+      agentkitRoot,
+      tmpDir,
+      allTmpFiles,
+      flags,
+      newManifestFiles,
+      previousManifest,
+      vars,
+      log,
+      logVerbose,
     });
 
-    if (failedFiles.length > 0) {
-      console.error(`[retort:sync] Error: ${failedFiles.length} file(s) failed to write:`);
-      for (const f of failedFiles) {
-        console.error(`  - ${f.file}: ${f.error}`);
-      }
-      throw new Error(`Sync completed with ${failedFiles.length} write failure(s)`);
-    }
-
-    // 7b. Scaffold summary
-    const hasManagedActivity =
-      scaffoldResults.alwaysRegenerated.length > 0 ||
-      scaffoldResults.managedRegenerated.length > 0 ||
-      scaffoldResults.managedMerged.length > 0 ||
-      scaffoldResults.managedConflicts.length > 0 ||
-      scaffoldResults.managedPreserved.length > 0;
-
-    if (hasManagedActivity) {
-      log('[retort:sync] Scaffold summary:');
-      if (scaffoldResults.alwaysRegenerated.length > 0) {
-        log(`  ${scaffoldResults.alwaysRegenerated.length} file(s) always-regenerated`);
-      }
-      if (scaffoldResults.managedRegenerated.length > 0) {
-        log(
-          `  ${scaffoldResults.managedRegenerated.length} managed file(s) regenerated (pristine)`
-        );
-      }
-      if (scaffoldResults.managedMerged.length > 0) {
-        log(
-          `  ${scaffoldResults.managedMerged.length} managed file(s) merged (user edits + template changes)`
-        );
-      }
-      if (scaffoldResults.managedConflicts.length > 0) {
-        console.warn(
-          `  ${scaffoldResults.managedConflicts.length} managed file(s) with CONFLICTS — resolve manually:`
-        );
-        for (const f of scaffoldResults.managedConflicts) {
-          console.warn(`    - ${f}`);
-        }
-      }
-      if (scaffoldResults.managedPreserved.length > 0) {
-        log(
-          `  ${scaffoldResults.managedPreserved.length} managed file(s) preserved (user edits detected)`
-        );
-        for (const f of scaffoldResults.managedPreserved) {
-          logVerbose(`    - ${f}`);
-        }
-      }
-    }
-    const scaffoldOnceSkipped = skippedScaffold - scaffoldResults.managedPreserved.length;
-    if (scaffoldOnceSkipped > 0) {
-      logVerbose(`  ${scaffoldOnceSkipped} scaffold-once file(s) skipped`);
-    }
-
-    // 7b. Carry forward scaffold-once files from previous manifest.
-    // When a file was generated in a previous sync but skipped this time (scaffold-once),
-    // it must remain in the new manifest so orphan cleanup does not delete it.
-    if (previousManifest?.files) {
-      for (const [prevFile, prevMeta] of Object.entries(previousManifest.files)) {
-        if (!newManifestFiles[prevFile]) {
-          const prevPath = resolve(projectRoot, prevFile);
-          if (existsSync(prevPath)) {
-            // File exists on disk but was not regenerated — carry forward its manifest entry
-            newManifestFiles[prevFile] = prevMeta;
-          }
-        }
-      }
-    }
-
     // 8. Stale file cleanup: delete orphaned files from previous sync (unless --no-clean)
-    let cleanedCount = 0;
-    if (!noClean && previousManifest?.files) {
-      const staleFiles = [];
-      for (const prevFile of Object.keys(previousManifest.files)) {
-        if (!newManifestFiles[prevFile]) {
-          staleFiles.push(prevFile);
-        }
-      }
-
-      await runConcurrent(staleFiles, async (prevFile) => {
-        const orphanPath = resolve(projectRoot, prevFile);
-        // Path traversal protection: ensure orphan path stays within project root
-        if (!orphanPath.startsWith(resolvedRoot)) {
-          console.warn(`[retort:sync] BLOCKED: path traversal in manifest — ${prevFile}`);
-          return;
-        }
-        if (existsSync(orphanPath)) {
-          try {
-            await unlink(orphanPath);
-            cleanedCount++;
-            logVerbose(`[retort:sync] Cleaned stale file: ${prevFile}`);
-          } catch (err) {
-            console.warn(
-              `[retort:sync] Warning: could not clean stale file ${prevFile} — ${err.message}`
-            );
-          }
-        }
-      });
-    }
+    const cleanedCount = await cleanStaleFiles({
+      projectRoot,
+      previousManifest,
+      newManifestFiles,
+      noClean,
+      logVerbose,
+    });
 
     // 9. Write new manifest
-    const newManifest = {
+    await writeManifest(manifestPath, {
       generatedAt: new Date().toISOString(),
       version,
       repoName: vars.repoName,
       files: newManifestFiles,
-    };
-    try {
-      await writeFile(manifestPath, JSON.stringify(newManifest, null, 2) + '\n', 'utf-8');
-    } catch (err) {
-      console.warn(`[retort:sync] Warning: could not write manifest — ${err.message}`);
-    }
+    });
 
     // 10. Post-sync prettier formatting — ensure generated files are formatted
-    const prettierBin = resolve(agentkitRoot, 'node_modules', 'prettier', 'bin', 'prettier.cjs');
-    if (existsSync(prettierBin) && writtenFiles.length > 0) {
-      try {
-        // Format in batches to avoid argument length limits
-        const BATCH_SIZE = 50;
-        let formattedCount = 0;
-        for (let i = 0; i < writtenFiles.length; i += BATCH_SIZE) {
-          const batch = writtenFiles.slice(i, i + BATCH_SIZE);
-          try {
-            execFileSync(process.execPath, [prettierBin, '--write', ...batch], {
-              cwd: projectRoot,
-              encoding: 'utf-8',
-              stdio: 'pipe',
-              timeout: 60_000,
-            });
-            formattedCount += batch.length;
-          } catch (err) {
-            if (err?.killed) {
-              logVerbose(`[retort:sync] Prettier batch timed out, continuing...`);
-            }
-            // prettier may fail on some files (e.g. non-parseable) — continue
-          }
-        }
-        if (formattedCount > 0) {
-          logVerbose(`[retort:sync] Formatted ${formattedCount} generated file(s) with Prettier.`);
-        }
-      } catch {
-        // If prettier is not available or fails entirely, just continue
-      }
-    }
+    await runPostSyncPrettier({ agentkitRoot, projectRoot, writtenFiles, logVerbose });
 
     if (skippedScaffold > 0) {
       log(`[retort:sync] Skipped ${skippedScaffold} project-owned file(s) (already exist).`);


### PR DESCRIPTION
## Summary

- Adds `retort run` — picks the highest-priority `submitted` task from the queue, transitions it `submitted → accepted → working`, and prints a formatted dispatch prompt for the assigned agent
- Supports `--id`, `--assignee`, `--dry-run`, and `--json` flags
- `run` is a framework command (CLI-only, no slash command)

## Flags

| Flag | Description |
|------|-------------|
| `--id <task-id>` | Dispatch a specific task instead of the queue head |
| `--assignee <team>` | Filter queue candidates by assigned team |
| `--dry-run` | Preview dispatch without transitioning state |
| `--json` | Machine-readable output |

## Test plan

- [x] 23 unit tests covering `assigneeToCommand`, `buildDispatchPrompt`, `advanceToWorking`, and `runRun`
- [x] `prettier.test.mjs` passing (files formatted)
- [x] `cli.test.mjs` and `validate.test.mjs` passing
- [x] Full suite: 1484+ passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "run" CLI command for selecting and dispatching tasks with dry-run, JSON output, assignee filtering, and error handling.
  * Introduced a centralized scaffold engine that manages template metadata, atomic scaffold writes, manifest persistence, and post-sync formatting.

* **Refactor**
  * Moved scaffold/write/cleanup responsibilities out of the sync flow into the new scaffold engine, simplifying sync logic.

* **Tests**
  * Added comprehensive test suites covering run command flows and scaffold engine behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->