### PR TITLE
test(engine): bump sync-guard + scaffold-merge coverage (incremental)

### DIFF
--- a/.agentkit/engines/node/src/__tests__/scaffold-merge.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/scaffold-merge.test.mjs
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { threeWayMerge, normalizeForComparison } from '../scaffold-merge.mjs';
+
+// ---------------------------------------------------------------------------
+// threeWayMerge — exercises the git merge-file wrapper across all 3 outcomes.
+// ---------------------------------------------------------------------------
+
+describe('threeWayMerge', () => {
+  it('returns merged content with hasConflicts:false on a clean merge', () => {
+    const base = 'line A\nline B\nline C\n';
+    // ours adds a header line, theirs appends a footer — non-overlapping edits
+    const ours = 'HEADER\nline A\nline B\nline C\n';
+    const theirs = 'line A\nline B\nline C\nFOOTER\n';
+
+    const result = threeWayMerge(ours, base, theirs);
+
+    expect(result).not.toBeNull();
+    expect(result.hasConflicts).toBe(false);
+    expect(result.merged).toContain('HEADER');
+    expect(result.merged).toContain('FOOTER');
+    expect(result.merged).toContain('line B');
+  });
+
+  it('returns hasConflicts:true with conflict markers on conflicting edits', () => {
+    const base = 'line A\nline B\nline C\n';
+    const ours = 'line A\nMINE\nline C\n';
+    const theirs = 'line A\nTHEIRS\nline C\n';
+
+    const result = threeWayMerge(ours, base, theirs);
+
+    expect(result).not.toBeNull();
+    expect(result.hasConflicts).toBe(true);
+    // Conflict block should mention both sides via the labels passed to git
+    expect(result.merged).toContain('YOUR_EDITS');
+    expect(result.merged).toContain('NEW_TEMPLATE');
+    // Either MINE or THEIRS (or both) must survive in the conflict block
+    expect(result.merged).toMatch(/MINE|THEIRS/);
+  });
+
+  it('returns identity when ours == base == theirs (no-op merge)', () => {
+    const content = 'unchanged\nunchanged\n';
+
+    const result = threeWayMerge(content, content, content);
+
+    expect(result).not.toBeNull();
+    expect(result.hasConflicts).toBe(false);
+    expect(result.merged).toBe(content);
+  });
+
+  it('returns the user version when only ours changed', () => {
+    const base = 'a\nb\n';
+    const ours = 'a\nUSER\n';
+    const theirs = 'a\nb\n';
+
+    const result = threeWayMerge(ours, base, theirs);
+
+    expect(result).not.toBeNull();
+    expect(result.hasConflicts).toBe(false);
+    expect(result.merged).toBe(ours);
+  });
+
+  it('returns the template version when only theirs changed', () => {
+    const base = 'a\nb\n';
+    const ours = 'a\nb\n';
+    const theirs = 'a\nTEMPLATE\n';
+
+    const result = threeWayMerge(ours, base, theirs);
+
+    expect(result).not.toBeNull();
+    expect(result.hasConflicts).toBe(false);
+    expect(result.merged).toBe(theirs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeForComparison — table-padding & trailing-whitespace canonicalisation
+// ---------------------------------------------------------------------------
+
+describe('normalizeForComparison', () => {
+  it('strips trailing whitespace from every line', () => {
+    const input = 'foo   \nbar\t \nbaz\n';
+    const output = normalizeForComparison(input);
+
+    expect(output).toBe('foo\nbar\nbaz');
+  });
+
+  it('trims trailing whitespace at end-of-document', () => {
+    expect(normalizeForComparison('hello\n\n\n')).toBe('hello');
+  });
+
+  it('canonicalises a wide table separator row', () => {
+    const input = '| col |  col2  |\n| --- | ------ |\n| a   |  b     |';
+    const output = normalizeForComparison(input);
+
+    // Separator collapses to |---| canonical form per column
+    expect(output.split('\n')[1]).toBe('|-|-|');
+  });
+
+  it('preserves alignment markers (:--- / ---: / :---:) in separator rows', () => {
+    const input = '| a | b | c |\n| :--- | ---: | :---: |\n| 1 | 2 | 3 |';
+    const output = normalizeForComparison(input);
+
+    // After collapsing dashes the alignment colons must remain.
+    expect(output.split('\n')[1]).toBe('|:-|-:|:-:|');
+  });
+
+  it('normalises data-row cell padding to a single space either side', () => {
+    const input = '|alpha|beta|\n|   tightly  packed   |   another   |';
+    const output = normalizeForComparison(input);
+
+    // Both rows should end up with " value " padding for inner cells.
+    const rows = output.split('\n');
+    expect(rows[0]).toBe('| alpha | beta |');
+    expect(rows[1]).toBe('| tightly  packed | another |');
+  });
+
+  it('leaves non-table lines untouched apart from trailing whitespace', () => {
+    const input = '# Heading\n\nA paragraph with two trailing spaces.  \n\nMore text.';
+    const output = normalizeForComparison(input);
+
+    expect(output).toBe('# Heading\n\nA paragraph with two trailing spaces.\n\nMore text.');
+  });
+
+  it('canonicalises a Prettier-padded table the same as a compact table', () => {
+    const padded = '| Name  | Age |\n| ----- | --- |\n| Alice |  30 |\n| Bob   |  25 |';
+    const compact = '|Name|Age|\n|---|---|\n|Alice|30|\n|Bob|25|';
+
+    expect(normalizeForComparison(padded)).toBe(normalizeForComparison(compact));
+  });
+});

--- a/.agentkit/engines/node/src/__tests__/sync-guard.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-guard.test.mjs
@@ -119,15 +119,20 @@ describe('checkDirtyProtectedFiles', () => {
   });
 
   it('handles renames by extracting the new path', () => {
-    // Stage a rename: move app.js from src/ into .agentkit/spec/ (so it lands inside a protected dir)
+    // To exercise the "R old -> new" rename-parsing branch, both endpoints of
+    // the rename must be inside the scope passed to `git status --porcelain`.
+    // If only the destination is in scope, git collapses the entry to "A new"
+    // (an add) and the rename branch is never hit.
     execFileSync('git', ['mv', 'src/app.js', '.agentkit/spec/app.js'], {
       cwd: tempDir,
       stdio: 'pipe',
     });
-    const result = checkDirtyProtectedFiles(tempDir, ['.agentkit/spec']);
+    const result = checkDirtyProtectedFiles(tempDir, ['src', '.agentkit/spec']);
     expect(result.dirty).toBe(true);
-    // Rename appears as "R  src/app.js -> .agentkit/spec/app.js" — we keep the destination.
+    // git emits "R  src/app.js -> .agentkit/spec/app.js" — we keep the destination.
     expect(result.files).toContain('.agentkit/spec/app.js');
+    expect(result.files).not.toContain('src/app.js');
+    // Sanity: no entry should still contain the literal arrow.
     expect(result.files.every((f) => !f.includes(' -> '))).toBe(true);
   });
 });
@@ -185,11 +190,10 @@ describe('promptDirtyFileAction', () => {
   });
 
   it('returns abort when stash subprocess fails', async () => {
-    // Use a path that git can't possibly stash because there is no repo here.
-    // The original cwd of the test process is irrelevant — what matters is that
-    // the stash command in sync-guard runs from process.cwd(), and since we never
-    // staged anything related to ".agentkit-sync-guard-test-no-such-file" git
-    // returns non-zero on the rename that follows.
+    // Force the stash subprocess to fail by running it from a directory that
+    // is NOT a git repository: `git stash push ...` exits non-zero with
+    // "fatal: not a git repository", sync-guard catches that and returns 'abort'.
+    // We chdir into a fresh temp dir (no .git) for the duration of this test.
     const origCwd = process.cwd();
     const noRepo = mkdtempSync(join(tmpdir(), 'sync-guard-norepo-'));
     process.chdir(noRepo);

--- a/.agentkit/engines/node/src/__tests__/sync-guard.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-guard.test.mjs
@@ -3,7 +3,12 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { checkDirtyProtectedFiles } from '../sync-guard.mjs';
+import {
+  checkDirtyProtectedFiles,
+  promptDirtyFileAction,
+  promptApplyMode,
+  promptSingleFile,
+} from '../sync-guard.mjs';
 
 // ---------------------------------------------------------------------------
 // checkDirtyProtectedFiles — integration tests using real git operations
@@ -111,5 +116,205 @@ describe('checkDirtyProtectedFiles', () => {
     ]);
     expect(result.dirty).toBe(true);
     expect(result.files.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('handles renames by extracting the new path', () => {
+    // Stage a rename: move app.js from src/ into .agentkit/spec/ (so it lands inside a protected dir)
+    execFileSync('git', ['mv', 'src/app.js', '.agentkit/spec/app.js'], {
+      cwd: tempDir,
+      stdio: 'pipe',
+    });
+    const result = checkDirtyProtectedFiles(tempDir, ['.agentkit/spec']);
+    expect(result.dirty).toBe(true);
+    // Rename appears as "R  src/app.js -> .agentkit/spec/app.js" — we keep the destination.
+    expect(result.files).toContain('.agentkit/spec/app.js');
+    expect(result.files.every((f) => !f.includes(' -> '))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Interactive prompts — mock @clack/prompts so we can drive each branch.
+// ---------------------------------------------------------------------------
+
+// Mutable per-test queues that the mocked clack.select pulls from.
+const selectQueue = [];
+let lastIsCancelTarget = null;
+
+vi.mock('@clack/prompts', () => {
+  const CANCEL = Symbol('clack-cancel');
+  return {
+    note: vi.fn(),
+    log: { success: vi.fn(), error: vi.fn() },
+    select: vi.fn(async () => {
+      if (selectQueue.length === 0) {
+        throw new Error('test bug: select() called with empty selectQueue');
+      }
+      const next = selectQueue.shift();
+      if (next === '__CANCEL__') {
+        lastIsCancelTarget = CANCEL;
+        return CANCEL;
+      }
+      return next;
+    }),
+    isCancel: (v) => v === CANCEL || v === lastIsCancelTarget,
+  };
+});
+
+describe('promptDirtyFileAction', () => {
+  beforeEach(() => {
+    selectQueue.length = 0;
+    lastIsCancelTarget = null;
+  });
+
+  it('returns abort when the user picks Abort', async () => {
+    selectQueue.push('abort');
+    const result = await promptDirtyFileAction(['.agentkit/spec/foo.yaml']);
+    expect(result).toBe('abort');
+  });
+
+  it('returns abort when the user cancels (Ctrl-C)', async () => {
+    selectQueue.push('__CANCEL__');
+    const result = await promptDirtyFileAction(['.agentkit/spec/foo.yaml']);
+    expect(result).toBe('abort');
+  });
+
+  it('returns continue when the user picks Continue', async () => {
+    selectQueue.push('continue');
+    const result = await promptDirtyFileAction(['.agentkit/spec/foo.yaml']);
+    expect(result).toBe('continue');
+  });
+
+  it('returns abort when stash subprocess fails', async () => {
+    // Use a path that git can't possibly stash because there is no repo here.
+    // The original cwd of the test process is irrelevant — what matters is that
+    // the stash command in sync-guard runs from process.cwd(), and since we never
+    // staged anything related to ".agentkit-sync-guard-test-no-such-file" git
+    // returns non-zero on the rename that follows.
+    const origCwd = process.cwd();
+    const noRepo = mkdtempSync(join(tmpdir(), 'sync-guard-norepo-'));
+    process.chdir(noRepo);
+    try {
+      selectQueue.push('stash');
+      const result = await promptDirtyFileAction(['nonexistent-file-for-stash.txt']);
+      expect(result).toBe('abort');
+    } finally {
+      process.chdir(origCwd);
+      rmSync(noRepo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('promptApplyMode', () => {
+  beforeEach(() => {
+    selectQueue.length = 0;
+    lastIsCancelTarget = null;
+  });
+
+  it('returns the selected mode for "all"', async () => {
+    selectQueue.push('all');
+    const result = await promptApplyMode({ creates: 2, updates: 3 });
+    expect(result).toBe('all');
+  });
+
+  it('returns the selected mode for "each"', async () => {
+    selectQueue.push('each');
+    const result = await promptApplyMode({ creates: 1, updates: 1 });
+    expect(result).toBe('each');
+  });
+
+  it('returns "none" when the user cancels', async () => {
+    selectQueue.push('__CANCEL__');
+    const result = await promptApplyMode({ creates: 0, updates: 0 });
+    expect(result).toBe('none');
+  });
+});
+
+describe('promptSingleFile', () => {
+  beforeEach(() => {
+    selectQueue.length = 0;
+    lastIsCancelTarget = null;
+  });
+
+  it('returns "apply" for a create action', async () => {
+    selectQueue.push('apply');
+    const result = await promptSingleFile(
+      { relPath: 'foo.md', action: 'create' },
+      null,
+      null,
+      'new'
+    );
+    expect(result).toBe('apply');
+  });
+
+  it('returns "skip" when the user cancels', async () => {
+    selectQueue.push('__CANCEL__');
+    const result = await promptSingleFile(
+      { relPath: 'foo.md', action: 'create' },
+      null,
+      null,
+      'new'
+    );
+    expect(result).toBe('skip');
+  });
+
+  it('returns "apply-rest" when the user picks it', async () => {
+    selectQueue.push('apply-rest');
+    const result = await promptSingleFile(
+      { relPath: 'foo.md', action: 'update' },
+      () => 'diff',
+      'old',
+      'new'
+    );
+    expect(result).toBe('apply-rest');
+  });
+
+  it('shows the diff and re-prompts on update with diffFn', async () => {
+    selectQueue.push('diff', 'apply');
+    const diffFn = vi.fn(() => '- old\n+ new');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const result = await promptSingleFile(
+        { relPath: 'foo.md', action: 'update' },
+        diffFn,
+        'old',
+        'new'
+      );
+      expect(result).toBe('apply');
+      expect(diffFn).toHaveBeenCalledWith('old', 'new');
+      // Indented diff was printed.
+      expect(logSpy.mock.calls.some(([msg]) => String(msg).includes('    - old'))).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('prints "(no differences)" when diffFn returns null', async () => {
+    selectQueue.push('diff', 'skip');
+    const diffFn = vi.fn(() => null);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const result = await promptSingleFile(
+        { relPath: 'foo.md', action: 'update' },
+        diffFn,
+        'old',
+        'new'
+      );
+      expect(result).toBe('skip');
+      expect(logSpy).toHaveBeenCalledWith('    (no differences)');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('does not offer "diff" when action is "create"', async () => {
+    // No diffFn re-prompt path possible — the first selection must terminate.
+    selectQueue.push('skip');
+    const result = await promptSingleFile(
+      { relPath: 'foo.md', action: 'create' },
+      () => 'diff',
+      null,
+      'new'
+    );
+    expect(result).toBe('skip');
   });
 });


### PR DESCRIPTION
## Summary

Incremental progress toward clearing the 80%/80% line/branch coverage threshold that has been failing CI on every push to \`dev\` and \`main\` since 2026-04-01.

**This PR is intentionally partial** — it does not yet take the project past the threshold on its own. It clears two of the worst-covered modules to near-100% as a foundation, demonstrates the test patterns (especially \`vi.mock\`-ing \`@clack/prompts\`), and outlines what's left.

## Coverage delta

| Module | Before | After |
|---|---|---|
| \`sync-guard.mjs\` | 20% lines / 5% branches | **100% lines / 90% branches** |
| \`scaffold-merge.mjs\` | 11% lines / 7% branches | **~100% (new test file)** |

Estimated CI-side aggregate delta: **lines +0.7%, branches +1.5%**.

## What's added

### \`sync-guard.test.mjs\` (+13 tests)
- \`promptDirtyFileAction\`: abort / continue / cancel / failed-stash branches
- \`promptApplyMode\`: all / each / cancel branches
- \`promptSingleFile\`: apply / skip / apply-rest / cancel / diff (re-prompt loop) / null-diff / no-diff-on-create branches
- New rename-detection case for \`checkDirtyProtectedFiles\`
- Mocks \`@clack/prompts\` via \`vi.mock\` with a queue-based \`select()\` so each branch is driven deterministically.

### \`scaffold-merge.test.mjs\` (new file, 12 tests)
- \`threeWayMerge\` across clean merge / conflicting edits / no-op / ours-only / theirs-only outcomes
- \`normalizeForComparison\` across separator-row collapsing, alignment-marker preservation (\`:---\` / \`---:\` / \`:---:\`), data-row padding, trailing-whitespace stripping, and Prettier-padded vs compact-table equivalence

## What's left to clear the gate

The 80% gate still needs further work in (roughly in order of leverage):

| Module | Lines | Branches |
|---|---|---|
| \`init.mjs\` | 44% | 37% |
| \`orchestrator.mjs\` | 51% | 42% |
| \`check.mjs\` | 54% | 40% |
| \`cost-tracker.mjs\` | 57% | 40% |
| \`scaffold-engine.mjs\` | 58% | 60% |
| \`discover.mjs\` | 61% | 52% |
| \`healthcheck.mjs\` | 62% | 47% |
| \`var-builders.mjs\` | 64% | 58% |
| \`ralph-config-wizard.mjs\` | 36% | 27% |

A follow-up PR should target the top 3-4 to clear both thresholds.

## Test plan

- [x] \`pnpm vitest run engines/node/src/__tests__/sync-guard.test.mjs engines/node/src/__tests__/scaffold-merge.test.mjs\` → 33/33 pass locally
- [ ] CI confirms the per-file coverage jumps and reports the new aggregate

## Notes

- No production code changed.
- The mock pattern (\`vi.mock('@clack/prompts')\` with a queue-based \`select()\`) is reusable for testing other CLI-prompt code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for scaffold-merge utilities, including merge conflict handling and text normalization.
  * Expanded test coverage for sync-guard functionality with interactive CLI behavior scenarios and file operation validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phoenixvc/retort/pull/517)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->