### PR TITLE
chore(ci): switch self-hosted workflow runners to ubuntu-latest

### DIFF
--- a/.agentkit/templates/github/workflows/breaking-change-detection.yml
+++ b/.agentkit/templates/github/workflows/breaking-change-detection.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   detect:
     name: Detect breaking changes
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.agentkit/templates/github/workflows/coverage-report.yml
+++ b/.agentkit/templates/github/workflows/coverage-report.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   coverage-node:
     name: Node.js coverage
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     if: hashFiles('package.json') != '' || hashFiles('**/package.json') != ''
     steps:
@@ -122,7 +122,7 @@ jobs:
 {{#if hasLanguageRust}}
   coverage-rust:
     name: Rust coverage
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     if: hashFiles('Cargo.toml') != ''
     steps:
@@ -154,7 +154,7 @@ jobs:
 
   summary:
     name: Coverage summary
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [coverage-node{{#if hasLanguageRust}}, coverage-rust{{/if}}]
     if: always()
     steps:

--- a/.agentkit/templates/github/workflows/dependency-audit.yml
+++ b/.agentkit/templates/github/workflows/dependency-audit.yml
@@ -44,7 +44,7 @@ concurrency:
 jobs:
   audit-node:
     name: Node.js dependency audit
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     if: hashFiles('package.json') != '' || hashFiles('**/package.json') != ''
     steps:
@@ -116,7 +116,7 @@ jobs:
 {{#if hasLanguageRust}}
   audit-rust:
     name: Rust dependency audit
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     if: hashFiles('Cargo.toml') != '' || hashFiles('**/Cargo.toml') != ''
     steps:
@@ -144,7 +144,7 @@ jobs:
 {{#if hasLanguagePython}}
   audit-python:
     name: Python dependency audit
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     if: hashFiles('pyproject.toml') != '' || hashFiles('requirements*.txt') != ''
     steps:
@@ -178,7 +178,7 @@ jobs:
 
   summary:
     name: Audit summary
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [audit-node{{#if hasLanguageRust}}, audit-rust{{/if}}{{#if hasLanguagePython}}, audit-python{{/if}}]
     if: always()
     steps:

--- a/.agentkit/templates/github/workflows/documentation-quality.yml
+++ b/.agentkit/templates/github/workflows/documentation-quality.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   quality-check:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.agentkit/templates/github/workflows/documentation-validation.yml
+++ b/.agentkit/templates/github/workflows/documentation-validation.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   documentation-check:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.agentkit/templates/github/workflows/pr-validation.yml
+++ b/.agentkit/templates/github/workflows/pr-validation.yml
@@ -19,7 +19,7 @@ jobs:
 {{#if hasAnyInfraConfig}}
   terraform-fmt:
     name: Terraform format check
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     if: >-
       contains(github.event.pull_request.changed_files, '.tf') ||
@@ -49,7 +49,7 @@ jobs:
 {{/if}}
   shellcheck:
     name: Shell script lint
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -79,7 +79,7 @@ jobs:
 
   yaml-lint:
     name: YAML syntax check
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -104,7 +104,7 @@ jobs:
 
   summary:
     name: Validation summary
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [{{#if hasAnyInfraConfig}}terraform-fmt, {{/if}}shellcheck, yaml-lint]
     if: always()
     steps:

--- a/.agentkit/templates/github/workflows/retrospective-quality.yml
+++ b/.agentkit/templates/github/workflows/retrospective-quality.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   validate-retrospective:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     # Non-blocking: continue-on-error ensures this never gates delivery
     continue-on-error: true
     permissions:

--- a/.github/workflows/breaking-change-detection.yml
+++ b/.github/workflows/breaking-change-detection.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   detect:
     name: Detect breaking changes
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   coverage-node:
     name: Node.js coverage
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     if: hashFiles('package.json') != '' || hashFiles('**/package.json') != ''
     steps:
@@ -119,7 +119,7 @@ jobs:
 
   summary:
     name: Coverage summary
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [coverage-node]
     if: always()
     steps:

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   audit-node:
     name: Node.js dependency audit
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     if: hashFiles('package.json') != '' || hashFiles('**/package.json') != ''
     steps:
@@ -93,7 +93,7 @@ jobs:
 
   summary:
     name: Audit summary
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [audit-node]
     if: always()
     steps:

--- a/.github/workflows/documentation-quality.yml
+++ b/.github/workflows/documentation-quality.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   quality-check:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/documentation-validation.yml
+++ b/.github/workflows/documentation-validation.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   documentation-check:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   terraform-fmt:
     name: Terraform format check
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     if: >-
       contains(github.event.pull_request.changed_files, '.tf') ||
@@ -47,7 +47,7 @@ jobs:
 
   shellcheck:
     name: Shell script lint
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -77,7 +77,7 @@ jobs:
 
   yaml-lint:
     name: YAML syntax check
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -102,7 +102,7 @@ jobs:
 
   summary:
     name: Validation summary
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [terraform-fmt, shellcheck, yaml-lint]
     if: always()
     steps:

--- a/.github/workflows/retrospective-quality.yml
+++ b/.github/workflows/retrospective-quality.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   validate-retrospective:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     # Non-blocking: continue-on-error ensures this never gates delivery
     continue-on-error: true
     permissions:


### PR DESCRIPTION
## Summary

The `phoenix-runner` self-hosted Azure VMSS pool is currently unavailable. As a result, every PR has at least two workflow jobs stuck in **queued** with no runner assignment for over an hour:

- PR #515 example: `Detect breaking changes` and `documentation-check` both `status: queued`, `runner_name: ""`, `started_at: 2026-05-09T16:17:04Z` (no progress 1h+ later).

This PR switches all 12 unconditional + 3 conditional `runs-on: self-hosted` declarations across **7 workflow templates** (and their generated outputs) to `runs-on: ubuntu-latest` so CI can complete on GitHub-hosted runners while the self-hosted pool is offline.

## Layers fixed

Per Copilot review, the upstream **templates** are the source of truth and the regeneration pipeline would have overwritten direct edits to `.github/workflows/`. Both are updated:

- **Commit 1** (`53e50a83`): generated `.github/workflows/*.yml` outputs
- **Commit 2** (`1b1c2c23`): `.agentkit/templates/github/workflows/*.yml` upstream templates

After both commits, `pnpm -C .agentkit retort:sync` produces no further drift in the workflow files.

## Files affected

All in `.agentkit/templates/github/workflows/` (and corresponding `.github/workflows/`):

| Workflow | Template `runs-on` | Output `runs-on` |
|---|---|---|
| breaking-change-detection.yml | 1 | 1 |
| coverage-report.yml | 3 | 2 |
| dependency-audit.yml | 4 | 2 |
| documentation-quality.yml | 1 | 1 |
| documentation-validation.yml | 1 | 1 |
| pr-validation.yml | 4 | 4 |
| retrospective-quality.yml | 1 | 1 |
| **Total** | **15** | **12** |

(3 template occurrences are gated by feature/integration conditionals that aren't active in the current spec.)

## When phoenix-runner is back

Either revert this PR, or convert the `runs-on:` value to a template variable so the runner pool can be selected per-environment via `project.yaml`.

## Test plan

- [x] CI runs on this PR exclusively on GitHub-hosted runners
- [x] `Detect breaking changes` and `documentation-check` complete (both passing on `ubuntu-latest`)
- [x] No `queued` checks remain after ~5 minutes
- [x] `pnpm -C .agentkit retort:sync` produces no drift in `.github/workflows/`

## Notes

- `Test` failure is structural (pre-existing 80%/80% coverage threshold failing on every dev/main push since 2026-04-01); see PR #517 for the start of fixing that.
- Workflow logic itself is unchanged — only the runner label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)