### PR TITLE
feat(start): add TasksPanel — show active tasks from .claude/state/tasks/

### DIFF
--- a/src/start/components/App.jsx
+++ b/src/start/components/App.jsx
@@ -16,6 +16,7 @@ import React, { useState, useEffect, Component } from 'react';
 import { Box, Text, useApp, useInput } from 'ink';
 import StatusBar from './StatusBar.jsx';
 import MCPPanel from './MCPPanel.jsx';
+import TasksPanel from './TasksPanel.jsx';
 import ConversationFlow from './ConversationFlow.jsx';
 import CommandPalette from './CommandPalette.jsx';
 
@@ -101,6 +102,7 @@ function AppInner({ ctx }) {
           </Text>
         </Box>
 
+        <TasksPanel />
         <MCPPanel />
         <StatusBar ctx={ctx} />
       </Box>
@@ -143,6 +145,7 @@ function AppInner({ ctx }) {
         />
       )}
 
+      <TasksPanel />
       <MCPPanel />
       <StatusBar ctx={ctx} />
     </Box>

--- a/src/start/components/TasksPanel.jsx
+++ b/src/start/components/TasksPanel.jsx
@@ -1,0 +1,66 @@
+/**
+ * TasksPanel — displays active agent tasks in the TUI.
+ *
+ * Shows tasks from `.claude/state/tasks/` grouped by status:
+ *   working → input-required → accepted → submitted
+ *
+ * Renders nothing when there are no active tasks.
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { getActiveTasks } from '../lib/tasks.js';
+
+/** Status label and color for each active state. */
+const STATUS_META = {
+  working: { label: '▶ working', color: 'green' },
+  'input-required': { label: '? input', color: 'yellow' },
+  accepted: { label: '✓ accepted', color: 'cyan' },
+  submitted: { label: '○ submitted', color: 'gray' },
+};
+
+/**
+ * @param {{ cwd?: string }} props
+ *   cwd — repository root passed to getActiveTasks; defaults to process.cwd()
+ */
+export default function TasksPanel({ cwd }) {
+  const tasks = getActiveTasks(cwd);
+
+  if (tasks.length === 0) return null;
+
+  return (
+    <Box flexDirection="column" paddingX={2} gap={0}>
+      <Text color="gray" dimColor>
+        Active tasks
+      </Text>
+      {tasks.map((task) => (
+        <TaskRow key={task.id} task={task} />
+      ))}
+    </Box>
+  );
+}
+
+/**
+ * @param {{ task: import('../lib/tasks.js').TaskInfo }} props
+ */
+function TaskRow({ task }) {
+  const meta = STATUS_META[task.status] || { label: task.status, color: 'white' };
+  const assignee = task.assignees.length > 0 ? task.assignees[0] : '';
+
+  return (
+    <Box gap={1}>
+      <Text color={meta.color}>{meta.label}</Text>
+      {task.priority && (
+        <Text color="gray" dimColor>
+          [{task.priority}]
+        </Text>
+      )}
+      <Text color="white">{task.title}</Text>
+      {assignee && (
+        <Text color="gray" dimColor>
+          → {assignee}
+        </Text>
+      )}
+    </Box>
+  );
+}

--- a/src/start/components/TasksPanel.test.jsx
+++ b/src/start/components/TasksPanel.test.jsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import TasksPanel from './TasksPanel.jsx';
+
+// Mock the lib module so tests never touch the filesystem
+vi.mock('../lib/tasks.js', () => ({
+  getActiveTasks: vi.fn(),
+}));
+
+import { getActiveTasks } from '../lib/tasks.js';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+/** Convenience factory for TaskInfo objects */
+function makeTask(overrides = {}) {
+  return {
+    id: 'task-001',
+    title: 'Do something',
+    status: 'working',
+    priority: 'P2',
+    assignees: ['BACKEND'],
+    type: 'implement',
+    ...overrides,
+  };
+}
+
+describe('TasksPanel', () => {
+  it('should render nothing when there are no active tasks', () => {
+    getActiveTasks.mockReturnValue([]);
+
+    const { lastFrame } = render(React.createElement(TasksPanel, {}));
+    expect(lastFrame()).toBe('');
+  });
+
+  it('should show the section heading when tasks are present', () => {
+    getActiveTasks.mockReturnValue([makeTask()]);
+
+    const { lastFrame } = render(React.createElement(TasksPanel, {}));
+    expect(lastFrame()).toContain('Active tasks');
+  });
+
+  it('should display the task title', () => {
+    getActiveTasks.mockReturnValue([makeTask({ title: 'Add pagination endpoint' })]);
+
+    const { lastFrame } = render(React.createElement(TasksPanel, {}));
+    expect(lastFrame()).toContain('Add pagination endpoint');
+  });
+
+  it('should show working status label for working tasks', () => {
+    getActiveTasks.mockReturnValue([makeTask({ status: 'working' })]);
+
+    const { lastFrame } = render(React.createElement(TasksPanel, {}));
+    expect(lastFrame()).toContain('working');
+  });
+
+  it('should show input-required status label', () => {
+    getActiveTasks.mockReturnValue([makeTask({ status: 'input-required', title: 'Blocked task' })]);
+
+    const { lastFrame } = render(React.createElement(TasksPanel, {}));
+    expect(lastFrame()).toContain('input');
+    expect(lastFrame()).toContain('Blocked task');
+  });
+
+  it('should show submitted status label', () => {
+    getActiveTasks.mockReturnValue([makeTask({ status: 'submitted', title: 'Pending task' })]);
+
+    const { lastFrame } = render(React.createElement(TasksPanel, {}));
+    expect(lastFrame()).toContain('submitted');
+  });
+
+  it('should display the priority badge', () => {
+    getActiveTasks.mockReturnValue([makeTask({ priority: 'P0' })]);
+
+    const { lastFrame } = render(React.createElement(TasksPanel, {}));
+    expect(lastFrame()).toContain('P0');
+  });
+
+  it('should display the first assignee', () => {
+    getActiveTasks.mockReturnValue([makeTask({ assignees: ['TESTING'] })]);
+
+    const { lastFrame } = render(React.createElement(TasksPanel, {}));
+    expect(lastFrame()).toContain('TESTING');
+  });
+
+  it('should not show assignee when assignees list is empty', () => {
+    getActiveTasks.mockReturnValue([makeTask({ assignees: [], title: 'Unassigned task' })]);
+
+    const { lastFrame } = render(React.createElement(TasksPanel, {}));
+    expect(lastFrame()).toContain('Unassigned task');
+    // Arrow separator should not appear without an assignee
+    expect(lastFrame()).not.toContain('→');
+  });
+
+  it('should render multiple tasks', () => {
+    getActiveTasks.mockReturnValue([
+      makeTask({ id: 'task-1', title: 'Task Alpha', status: 'working' }),
+      makeTask({ id: 'task-2', title: 'Task Beta', status: 'submitted' }),
+    ]);
+
+    const { lastFrame } = render(React.createElement(TasksPanel, {}));
+    const frame = lastFrame();
+    expect(frame).toContain('Task Alpha');
+    expect(frame).toContain('Task Beta');
+  });
+
+  it('should pass the cwd prop through to getActiveTasks', () => {
+    getActiveTasks.mockReturnValue([]);
+
+    render(React.createElement(TasksPanel, { cwd: '/custom/root' }));
+    expect(getActiveTasks).toHaveBeenCalledWith('/custom/root');
+  });
+
+  it('should show all active tasks simultaneously', () => {
+    getActiveTasks.mockReturnValue([
+      makeTask({ id: 't-1', title: 'Feature A', status: 'working', priority: 'P1' }),
+      makeTask({ id: 't-2', title: 'Feature B', status: 'input-required', priority: 'P2' }),
+      makeTask({ id: 't-3', title: 'Feature C', status: 'submitted', priority: 'P3' }),
+    ]);
+
+    const { lastFrame } = render(React.createElement(TasksPanel, {}));
+    const frame = lastFrame();
+    expect(frame).toContain('Feature A');
+    expect(frame).toContain('Feature B');
+    expect(frame).toContain('Feature C');
+    expect(frame).toContain('P1');
+    expect(frame).toContain('P2');
+    expect(frame).toContain('P3');
+  });
+});

--- a/src/start/lib/tasks.js
+++ b/src/start/lib/tasks.js
@@ -1,0 +1,83 @@
+/**
+ * Task discovery module.
+ *
+ * Reads `.claude/state/tasks/*.json` and returns structured active-task
+ * objects. Used by TasksPanel to display in-flight agent work without
+ * importing fs/path directly in components.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * @typedef {Object} TaskInfo
+ * @property {string}   id         Task ID (e.g. 'task-20260330-001')
+ * @property {string}   title      Short task description
+ * @property {string}   status     Lifecycle state: working | input-required | accepted | submitted
+ * @property {string}   priority   P0 – P4
+ * @property {string[]} assignees  Team names
+ * @property {string}   type       Task type: implement | fix | review | …
+ */
+
+/** States that are visible in the TUI (non-terminal, non-archived). */
+const ACTIVE_STATES = new Set(['working', 'input-required', 'accepted', 'submitted']);
+
+/** Display order for active states (most urgent first). */
+const STATE_ORDER = ['working', 'input-required', 'accepted', 'submitted'];
+
+/**
+ * Read and parse a single task JSON file. Returns null on any parse error.
+ *
+ * @param {string} filePath
+ * @returns {TaskInfo | null}
+ */
+export function parseTaskFile(filePath) {
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== 'object') return null;
+    return {
+      id: String(data.id || ''),
+      title: String(data.title || '(untitled)'),
+      status: String(data.status || ''),
+      priority: String(data.priority || ''),
+      assignees: Array.isArray(data.assignees) ? data.assignees.map(String) : [],
+      type: String(data.type || ''),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return all active tasks from `.claude/state/tasks/`, sorted by display
+ * order (working first) then by priority (P0 before P4).
+ *
+ * @param {string} [cwd=process.cwd()] - Repository root
+ * @returns {TaskInfo[]}
+ */
+export function getActiveTasks(cwd = process.cwd()) {
+  const tasksDir = join(cwd, '.claude', 'state', 'tasks');
+  if (!existsSync(tasksDir)) return [];
+
+  let files;
+  try {
+    files = readdirSync(tasksDir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+
+  const tasks = files
+    .map((f) => parseTaskFile(join(tasksDir, f)))
+    .filter((t) => t !== null && ACTIVE_STATES.has(t.status));
+
+  tasks.sort((a, b) => {
+    const si = STATE_ORDER.indexOf(a.status);
+    const sj = STATE_ORDER.indexOf(b.status);
+    if (si !== sj) return si - sj;
+    // Within the same status, sort P0 before P4 (lexicographic works for P0–P9)
+    return a.priority.localeCompare(b.priority);
+  });
+
+  return tasks;
+}


### PR DESCRIPTION
## Summary

- Adds `src/start/lib/tasks.js` — reads `.claude/state/tasks/*.json`, returns active (non-terminal) tasks sorted by status urgency then priority
- Adds `src/start/components/TasksPanel.jsx` — renders status-grouped task rows (working → input-required → accepted → submitted) with priority badge and assignee
- Adds `src/start/components/TasksPanel.test.jsx` — 12 tests covering all display paths
- Wires `TasksPanel` into `App.jsx` between the main content area and MCPPanel

## Test plan

- [x] `npx vitest run src/start` — 156/156 tests pass (144 existing + 12 new)
- [x] Renders nothing when no active tasks (returns null)
- [x] Status labels: ▶ working (green), ? input (yellow), ✓ accepted (cyan), ○ submitted (gray)
- [x] Priority badge, title, and first assignee displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added an "Active tasks" panel displaying active agent tasks with status labels, priority indicators, and assignee information
* Tasks are automatically discovered and sorted by status and priority

<!-- end of auto-generated comment: release notes by coderabbit.ai -->