### PR TITLE
fix(tests): add maxRetries to rmSync in run-cli afterEach to prevent ENOTEMPTY race

### DIFF
--- a/.agentkit/engines/node/src/__tests__/run-cli.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/run-cli.test.mjs
@@ -16,7 +16,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Summary

- `afterEach` in `run-cli.test.mjs` used `rmSync(tmpRoot, { recursive: true, force: true })` — no retry logic
- On Windows (NTFS) and some Linux filesystems the OS hasn't fully flushed directory handles from async writes in the test before the recursive delete fires, causing occasional `ENOTEMPTY` errors
- Added `maxRetries: 3, retryDelay: 100` — Node 16.5+ added these options to `rmSync` for exactly this scenario

## Test plan

- [x] All 23 `run-cli.test.mjs` tests pass locally
- [x] Addresses pre-existing flaky failure logged in session handoff: "filters by --assignee" ENOTEMPTY race

🤖 Generated with [Claude Code](https://claude.com/claude-code)