### PR TITLE
feat(start): add WorktreesPanel showing active agent worktrees

### DIFF
--- a/src/start/components/WorktreesPanel.jsx
+++ b/src/start/components/WorktreesPanel.jsx
@@ -4,8 +4,8 @@
  * Lists all worktrees for the current repo, highlighting agent-owned
  * branches (those matching the feat|fix|chore/agent-<name>/ convention).
  *
- * Renders nothing if there is only one worktree (the main one) since
- * there is nothing interesting to show in that case.
+ * Renders nothing if there is only one worktree (the main one), or if no
+ * worktree is agent-owned, since there is nothing interesting to show.
  */
 
 import React from 'react';
@@ -19,8 +19,8 @@ import { getAgentWorktrees } from '../lib/worktrees.js';
 export default function WorktreesPanel({ cwd }) {
   const worktrees = getAgentWorktrees(cwd);
 
-  // Nothing worth showing when only the main worktree exists
-  if (worktrees.length <= 1) return null;
+  // Nothing worth showing when there are no agent worktrees
+  if (worktrees.length <= 1 || !worktrees.some((w) => w.isAgent)) return null;
 
   return (
     <Box flexDirection="column" paddingX={2} gap={0}>

--- a/src/start/components/WorktreesPanel.jsx
+++ b/src/start/components/WorktreesPanel.jsx
@@ -1,0 +1,55 @@
+/**
+ * WorktreesPanel — displays active git worktrees in the TUI.
+ *
+ * Lists all worktrees for the current repo, highlighting agent-owned
+ * branches (those matching the feat|fix|chore/agent-<name>/ convention).
+ *
+ * Renders nothing if there is only one worktree (the main one) since
+ * there is nothing interesting to show in that case.
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { getAgentWorktrees } from '../lib/worktrees.js';
+
+/**
+ * @param {{ cwd?: string }} props
+ *   cwd — repository root passed to getAgentWorktrees; defaults to process.cwd()
+ */
+export default function WorktreesPanel({ cwd }) {
+  const worktrees = getAgentWorktrees(cwd);
+
+  // Nothing worth showing when only the main worktree exists
+  if (worktrees.length <= 1) return null;
+
+  return (
+    <Box flexDirection="column" paddingX={2} gap={0}>
+      <Text color="gray" dimColor>
+        Active worktrees
+      </Text>
+      {worktrees.map((wt) => (
+        <WorktreeRow key={wt.path} wt={wt} />
+      ))}
+    </Box>
+  );
+}
+
+/**
+ * @param {{ wt: import('../lib/worktrees.js').WorktreeInfo }} props
+ */
+function WorktreeRow({ wt }) {
+  const label = wt.isMain ? '(main)' : wt.branch || '(detached)';
+  const color = wt.isMain ? 'gray' : wt.isAgent ? 'cyan' : 'white';
+
+  return (
+    <Box gap={1}>
+      <Text color={color}>{wt.isAgent ? '⚡' : '○'}</Text>
+      <Text color={color}>{label}</Text>
+      {wt.head && (
+        <Text color="gray" dimColor>
+          {wt.head}
+        </Text>
+      )}
+    </Box>
+  );
+}

--- a/src/start/components/WorktreesPanel.test.jsx
+++ b/src/start/components/WorktreesPanel.test.jsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import WorktreesPanel from './WorktreesPanel.jsx';
+
+// Mock the lib module so tests never invoke child_process
+vi.mock('../lib/worktrees.js', () => ({
+  getAgentWorktrees: vi.fn(),
+}));
+
+// Import after mock registration so we get the mocked version
+import { getAgentWorktrees } from '../lib/worktrees.js';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+/** Convenience factory for WorktreeInfo objects */
+function makeWorktree(overrides = {}) {
+  return {
+    path: '/repo',
+    branch: '',
+    head: 'abc1234',
+    isMain: false,
+    isAgent: false,
+    ...overrides,
+  };
+}
+
+describe('WorktreesPanel', () => {
+  it('should render nothing when there is only the main worktree', () => {
+    getAgentWorktrees.mockReturnValue([
+      makeWorktree({ path: '/repo', isMain: true }),
+    ]);
+
+    const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
+    // Ink renders an empty string when the component returns null
+    expect(lastFrame()).toBe('');
+  });
+
+  it('should render nothing when the worktree list is empty', () => {
+    getAgentWorktrees.mockReturnValue([]);
+
+    const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
+    expect(lastFrame()).toBe('');
+  });
+
+  it('should show the section heading when multiple worktrees exist', () => {
+    getAgentWorktrees.mockReturnValue([
+      makeWorktree({ path: '/repo', isMain: true }),
+      makeWorktree({ path: '/repo/.worktrees/feat', branch: 'feat/something', isAgent: false }),
+    ]);
+
+    const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
+    expect(lastFrame()).toContain('Active worktrees');
+  });
+
+  it('should display the branch name for a non-agent worktree', () => {
+    getAgentWorktrees.mockReturnValue([
+      makeWorktree({ path: '/repo', isMain: true }),
+      makeWorktree({ path: '/repo/.worktrees/fix', branch: 'fix/some-bug', isAgent: false }),
+    ]);
+
+    const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
+    expect(lastFrame()).toContain('fix/some-bug');
+  });
+
+  it('should mark agent worktrees with ⚡ and the branch name', () => {
+    getAgentWorktrees.mockReturnValue([
+      makeWorktree({ path: '/repo', isMain: true }),
+      makeWorktree({
+        path: '/repo/.worktrees/agent-backend',
+        branch: 'feat/agent-backend/add-endpoint',
+        isAgent: true,
+      }),
+    ]);
+
+    const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
+    const frame = lastFrame();
+    expect(frame).toContain('⚡');
+    expect(frame).toContain('feat/agent-backend/add-endpoint');
+  });
+
+  it('should show the commit SHA for each worktree', () => {
+    getAgentWorktrees.mockReturnValue([
+      makeWorktree({ path: '/repo', isMain: true }),
+      makeWorktree({
+        path: '/repo/.worktrees/feat',
+        branch: 'feat/something',
+        head: 'deadbee',
+      }),
+    ]);
+
+    const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
+    expect(lastFrame()).toContain('deadbee');
+  });
+
+  it('should show (detached) for a worktree with no branch', () => {
+    getAgentWorktrees.mockReturnValue([
+      makeWorktree({ path: '/repo', isMain: true }),
+      makeWorktree({ path: '/repo/.worktrees/detached', branch: '', isAgent: false }),
+    ]);
+
+    const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
+    expect(lastFrame()).toContain('(detached)');
+  });
+
+  it('should show (main) label for the main worktree', () => {
+    getAgentWorktrees.mockReturnValue([
+      makeWorktree({ path: '/repo', isMain: true }),
+      makeWorktree({ path: '/repo/.worktrees/feat', branch: 'feat/x' }),
+    ]);
+
+    const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
+    expect(lastFrame()).toContain('(main)');
+  });
+
+  it('should pass the cwd prop through to getAgentWorktrees', () => {
+    getAgentWorktrees.mockReturnValue([]);
+
+    render(React.createElement(WorktreesPanel, { cwd: '/custom/root' }));
+    expect(getAgentWorktrees).toHaveBeenCalledWith('/custom/root');
+  });
+
+  it('should handle multiple agent worktrees simultaneously', () => {
+    getAgentWorktrees.mockReturnValue([
+      makeWorktree({ path: '/repo', isMain: true }),
+      makeWorktree({
+        path: '/repo/.worktrees/a1',
+        branch: 'feat/agent-backend/task-one',
+        isAgent: true,
+        head: 'aaaaaaa',
+      }),
+      makeWorktree({
+        path: '/repo/.worktrees/a2',
+        branch: 'fix/agent-testing/coverage',
+        isAgent: true,
+        head: 'bbbbbbb',
+      }),
+    ]);
+
+    const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
+    const frame = lastFrame();
+    expect(frame).toContain('feat/agent-backend/task-one');
+    expect(frame).toContain('fix/agent-testing/coverage');
+    expect(frame).toContain('aaaaaaa');
+    expect(frame).toContain('bbbbbbb');
+  });
+});

--- a/src/start/components/WorktreesPanel.test.jsx
+++ b/src/start/components/WorktreesPanel.test.jsx
@@ -45,10 +45,24 @@ describe('WorktreesPanel', () => {
     expect(lastFrame()).toBe('');
   });
 
-  it('should show the section heading when multiple worktrees exist', () => {
+  it('should not show the section heading when only non-agent worktrees exist', () => {
     getAgentWorktrees.mockReturnValue([
       makeWorktree({ path: '/repo', isMain: true }),
       makeWorktree({ path: '/repo/.worktrees/feat', branch: 'feat/something', isAgent: false }),
+    ]);
+
+    const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
+    expect(lastFrame()).not.toContain('Active worktrees');
+  });
+
+  it('should show the section heading when at least one agent worktree exists', () => {
+    getAgentWorktrees.mockReturnValue([
+      makeWorktree({ path: '/repo', isMain: true }),
+      makeWorktree({
+        path: '/repo/.worktrees/agent-backend',
+        branch: 'feat/agent-backend/add-endpoint',
+        isAgent: true,
+      }),
     ]);
 
     const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
@@ -59,6 +73,7 @@ describe('WorktreesPanel', () => {
     getAgentWorktrees.mockReturnValue([
       makeWorktree({ path: '/repo', isMain: true }),
       makeWorktree({ path: '/repo/.worktrees/fix', branch: 'fix/some-bug', isAgent: false }),
+      makeWorktree({ path: '/repo/.worktrees/agent', branch: 'feat/agent-x/y', isAgent: true }),
     ]);
 
     const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
@@ -86,8 +101,9 @@ describe('WorktreesPanel', () => {
       makeWorktree({ path: '/repo', isMain: true }),
       makeWorktree({
         path: '/repo/.worktrees/feat',
-        branch: 'feat/something',
+        branch: 'feat/agent-x/something',
         head: 'deadbee',
+        isAgent: true,
       }),
     ]);
 
@@ -99,6 +115,7 @@ describe('WorktreesPanel', () => {
     getAgentWorktrees.mockReturnValue([
       makeWorktree({ path: '/repo', isMain: true }),
       makeWorktree({ path: '/repo/.worktrees/detached', branch: '', isAgent: false }),
+      makeWorktree({ path: '/repo/.worktrees/agent', branch: 'feat/agent-x/y', isAgent: true }),
     ]);
 
     const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
@@ -108,7 +125,7 @@ describe('WorktreesPanel', () => {
   it('should show (main) label for the main worktree', () => {
     getAgentWorktrees.mockReturnValue([
       makeWorktree({ path: '/repo', isMain: true }),
-      makeWorktree({ path: '/repo/.worktrees/feat', branch: 'feat/x' }),
+      makeWorktree({ path: '/repo/.worktrees/agent', branch: 'feat/agent-x/y', isAgent: true }),
     ]);
 
     const { lastFrame } = render(React.createElement(WorktreesPanel, {}));

--- a/src/start/components/WorktreesPanel.test.jsx
+++ b/src/start/components/WorktreesPanel.test.jsx
@@ -29,9 +29,7 @@ function makeWorktree(overrides = {}) {
 
 describe('WorktreesPanel', () => {
   it('should render nothing when there is only the main worktree', () => {
-    getAgentWorktrees.mockReturnValue([
-      makeWorktree({ path: '/repo', isMain: true }),
-    ]);
+    getAgentWorktrees.mockReturnValue([makeWorktree({ path: '/repo', isMain: true })]);
 
     const { lastFrame } = render(React.createElement(WorktreesPanel, {}));
     // Ink renders an empty string when the component returns null

--- a/src/start/lib/worktrees.js
+++ b/src/start/lib/worktrees.js
@@ -1,0 +1,97 @@
+/**
+ * Worktree discovery module.
+ *
+ * Parses `git worktree list --porcelain` output and returns structured
+ * objects for each worktree. Used by WorktreesPanel to display active
+ * agent worktrees without importing child_process directly in components.
+ */
+
+import { execSync } from 'node:child_process';
+
+/**
+ * @typedef {Object} WorktreeInfo
+ * @property {string}       path      Absolute path to the worktree root
+ * @property {string}       branch    Branch name (e.g. 'feat/agent-frontend/my-task')
+ *                                    or empty string for detached HEAD
+ * @property {string}       head      Commit SHA (short)
+ * @property {boolean}      isMain    True if this is the main (bare) worktree
+ * @property {boolean}      isAgent   True if branch matches the agent branch pattern
+ */
+
+/** Regex for branches created by the agent worktree convention. */
+const AGENT_BRANCH_RE = /^(feat|fix|chore)\/agent-[^/]+\//;
+
+/**
+ * Parse the porcelain output of `git worktree list --porcelain`.
+ *
+ * Each entry is separated by a blank line and has the form:
+ *   worktree <path>
+ *   HEAD <sha>
+ *   branch refs/heads/<name>   — or —
+ *   detached
+ *
+ * @param {string} raw - Raw stdout from `git worktree list --porcelain`
+ * @returns {WorktreeInfo[]}
+ */
+export function parseWorktreeOutput(raw) {
+  const entries = raw.trim().split(/\n\n+/);
+  const worktrees = [];
+
+  for (const entry of entries) {
+    if (!entry.trim()) continue;
+
+    const lines = entry.split('\n');
+    let path = '';
+    let head = '';
+    let branch = '';
+    let isMain = false;
+
+    for (const line of lines) {
+      if (line.startsWith('worktree ')) {
+        path = line.slice('worktree '.length).trim();
+      } else if (line.startsWith('HEAD ')) {
+        head = line.slice('HEAD '.length, 'HEAD '.length + 7).trim();
+      } else if (line.startsWith('branch ')) {
+        const ref = line.slice('branch '.length).trim();
+        // Strip refs/heads/ prefix
+        branch = ref.replace(/^refs\/heads\//, '');
+      } else if (line === 'bare') {
+        isMain = true;
+      }
+    }
+
+    if (!path) continue;
+
+    worktrees.push({
+      path,
+      branch,
+      head,
+      isMain,
+      isAgent: AGENT_BRANCH_RE.test(branch),
+    });
+  }
+
+  return worktrees;
+}
+
+/**
+ * Retrieve all git worktrees for the given repository root.
+ *
+ * Returns an empty array if the command fails (e.g. not a git repo,
+ * or `git` is not available in PATH).
+ *
+ * @param {string} [cwd=process.cwd()] - Repository root
+ * @returns {WorktreeInfo[]}
+ */
+export function getAgentWorktrees(cwd = process.cwd()) {
+  try {
+    const raw = execSync('git worktree list --porcelain', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return parseWorktreeOutput(raw);
+  } catch {
+    return [];
+  }
+}

--- a/src/start/lib/worktrees.js
+++ b/src/start/lib/worktrees.js
@@ -14,12 +14,12 @@ import { execSync } from 'node:child_process';
  * @property {string}       branch    Branch name (e.g. 'feat/agent-frontend/my-task')
  *                                    or empty string for detached HEAD
  * @property {string}       head      Commit SHA (short)
- * @property {boolean}      isMain    True if this is the main (bare) worktree
+ * @property {boolean}      isMain    True if this is the primary worktree (first entry)
  * @property {boolean}      isAgent   True if branch matches the agent branch pattern
  */
 
 /** Regex for branches created by the agent worktree convention. */
-const AGENT_BRANCH_RE = /^(feat|fix|chore)\/agent-[^/]+\//;
+const AGENT_BRANCH_RE = /^(feat|fix|chore|refactor|test|perf|ci|build|docs)\/agent-[^/]+\//;
 
 /**
  * Parse the porcelain output of `git worktree list --porcelain`.
@@ -66,7 +66,7 @@ export function parseWorktreeOutput(raw) {
       path,
       branch,
       head,
-      isMain,
+      isMain: isMain || worktrees.length === 0,
       isAgent: AGENT_BRANCH_RE.test(branch),
     });
   }

--- a/src/start/lib/worktrees.js
+++ b/src/start/lib/worktrees.js
@@ -91,7 +91,8 @@ export function getAgentWorktrees(cwd = process.cwd()) {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     return parseWorktreeOutput(raw);
-  } catch {
+  } catch (err) {
+    process.stderr.write(`[worktrees] git worktree list failed: ${err.message}\n`);
     return [];
   }
 }

--- a/src/start/lib/worktrees.test.js
+++ b/src/start/lib/worktrees.test.js
@@ -17,7 +17,7 @@ branch refs/heads/main
     expect(result[0].path).toBe('/home/user/repo');
     expect(result[0].branch).toBe('main');
     expect(result[0].head).toBe('abc1234');
-    expect(result[0].isMain).toBe(false);
+    expect(result[0].isMain).toBe(true);
     expect(result[0].isAgent).toBe(false);
   });
 
@@ -57,6 +57,12 @@ branch refs/heads/feat/agent-backend/add-endpoint
       'feat/agent-backend/add-endpoint',
       'fix/agent-testing/coverage-auth',
       'chore/agent-infra/update-deps',
+      'refactor/agent-quality/extract-helpers',
+      'test/agent-testing/add-unit-tests',
+      'perf/agent-backend/optimise-query',
+      'ci/agent-devops/add-coverage-gate',
+      'build/agent-devops/update-bundler',
+      'docs/agent-docs/update-readme',
     ];
 
     for (const branch of agentBranches) {

--- a/src/start/lib/worktrees.test.js
+++ b/src/start/lib/worktrees.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseWorktreeOutput, getAgentWorktrees } from './worktrees.js';
+
+// ---------------------------------------------------------------------------
+// parseWorktreeOutput — pure function, no mocking needed
+// ---------------------------------------------------------------------------
+
+describe('parseWorktreeOutput', () => {
+  it('should parse a single main worktree', () => {
+    const raw = `worktree /home/user/repo
+HEAD abc1234567890
+branch refs/heads/main
+
+`;
+    const result = parseWorktreeOutput(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('/home/user/repo');
+    expect(result[0].branch).toBe('main');
+    expect(result[0].head).toBe('abc1234');
+    expect(result[0].isMain).toBe(false);
+    expect(result[0].isAgent).toBe(false);
+  });
+
+  it('should parse a bare (main) worktree', () => {
+    const raw = `worktree /home/user/repo
+HEAD abc1234567890
+bare
+
+`;
+    const result = parseWorktreeOutput(raw);
+    expect(result[0].isMain).toBe(true);
+  });
+
+  it('should handle detached HEAD (no branch line)', () => {
+    const raw = `worktree /home/user/repo/.worktrees/detached
+HEAD deadbeef1234
+detached
+
+`;
+    const result = parseWorktreeOutput(raw);
+    expect(result[0].branch).toBe('');
+    expect(result[0].isAgent).toBe(false);
+  });
+
+  it('should strip refs/heads/ prefix from branch names', () => {
+    const raw = `worktree /repo/.worktrees/feat
+HEAD 1111111
+branch refs/heads/feat/agent-backend/add-endpoint
+
+`;
+    const result = parseWorktreeOutput(raw);
+    expect(result[0].branch).toBe('feat/agent-backend/add-endpoint');
+  });
+
+  it('should mark agent branches correctly', () => {
+    const agentBranches = [
+      'feat/agent-backend/add-endpoint',
+      'fix/agent-testing/coverage-auth',
+      'chore/agent-infra/update-deps',
+    ];
+
+    for (const branch of agentBranches) {
+      const raw = `worktree /repo/.worktrees/x\nHEAD 1234567\nbranch refs/heads/${branch}\n\n`;
+      const [wt] = parseWorktreeOutput(raw);
+      expect(wt.isAgent).toBe(true);
+    }
+  });
+
+  it('should not mark non-agent branches as agent', () => {
+    const nonAgentBranches = ['main', 'dev', 'feat/add-something', 'fix/my-bug'];
+
+    for (const branch of nonAgentBranches) {
+      const raw = `worktree /repo\nHEAD 1234567\nbranch refs/heads/${branch}\n\n`;
+      const [wt] = parseWorktreeOutput(raw);
+      expect(wt.isAgent).toBe(false);
+    }
+  });
+
+  it('should parse multiple worktrees separated by blank lines', () => {
+    const raw = `worktree /repo
+HEAD aaa1111
+branch refs/heads/main
+
+worktree /repo/.worktrees/feat
+HEAD bbb2222
+branch refs/heads/feat/agent-frontend/my-task
+
+`;
+    const result = parseWorktreeOutput(raw);
+    expect(result).toHaveLength(2);
+    expect(result[0].branch).toBe('main');
+    expect(result[1].branch).toBe('feat/agent-frontend/my-task');
+    expect(result[1].isAgent).toBe(true);
+  });
+
+  it('should skip entries with no worktree path', () => {
+    const raw = `HEAD aaa1111
+branch refs/heads/main
+
+worktree /repo/.worktrees/real
+HEAD bbb2222
+branch refs/heads/dev
+
+`;
+    const result = parseWorktreeOutput(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].branch).toBe('dev');
+  });
+
+  it('should truncate HEAD SHA to 7 characters', () => {
+    const raw = `worktree /repo
+HEAD abcdef1234567890
+branch refs/heads/main
+
+`;
+    const [wt] = parseWorktreeOutput(raw);
+    expect(wt.head).toBe('abcdef1');
+  });
+
+  it('should return an empty array for empty input', () => {
+    expect(parseWorktreeOutput('')).toEqual([]);
+    expect(parseWorktreeOutput('   ')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAgentWorktrees — wraps execSync, needs mocking
+// ---------------------------------------------------------------------------
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'node:child_process';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('getAgentWorktrees', () => {
+  it('should return parsed worktrees on success', () => {
+    execSync.mockReturnValue(`worktree /repo
+HEAD abc1234567890
+branch refs/heads/main
+
+`);
+    const result = getAgentWorktrees('/repo');
+    expect(result).toHaveLength(1);
+    expect(result[0].branch).toBe('main');
+  });
+
+  it('should pass cwd to execSync', () => {
+    execSync.mockReturnValue('');
+    getAgentWorktrees('/custom/path');
+    expect(execSync).toHaveBeenCalledWith(
+      'git worktree list --porcelain',
+      expect.objectContaining({ cwd: '/custom/path' })
+    );
+  });
+
+  it('should return an empty array when execSync throws', () => {
+    execSync.mockImplementation(() => {
+      throw new Error('not a git repo');
+    });
+    const result = getAgentWorktrees('/not-a-repo');
+    expect(result).toEqual([]);
+  });
+
+  it('should default cwd to process.cwd()', () => {
+    execSync.mockReturnValue('');
+    getAgentWorktrees();
+    expect(execSync).toHaveBeenCalledWith(
+      'git worktree list --porcelain',
+      expect.objectContaining({ cwd: process.cwd() })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `WorktreesPanel` component to the `/start` TUI showing active agent git worktrees
- Detects agent worktrees by branch pattern (`feat|fix|chore|refactor/agent-*`)
- Returns `null` when no agent worktrees are active — no noise during normal solo work

## Details

**`src/start/lib/worktrees.js`** (new)
- `parseWorktreeOutput(raw)` — pure parser for `git worktree list --porcelain`; returns `WorktreeInfo[]` with `path`, `branch`, `head`, `isMain`, `isAgent`
- `getAgentWorktrees(cwd?)` — calls `execSync` and delegates to parser; returns `[]` on any error
- `AGENT_BRANCH_RE` — pattern matching branches owned by agents

**`src/start/components/WorktreesPanel.jsx`** (new)
- Imports `getAgentWorktrees` from lib (no direct `child_process` in component)
- Shows `⚡` per agent worktree with stripped branch name + short SHA
- `○` for non-agent worktrees, `(detached)` for detached HEAD

**`src/start/lib/worktrees.test.js`** — 14 tests (pure parser + mocked execSync)
**`src/start/components/WorktreesPanel.test.jsx`** — 10 tests (mocked lib module)

## Test plan

- [x] 135/135 tests passing (`vitest run`)
- [x] Agent branches matched correctly by pattern
- [x] Non-agent and detached worktrees handled
- [x] Renders nothing when no agent worktrees active
- [x] Handles execSync errors gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Active worktrees" panel that displays all Git repository worktrees with their branch names, commit SHAs, and visual indicators. Each worktree is clearly labeled as main or alternative, helping developers quickly identify and navigate between different worktree states and branch information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->