### PR TITLE
fix(scaffold-engine): narrow carry-forward and fix manifest/Prettier ordering

### DIFF
--- a/.agentkit/engines/node/src/__tests__/scaffold-engine.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/scaffold-engine.test.mjs
@@ -204,19 +204,43 @@ describe('writeScaffoldOutputs', () => {
   });
 
   it('carries forward scaffold-once files from previous manifest into newManifestFiles', async () => {
-    // File exists on disk but was not re-generated this sync (scaffold:once)
-    const existingFile = join(projectRoot, 'preserved.md');
-    writeSync(existingFile, 'user content\n');
+    // File exists on disk and is skipped as scaffold:once during this sync run.
+    // Its manifest entry must be carried forward so orphan cleanup does not delete it.
+    const destFile = join(projectRoot, 'preserved.md');
+    writeSync(destFile, 'user content\n');
+
+    const srcFile = join(tmpDir, 'preserved.md');
+    writeSync(srcFile, 'template content\n');
+
+    setTemplateMeta('preserved.md', { agentkit: { scaffold: 'once' } });
 
     const newManifestFiles = {};
     const previousManifest = {
       files: { 'preserved.md': { hash: 'abc123' } },
     };
 
+    await run({ allTmpFiles: [srcFile], newManifestFiles, previousManifest });
+
+    // Scaffold-once skip should carry forward the previous manifest entry
+    expect(newManifestFiles['preserved.md']).toEqual({ hash: 'abc123' });
+  });
+
+  it('does not carry forward files removed from the template set', async () => {
+    // File exists on disk and in the previous manifest, but was NOT processed
+    // this sync (template removed / feature disabled). It must NOT be carried
+    // forward — cleanStaleFiles() should be free to delete it.
+    const existingFile = join(projectRoot, 'stale.md');
+    writeSync(existingFile, 'old content\n');
+
+    const newManifestFiles = {};
+    const previousManifest = {
+      files: { 'stale.md': { hash: 'abc123' } },
+    };
+
+    // No allTmpFiles entry for stale.md — simulates template being removed
     await run({ allTmpFiles: [], newManifestFiles, previousManifest });
 
-    // The file should be carried forward so orphan cleanup doesn't delete it
-    expect(newManifestFiles['preserved.md']).toEqual({ hash: 'abc123' });
+    expect(newManifestFiles['stale.md']).toBeUndefined();
   });
 
   it('does not carry forward files that no longer exist on disk', async () => {

--- a/.agentkit/engines/node/src/scaffold-engine.mjs
+++ b/.agentkit/engines/node/src/scaffold-engine.mjs
@@ -100,6 +100,7 @@ export async function writeScaffoldOutputs({
   // NOTE: Safe for single-threaded async (Array.push is synchronous in V8).
   // If runConcurrent ever uses worker threads, this needs synchronization.
   const writtenFiles = []; // absolute paths of files written, for post-sync formatting
+  const scaffoldOnceSkippedFiles = []; // paths skipped due to scaffold:once
   const scaffoldResults = {
     alwaysRegenerated: [],
     managedRegenerated: [],
@@ -136,6 +137,7 @@ export async function writeScaffoldOutputs({
 
       if (action === 'skip') {
         skippedScaffold++;
+        scaffoldOnceSkippedFiles.push(normalizedRel);
         return;
       }
 
@@ -338,15 +340,22 @@ export async function writeScaffoldOutputs({
     logVerbose(`  ${scaffoldOnceSkipped} scaffold-once file(s) skipped`);
   }
 
-  // Carry forward scaffold-once files from previous manifest.
-  // When a file was generated in a previous sync but skipped this time (scaffold-once),
-  // it must remain in the new manifest so orphan cleanup does not delete it.
+  // Carry forward legitimately-skipped files from the previous manifest so orphan
+  // cleanup does not delete them. Only files skipped for known reasons are eligible:
+  //   - scaffold:once  — file is project-owned after first write
+  //   - managed files with user edits preserved (managedPreserved)
+  //
+  // Files absent from newManifestFiles for any other reason (template removed, feature
+  // disabled, etc.) are intentionally omitted so cleanStaleFiles() can delete them.
   if (previousManifest?.files) {
+    const legitimatelySkipped = new Set([
+      ...scaffoldOnceSkippedFiles,
+      ...scaffoldResults.managedPreserved,
+    ]);
     for (const [prevFile, prevMeta] of Object.entries(previousManifest.files)) {
-      if (!newManifestFiles[prevFile]) {
+      if (!newManifestFiles[prevFile] && legitimatelySkipped.has(prevFile)) {
         const prevPath = resolve(projectRoot, prevFile);
         if (existsSync(prevPath)) {
-          // File exists on disk but was not regenerated — carry forward its manifest entry
           newManifestFiles[prevFile] = prevMeta;
         }
       }

--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -2838,16 +2838,34 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
       logVerbose,
     });
 
-    // 9. Write new manifest
+    // 9. Post-sync prettier formatting — format before hashing so manifest hashes
+    //    reflect on-disk content. Without this, managed-file hash checks on the next
+    //    sync treat Prettier output as a "user edit" and skip regeneration.
+    await runPostSyncPrettier({ agentkitRoot, projectRoot, writtenFiles, logVerbose });
+
+    // Refresh manifest hashes for files that Prettier may have reformatted.
+    for (const absPath of writtenFiles) {
+      const relPath = relative(projectRoot, absPath).replace(/\\/g, '/');
+      if (newManifestFiles[relPath]) {
+        try {
+          const diskContent = await readFile(absPath);
+          newManifestFiles[relPath].hash = createHash('sha256')
+            .update(diskContent)
+            .digest('hex')
+            .slice(0, 12);
+        } catch {
+          // file may have been deleted or be unreadable — leave hash as-is
+        }
+      }
+    }
+
+    // 10. Write new manifest with post-format hashes
     await writeManifest(manifestPath, {
       generatedAt: new Date().toISOString(),
       version,
       repoName: vars.repoName,
       files: newManifestFiles,
     });
-
-    // 10. Post-sync prettier formatting — ensure generated files are formatted
-    await runPostSyncPrettier({ agentkitRoot, projectRoot, writtenFiles, logVerbose });
 
     if (skippedScaffold > 0) {
       log(`[retort:sync] Skipped ${skippedScaffold} project-owned file(s) (already exist).`);


### PR DESCRIPTION
## Summary

Addresses two major issues flagged by CodeRabbit on PR #492.

### Fix 1 — Carry-forward only legitimately-skipped files (`scaffold-engine.mjs`)

The carry-forward loop was re-adding **any** previous manifest entry that still existed on disk, regardless of why it was absent from the new manifest. This silently prevented `cleanStaleFiles()` from removing files whose templates were deleted or features disabled.

**Root cause:** The condition was `exists on disk && not in newManifestFiles` — too broad.

**Fix:** Track paths explicitly skipped as `scaffold:once` during the run (`scaffoldOnceSkippedFiles`). Carry forward only those plus `managedPreserved` (user-edited managed files). Everything else is now correctly left out for orphan cleanup.

### Fix 2 — Manifest written before Prettier ran (`synchronize.mjs`)

`writeManifest` (step 9) ran before `runPostSyncPrettier` (step 10). If Prettier reformatted a managed file, the manifest stored pre-format hashes. On the next sync, the hash check saw formatted content ≠ manifest hash and misclassified Prettier's output as a user edit, skipping regeneration indefinitely.

**Fix:** Swap steps 9 and 10 — Prettier runs first, then manifest hashes are refreshed from post-format disk content before `writeManifest`.

## Test plan

- [x] Updated `scaffold-engine.test.mjs`: existing carry-forward test now properly simulates a scaffold:once skip; added new test asserting stale files (template removed) are NOT carried forward
- [x] 22/22 scaffold-engine tests passing
- [x] `prettier.test.mjs` passing (no formatting issues introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of files marked with the `scaffold:once` directive in template manifests
  * Fixed cleanup of orphaned template files no longer included in active templates
  * Enhanced manifest accuracy for formatted files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->