### PR TITLE
docs(readme): drop phoenix-flow rename parenthetical from baton row

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Run `retort init` to auto-detect values from your repo, or edit `project.yaml` d
 | Repo                                                            | Role                                                                                         |
 | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | [`retort-plugins`](https://github.com/phoenixvc/retort-plugins) | IDE plugins — VS Code (`@retort` Copilot Chat), JetBrains (Junie), Zed                       |
-| [`baton`](https://github.com/phoenixvc/baton)                   | Task graph + MCP server — retort projects read live tasks from baton (formerly phoenix-flow) |
+| [`baton`](https://github.com/phoenixvc/baton)                   | Task graph + MCP server — retort projects read live tasks from baton                         |
 | [`sluice`](https://github.com/phoenixvc/sluice)                 | AI gateway — retort-scaffolded projects route model calls through sluice                     |
 | [`docket`](https://github.com/phoenixvc/docket)                 | AI cost ops — tracks token spend and model costs per project                                 |
 | [`cognitive-mesh`](https://github.com/phoenixvc/cognitive-mesh) | Agent orchestration — complex multi-agent tasks route through cognitive-mesh                 |


### PR DESCRIPTION
## Summary

The phoenix-flow → baton rename is complete; the `(formerly phoenix-flow)` migration hint in the ecosystem table is no longer needed.

## Test plan

- [x] No code changes — README only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ecosystem documentation to remove outdated references and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->