### PR TITLE
test(engine): raise coverage on low-covered modules to clear 80% gate

### DIFF
--- a/.agentkit/engines/node/src/__tests__/scaffold-engine-extra.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/scaffold-engine-extra.test.mjs
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
+import { cleanStaleFiles, runPostSyncPrettier } from '../scaffold-engine.mjs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(prefix) {
+  const dir = join(
+    tmpdir(),
+    `scaffold-extra-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeSync(filePath, content) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, 'utf-8');
+}
+
+const noop = () => {};
+
+// ---------------------------------------------------------------------------
+// cleanStaleFiles — path traversal protection
+// ---------------------------------------------------------------------------
+
+describe('cleanStaleFiles — path traversal', () => {
+  let projectRoot;
+
+  beforeEach(() => {
+    projectRoot = makeTmpDir('clean-traversal');
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('blocks path traversal attempts in manifest entries', async () => {
+    // A previous manifest contains a malicious entry that resolves outside the
+    // project root. cleanStaleFiles should warn and skip rather than unlink.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const count = await cleanStaleFiles({
+      projectRoot,
+      previousManifest: { files: { '../escape.txt': { hash: 'abc' } } },
+      newManifestFiles: {},
+      noClean: false,
+      logVerbose: noop,
+    });
+
+    expect(count).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/path traversal in manifest/i));
+    warnSpy.mockRestore();
+  });
+
+  it('warns but does not throw when unlink fails', async () => {
+    // Add a stale entry that exists but points to a directory (rmdir would
+    // succeed via unlink on POSIX-only? unlink on a directory throws EISDIR).
+    const staleDirPath = join(projectRoot, 'stale-dir');
+    mkdirSync(staleDirPath, { recursive: true });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const count = await cleanStaleFiles({
+      projectRoot,
+      previousManifest: { files: { 'stale-dir': { hash: 'abc' } } },
+      newManifestFiles: {},
+      noClean: false,
+      logVerbose: noop,
+    });
+
+    // unlink on a directory should fail; cleanStaleFiles should warn and not throw.
+    // count remains 0 because unlink was unsuccessful.
+    expect(count).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/could not clean stale file/i));
+    warnSpy.mockRestore();
+  });
+
+  it('does not unlink when newManifestFiles already lists the file', async () => {
+    const filePath = join(projectRoot, 'kept.md');
+    writeSync(filePath, 'keep me\n');
+
+    const count = await cleanStaleFiles({
+      projectRoot,
+      previousManifest: { files: { 'kept.md': { hash: 'a' } } },
+      newManifestFiles: { 'kept.md': { hash: 'b' } },
+      noClean: false,
+      logVerbose: noop,
+    });
+
+    expect(count).toBe(0);
+    // file should still exist
+    const { existsSync } = await import('fs');
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  it('does not throw when previousManifest.files is empty', async () => {
+    const count = await cleanStaleFiles({
+      projectRoot,
+      previousManifest: { files: {} },
+      newManifestFiles: {},
+      noClean: false,
+      logVerbose: noop,
+    });
+    expect(count).toBe(0);
+  });
+
+  it('skips silently when the orphan path no longer exists', async () => {
+    const count = await cleanStaleFiles({
+      projectRoot,
+      previousManifest: { files: { 'never-existed.md': { hash: 'a' } } },
+      newManifestFiles: {},
+      noClean: false,
+      logVerbose: noop,
+    });
+    expect(count).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runPostSyncPrettier — short-circuit cases
+// ---------------------------------------------------------------------------
+
+describe('runPostSyncPrettier', () => {
+  let projectRoot;
+  let agentkitRoot;
+
+  beforeEach(() => {
+    projectRoot = makeTmpDir('prettier-project');
+    agentkitRoot = makeTmpDir('prettier-agentkit');
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(agentkitRoot, { recursive: true, force: true });
+  });
+
+  it('returns silently when prettier is not installed', async () => {
+    // No node_modules/prettier/bin/prettier.cjs in agentkitRoot
+    await expect(
+      runPostSyncPrettier({
+        agentkitRoot,
+        projectRoot,
+        writtenFiles: [join(projectRoot, 'a.md')],
+        logVerbose: noop,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('returns silently when writtenFiles is empty', async () => {
+    // Stub a fake prettier bin so the existence check passes
+    const fakeBin = resolve(agentkitRoot, 'node_modules', 'prettier', 'bin', 'prettier.cjs');
+    writeSync(fakeBin, '#!/usr/bin/env node\nconsole.log("noop");\n');
+
+    await expect(
+      runPostSyncPrettier({
+        agentkitRoot,
+        projectRoot,
+        writtenFiles: [],
+        logVerbose: noop,
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/.agentkit/engines/node/src/__tests__/scaffold-merge.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/scaffold-merge.test.mjs
@@ -127,4 +127,21 @@ describe('normalizeForComparison', () => {
 
     expect(normalizeForComparison(padded)).toBe(normalizeForComparison(compact));
   });
+
+  it('does not break lines that contain pipes but are not table rows', () => {
+    const line = 'echo "a | b | c"';
+    expect(normalizeForComparison(line)).toBe(line);
+  });
+
+  it('handles empty string input', () => {
+    expect(normalizeForComparison('')).toBe('');
+  });
+
+  it('handles single-line input', () => {
+    expect(normalizeForComparison('only one line')).toBe('only one line');
+  });
+
+  it('handles input with only whitespace lines', () => {
+    expect(normalizeForComparison('   \n\t\n')).toBe('');
+  });
 });

--- a/.agentkit/engines/node/src/__tests__/sync-guard-prompts.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-guard-prompts.test.mjs
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock @clack/prompts so we can drive promptDirtyFileAction / promptApplyMode /
+// promptSingleFile deterministically. The sync-guard module dynamically
+// imports @clack/prompts, so we mock at the module boundary.
+// ---------------------------------------------------------------------------
+
+const clackState = {
+  selectImpl: () => 'abort',
+  isCancelImpl: (val) => val === Symbol.for('clack:cancel'),
+  noteCalls: [],
+  successCalls: [],
+  errorCalls: [],
+};
+
+vi.mock('@clack/prompts', () => ({
+  note: (msg, title) => {
+    clackState.noteCalls.push({ msg, title });
+  },
+  select: vi.fn(async (opts) => clackState.selectImpl(opts)),
+  isCancel: (val) => clackState.isCancelImpl(val),
+  log: {
+    success: (msg) => {
+      clackState.successCalls.push(msg);
+    },
+    error: (msg) => {
+      clackState.errorCalls.push(msg);
+    },
+  },
+}));
+
+// Replace the git stash invocation with a controllable spy
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+// Import after mocks are registered
+const { execFileSync: execFileSyncMock } = await import('child_process');
+const { promptDirtyFileAction, promptApplyMode, promptSingleFile } =
+  await import('../sync-guard.mjs');
+
+beforeEach(() => {
+  clackState.selectImpl = () => 'abort';
+  clackState.isCancelImpl = (val) => val === Symbol.for('clack:cancel');
+  clackState.noteCalls = [];
+  clackState.successCalls = [];
+  clackState.errorCalls = [];
+  execFileSyncMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// promptDirtyFileAction
+// ---------------------------------------------------------------------------
+
+describe('promptDirtyFileAction', () => {
+  it("returns 'abort' when the user picks abort", async () => {
+    clackState.selectImpl = () => 'abort';
+    const result = await promptDirtyFileAction(['a.txt', 'b.txt']);
+    expect(result).toBe('abort');
+    // The note should have been emitted with the dirty files
+    expect(clackState.noteCalls).toHaveLength(1);
+    expect(clackState.noteCalls[0].msg).toContain('a.txt');
+    expect(clackState.noteCalls[0].msg).toContain('b.txt');
+    expect(clackState.noteCalls[0].title).toMatch(/Uncommitted/i);
+  });
+
+  it("returns 'continue' when the user picks continue", async () => {
+    clackState.selectImpl = () => 'continue';
+    const result = await promptDirtyFileAction(['x']);
+    expect(result).toBe('continue');
+  });
+
+  it("returns 'stash' when the user picks stash and stash succeeds", async () => {
+    clackState.selectImpl = () => 'stash';
+    execFileSyncMock.mockReturnValue(''); // git stash push succeeds
+
+    const result = await promptDirtyFileAction(['file1.txt']);
+    expect(result).toBe('stash');
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    const [cmd, args] = execFileSyncMock.mock.calls[0];
+    expect(cmd).toBe('git');
+    expect(args[0]).toBe('stash');
+    expect(args[1]).toBe('push');
+    expect(args).toContain('agentkit-sync-guard');
+    expect(args).toContain('file1.txt');
+    expect(clackState.successCalls).toHaveLength(1);
+    expect(clackState.successCalls[0]).toMatch(/stashed/i);
+  });
+
+  it("returns 'abort' when stash fails", async () => {
+    clackState.selectImpl = () => 'stash';
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    const result = await promptDirtyFileAction(['file1.txt']);
+    expect(result).toBe('abort');
+    expect(clackState.errorCalls).toHaveLength(1);
+    expect(clackState.errorCalls[0]).toMatch(/Stash failed/);
+    expect(clackState.errorCalls[0]).toMatch(/boom/);
+  });
+
+  it("returns 'abort' when stash throws a non-Error value", async () => {
+    clackState.selectImpl = () => 'stash';
+    execFileSyncMock.mockImplementation(() => {
+      // eslint-disable-next-line no-throw-literal
+      throw 'string-failure';
+    });
+
+    const result = await promptDirtyFileAction(['file1.txt']);
+    expect(result).toBe('abort');
+    expect(clackState.errorCalls[0]).toMatch(/string-failure/);
+  });
+
+  it("returns 'abort' when the user cancels (Ctrl+C)", async () => {
+    const cancelSym = Symbol.for('clack:cancel');
+    clackState.selectImpl = () => cancelSym;
+    clackState.isCancelImpl = (val) => val === cancelSym;
+
+    const result = await promptDirtyFileAction(['x']);
+    expect(result).toBe('abort');
+  });
+
+  it('renders dirty files line-by-line in the note message', async () => {
+    clackState.selectImpl = () => 'continue';
+    await promptDirtyFileAction(['one', 'two', 'three']);
+    expect(clackState.noteCalls[0].msg).toMatch(/  one\n  two\n  three/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// promptApplyMode
+// ---------------------------------------------------------------------------
+
+describe('promptApplyMode', () => {
+  it("returns 'all' when the user picks Apply all", async () => {
+    clackState.selectImpl = () => 'all';
+    const result = await promptApplyMode({ creates: 2, updates: 3 });
+    expect(result).toBe('all');
+  });
+
+  it("returns 'none' when the user picks Skip all", async () => {
+    clackState.selectImpl = () => 'none';
+    const result = await promptApplyMode({ creates: 0, updates: 0 });
+    expect(result).toBe('none');
+  });
+
+  it("returns 'each' when the user picks Prompt each", async () => {
+    clackState.selectImpl = () => 'each';
+    const result = await promptApplyMode({ creates: 5, updates: 0 });
+    expect(result).toBe('each');
+  });
+
+  it("returns 'none' when the user cancels", async () => {
+    const cancelSym = Symbol.for('clack:cancel');
+    clackState.selectImpl = () => cancelSym;
+    clackState.isCancelImpl = (val) => val === cancelSym;
+    const result = await promptApplyMode({ creates: 1, updates: 1 });
+    expect(result).toBe('none');
+  });
+
+  it('shows the total count and breakdown in the prompt message', async () => {
+    let captured;
+    clackState.selectImpl = (opts) => {
+      captured = opts;
+      return 'all';
+    };
+    await promptApplyMode({ creates: 4, updates: 7 });
+    expect(captured.message).toContain('11 file');
+    expect(captured.message).toContain('4 new');
+    expect(captured.message).toContain('7 updated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// promptSingleFile
+// ---------------------------------------------------------------------------
+
+describe('promptSingleFile', () => {
+  it("returns 'apply' when user picks Apply", async () => {
+    clackState.selectImpl = () => 'apply';
+    const result = await promptSingleFile(
+      { relPath: 'a.md', action: 'create' },
+      null,
+      null,
+      'new content'
+    );
+    expect(result).toBe('apply');
+  });
+
+  it("returns 'skip' when user picks Skip", async () => {
+    clackState.selectImpl = () => 'skip';
+    const result = await promptSingleFile(
+      { relPath: 'a.md', action: 'create' },
+      null,
+      null,
+      'new content'
+    );
+    expect(result).toBe('skip');
+  });
+
+  it("returns 'apply-rest' when user picks Apply all remaining", async () => {
+    clackState.selectImpl = () => 'apply-rest';
+    const result = await promptSingleFile(
+      { relPath: 'a.md', action: 'update' },
+      () => '',
+      'old',
+      'new'
+    );
+    expect(result).toBe('apply-rest');
+  });
+
+  it("returns 'skip' when user cancels", async () => {
+    const cancelSym = Symbol.for('clack:cancel');
+    clackState.selectImpl = () => cancelSym;
+    clackState.isCancelImpl = (val) => val === cancelSym;
+    const result = await promptSingleFile({ relPath: 'a.md', action: 'create' }, null, null, 'new');
+    expect(result).toBe('skip');
+  });
+
+  it("does NOT include 'Show diff' option for create actions", async () => {
+    let capturedOptions;
+    clackState.selectImpl = (opts) => {
+      capturedOptions = opts;
+      return 'apply';
+    };
+    await promptSingleFile({ relPath: 'a.md', action: 'create' }, () => 'diff', null, 'new');
+    const values = capturedOptions.options.map((o) => o.value);
+    expect(values).not.toContain('diff');
+    expect(values).toContain('apply');
+    expect(values).toContain('skip');
+    expect(values).toContain('apply-rest');
+  });
+
+  it("includes 'Show diff' option for update actions when diffFn is provided", async () => {
+    let capturedOptions;
+    clackState.selectImpl = (opts) => {
+      capturedOptions = opts;
+      return 'apply';
+    };
+    await promptSingleFile({ relPath: 'a.md', action: 'update' }, () => 'diff', 'old', 'new');
+    const values = capturedOptions.options.map((o) => o.value);
+    expect(values).toContain('diff');
+  });
+
+  it("does NOT include 'Show diff' for update actions when diffFn is missing", async () => {
+    let capturedOptions;
+    clackState.selectImpl = (opts) => {
+      capturedOptions = opts;
+      return 'apply';
+    };
+    await promptSingleFile({ relPath: 'a.md', action: 'update' }, null, 'old', 'new');
+    const values = capturedOptions.options.map((o) => o.value);
+    expect(values).not.toContain('diff');
+  });
+
+  it('shows the diff and re-prompts when user picks Show diff', async () => {
+    const diffFn = vi.fn(() => 'line1\nline2');
+    let callCount = 0;
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    clackState.selectImpl = () => {
+      callCount += 1;
+      if (callCount === 1) return 'diff';
+      return 'apply';
+    };
+
+    const result = await promptSingleFile(
+      { relPath: 'a.md', action: 'update' },
+      diffFn,
+      'old',
+      'new'
+    );
+
+    expect(result).toBe('apply');
+    expect(diffFn).toHaveBeenCalledWith('old', 'new');
+    expect(callCount).toBe(2);
+    // diff lines indented with 4 spaces
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('    line1'));
+    consoleLogSpy.mockRestore();
+  });
+
+  it('logs (no differences) when diffFn returns empty/null', async () => {
+    const diffFn = vi.fn(() => null);
+    let callCount = 0;
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    clackState.selectImpl = () => {
+      callCount += 1;
+      if (callCount === 1) return 'diff';
+      return 'skip';
+    };
+
+    const result = await promptSingleFile(
+      { relPath: 'a.md', action: 'update' },
+      diffFn,
+      'same',
+      'same'
+    );
+
+    expect(result).toBe('skip');
+    expect(consoleLogSpy).toHaveBeenCalledWith('    (no differences)');
+    consoleLogSpy.mockRestore();
+  });
+
+  it('uses the change action and relPath in the prompt message', async () => {
+    let capturedMsg;
+    clackState.selectImpl = (opts) => {
+      capturedMsg = opts.message;
+      return 'apply';
+    };
+    await promptSingleFile({ relPath: 'docs/file.md', action: 'create' }, null, null, 'content');
+    expect(capturedMsg).toContain('create');
+    expect(capturedMsg).toContain('docs/file.md');
+  });
+});

--- a/.agentkit/engines/node/src/__tests__/sync-guard.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-guard.test.mjs
@@ -135,6 +135,14 @@ describe('checkDirtyProtectedFiles', () => {
     // Sanity: no entry should still contain the literal arrow.
     expect(result.files.every((f) => !f.includes(' -> '))).toBe(true);
   });
+
+  it('handles short porcelain lines (length <= 3) by skipping them', () => {
+    // The internal filter drops lines too short to be valid porcelain entries.
+    // A clean tree exits via that filter; assert it does not throw and returns
+    // an array.
+    const result = checkDirtyProtectedFiles(tempDir, ['.agentkit/spec']);
+    expect(Array.isArray(result.files)).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/.agentkit/engines/node/src/__tests__/synchronize-helpers.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/synchronize-helpers.test.mjs
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// These helpers are exported from synchronize.mjs (and re-exported from
+// spec-loader.mjs). Importing from synchronize.mjs ensures the synchronize.mjs
+// copy of each helper is exercised by the coverage reporter.
+import { readYaml, readText, loadAgentsSpec, loadSpecDefaults } from '../synchronize.mjs';
+
+let tmp;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'sync-helpers-test-'));
+});
+
+afterEach(() => {
+  try {
+    rmSync(tmp, { recursive: true, force: true });
+  } catch {
+    /* Windows may briefly hold locks */
+  }
+});
+
+function writeYaml(path, content) {
+  mkdirSync(join(tmp, ...path.slice(0, -1)), { recursive: true });
+  writeFileSync(join(tmp, ...path), content, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// readYaml / readText
+// ---------------------------------------------------------------------------
+
+describe('readYaml (re-exported from synchronize.mjs)', () => {
+  it('returns null when file does not exist', () => {
+    expect(readYaml(join(tmp, 'missing.yaml'))).toBeNull();
+  });
+
+  it('parses a valid YAML file', () => {
+    writeYaml(['cfg.yaml'], 'name: demo\nvalue: 42\n');
+    const result = readYaml(join(tmp, 'cfg.yaml'));
+    expect(result).toEqual({ name: 'demo', value: 42 });
+  });
+
+  it('returns undefined-equivalent for an empty YAML file', () => {
+    writeYaml(['empty.yaml'], '');
+    // js-yaml.load on '' returns undefined
+    expect(readYaml(join(tmp, 'empty.yaml'))).toBeUndefined();
+  });
+});
+
+describe('readText (re-exported from synchronize.mjs)', () => {
+  it('returns null when file does not exist', () => {
+    expect(readText(join(tmp, 'missing.txt'))).toBeNull();
+  });
+
+  it('returns the file contents as a string', () => {
+    writeYaml(['hello.txt'], 'hello world\n');
+    expect(readText(join(tmp, 'hello.txt'))).toBe('hello world\n');
+  });
+
+  it('returns empty string for an empty file', () => {
+    writeYaml(['empty.txt'], '');
+    expect(readText(join(tmp, 'empty.txt'))).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadAgentsSpec — directory and fallback
+// ---------------------------------------------------------------------------
+
+describe('loadAgentsSpec (re-exported from synchronize.mjs)', () => {
+  it('returns empty object when neither agents/ dir nor agents.yaml exists', () => {
+    expect(loadAgentsSpec(tmp)).toEqual({});
+  });
+
+  it('loads from spec/agents.yaml fallback', () => {
+    writeYaml(
+      ['spec', 'agents.yaml'],
+      `agents:\n  engineering:\n    - id: be\n      name: Backend\n`
+    );
+    const result = loadAgentsSpec(tmp);
+    expect(result.agents.engineering[0].id).toBe('be');
+  });
+
+  it('loads from spec/agents/ directory of per-category YAML files', () => {
+    writeYaml(['spec', 'agents', 'engineering.yaml'], `engineering:\n  - id: be\n    name: BE\n`);
+    writeYaml(['spec', 'agents', 'testing.yaml'], `testing:\n  - id: qa\n    name: QA\n`);
+
+    const result = loadAgentsSpec(tmp);
+    expect(result.agents.engineering[0].id).toBe('be');
+    expect(result.agents.testing[0].id).toBe('qa');
+  });
+
+  it('skips non-yaml files in the agents directory', () => {
+    writeYaml(['spec', 'agents', 'engineering.yaml'], `engineering:\n  - id: be\n    name: BE\n`);
+    writeYaml(['spec', 'agents', 'README.md'], '# readme');
+    writeYaml(['spec', 'agents', '.gitkeep'], '');
+
+    const result = loadAgentsSpec(tmp);
+    expect(Object.keys(result.agents)).toEqual(['engineering']);
+  });
+
+  it('skips files that parse to non-object', () => {
+    writeYaml(['spec', 'agents', 'good.yaml'], `engineering:\n  - id: be\n    name: BE\n`);
+    writeYaml(['spec', 'agents', 'scalar.yaml'], 'just-a-scalar-string\n');
+
+    const result = loadAgentsSpec(tmp);
+    expect(result.agents.engineering[0].id).toBe('be');
+  });
+
+  it('skips non-array category values within a YAML file', () => {
+    writeYaml(
+      ['spec', 'agents', 'mixed.yaml'],
+      `engineering:\n  - id: be\n    name: BE\nbad: not-array\n`
+    );
+    const result = loadAgentsSpec(tmp);
+    expect(result.agents.engineering[0].id).toBe('be');
+    expect(result.agents.bad).toBeUndefined();
+  });
+
+  it('concatenates multiple YAML files that contribute to the same category', () => {
+    writeYaml(['spec', 'agents', 'a.yaml'], `engineering:\n  - id: be1\n    name: BE1\n`);
+    writeYaml(['spec', 'agents', 'b.yaml'], `engineering:\n  - id: be2\n    name: BE2\n`);
+
+    const result = loadAgentsSpec(tmp);
+    const ids = result.agents.engineering.map((a) => a.id).sort();
+    expect(ids).toEqual(['be1', 'be2']);
+  });
+
+  it('also accepts .yml extension', () => {
+    writeYaml(['spec', 'agents', 'engineering.yml'], `engineering:\n  - id: be\n    name: BE\n`);
+    const result = loadAgentsSpec(tmp);
+    expect(result.agents.engineering[0].id).toBe('be');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSpecDefaults — base / phase / teamSize layered
+// ---------------------------------------------------------------------------
+
+describe('loadSpecDefaults (re-exported from synchronize.mjs)', () => {
+  it('returns empty object when spec-defaults.yaml is missing', () => {
+    expect(loadSpecDefaults(tmp, {})).toEqual({});
+    expect(loadSpecDefaults(tmp)).toEqual({});
+  });
+
+  it('returns static defaults only when no phase/teamSize is supplied', () => {
+    writeYaml(
+      ['spec', 'spec-defaults.yaml'],
+      `staticA: 1\nstaticB: 'x'\nphase:\n  greenfield:\n    staticA: 99\n`
+    );
+    const result = loadSpecDefaults(tmp, {});
+    expect(result).toEqual({ staticA: 1, staticB: 'x' });
+  });
+
+  it('applies phase-conditional overrides on top of static defaults', () => {
+    writeYaml(
+      ['spec', 'spec-defaults.yaml'],
+      `staticA: 1\nphase:\n  greenfield:\n    staticA: 99\n    extra: 'g'\n`
+    );
+    const result = loadSpecDefaults(tmp, { phase: 'greenfield' });
+    expect(result.staticA).toBe(99);
+    expect(result.extra).toBe('g');
+  });
+
+  it('does not apply phase block when phase is unknown', () => {
+    writeYaml(
+      ['spec', 'spec-defaults.yaml'],
+      `staticA: 1\nphase:\n  greenfield:\n    staticA: 99\n`
+    );
+    const result = loadSpecDefaults(tmp, { phase: 'unknown' });
+    expect(result.staticA).toBe(1);
+  });
+
+  it('applies teamSize-conditional overrides with priority over phase', () => {
+    writeYaml(
+      ['spec', 'spec-defaults.yaml'],
+      [
+        'staticA: 1',
+        'phase:',
+        '  active:',
+        '    staticA: 50',
+        '    fromPhase: true',
+        'teamSize:',
+        '  large:',
+        '    staticA: 200',
+      ].join('\n') + '\n'
+    );
+    const result = loadSpecDefaults(tmp, { phase: 'active', teamSize: 'large' });
+    expect(result.staticA).toBe(200); // teamSize wins
+    expect(result.fromPhase).toBe(true); // phase still applied
+  });
+
+  it('returns empty object when YAML is empty/falsy', () => {
+    writeYaml(['spec', 'spec-defaults.yaml'], '');
+    expect(loadSpecDefaults(tmp, {})).toEqual({});
+  });
+
+  it('handles missing teamSize/phase blocks gracefully', () => {
+    writeYaml(['spec', 'spec-defaults.yaml'], `staticA: 1\n`);
+    const result = loadSpecDefaults(tmp, { phase: 'active', teamSize: 'large' });
+    expect(result).toEqual({ staticA: 1 });
+  });
+});

--- a/.agentkit/engines/node/src/__tests__/var-builders-extra.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/var-builders-extra.test.mjs
@@ -1,0 +1,692 @@
+import { describe, it, expect } from 'vitest';
+import {
+  inferMaxTaskTurns,
+  inferMaxHandoffChainDepth,
+  inferMaxStagnationTurns,
+  inferTestingCoverage,
+  buildBrowserTestingVars,
+  getTeamCommandStem,
+  isFeatureEnabled,
+  isItemFeatureEnabled,
+  buildTeamVars,
+  buildAreaRoutingTable,
+  buildCommandVars,
+  buildAgentVars,
+  buildAgentRegistry,
+} from '../var-builders.mjs';
+
+// ---------------------------------------------------------------------------
+// inferMaxTaskTurns
+// ---------------------------------------------------------------------------
+describe('inferMaxTaskTurns', () => {
+  it('returns 15 for solo team', () => {
+    expect(inferMaxTaskTurns('solo')).toBe(15);
+  });
+
+  it('returns 25 for small team', () => {
+    expect(inferMaxTaskTurns('small')).toBe(25);
+  });
+
+  it('returns 35 for medium team', () => {
+    expect(inferMaxTaskTurns('medium')).toBe(35);
+  });
+
+  it('returns 35 for large team', () => {
+    expect(inferMaxTaskTurns('large')).toBe(35);
+  });
+
+  it('falls back to 25 for unknown size', () => {
+    expect(inferMaxTaskTurns('huge')).toBe(25);
+    expect(inferMaxTaskTurns(undefined)).toBe(25);
+    expect(inferMaxTaskTurns(null)).toBe(25);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferMaxHandoffChainDepth
+// ---------------------------------------------------------------------------
+describe('inferMaxHandoffChainDepth', () => {
+  it('returns 3 for small team count (<=3)', () => {
+    expect(inferMaxHandoffChainDepth(1)).toBe(3);
+    expect(inferMaxHandoffChainDepth(3)).toBe(3);
+  });
+
+  it('returns 5 for medium team count (4-6)', () => {
+    expect(inferMaxHandoffChainDepth(4)).toBe(5);
+    expect(inferMaxHandoffChainDepth(6)).toBe(5);
+  });
+
+  it('returns 7 for large team count (>6)', () => {
+    expect(inferMaxHandoffChainDepth(7)).toBe(7);
+    expect(inferMaxHandoffChainDepth(13)).toBe(7);
+  });
+
+  it('returns 3 for zero or negative team count', () => {
+    expect(inferMaxHandoffChainDepth(0)).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferMaxStagnationTurns
+// ---------------------------------------------------------------------------
+describe('inferMaxStagnationTurns', () => {
+  it('returns 15 for greenfield', () => {
+    expect(inferMaxStagnationTurns('greenfield')).toBe(15);
+  });
+
+  it('returns 10 for active', () => {
+    expect(inferMaxStagnationTurns('active')).toBe(10);
+  });
+
+  it('returns 5 for maintenance and legacy', () => {
+    expect(inferMaxStagnationTurns('maintenance')).toBe(5);
+    expect(inferMaxStagnationTurns('legacy')).toBe(5);
+  });
+
+  it('falls back to 10 for unknown phase', () => {
+    expect(inferMaxStagnationTurns('unknown')).toBe(10);
+    expect(inferMaxStagnationTurns(undefined)).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferTestingCoverage
+// ---------------------------------------------------------------------------
+describe('inferTestingCoverage', () => {
+  it("returns '60' for greenfield", () => {
+    expect(inferTestingCoverage('greenfield')).toBe('60');
+  });
+
+  it("returns '80' for active", () => {
+    expect(inferTestingCoverage('active')).toBe('80');
+  });
+
+  it("returns '90' for maintenance and legacy", () => {
+    expect(inferTestingCoverage('maintenance')).toBe('90');
+    expect(inferTestingCoverage('legacy')).toBe('90');
+  });
+
+  it("falls back to '80' for unknown phase", () => {
+    expect(inferTestingCoverage('huh')).toBe('80');
+    expect(inferTestingCoverage(undefined)).toBe('80');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBrowserTestingVars
+// ---------------------------------------------------------------------------
+describe('buildBrowserTestingVars', () => {
+  it('returns both flags false when project spec is null/undefined', () => {
+    expect(buildBrowserTestingVars(null)).toEqual({ usesPlaywright: false, usesBrowser: false });
+    expect(buildBrowserTestingVars(undefined)).toEqual({
+      usesPlaywright: false,
+      usesBrowser: false,
+    });
+  });
+
+  it('returns both flags false when testing.e2e is missing', () => {
+    expect(buildBrowserTestingVars({})).toEqual({ usesPlaywright: false, usesBrowser: false });
+    expect(buildBrowserTestingVars({ testing: {} })).toEqual({
+      usesPlaywright: false,
+      usesBrowser: false,
+    });
+  });
+
+  it('returns both flags false when testing.e2e is not an array', () => {
+    expect(buildBrowserTestingVars({ testing: { e2e: 'playwright' } })).toEqual({
+      usesPlaywright: false,
+      usesBrowser: false,
+    });
+  });
+
+  it('detects playwright (case-insensitive)', () => {
+    expect(buildBrowserTestingVars({ testing: { e2e: ['Playwright'] } })).toEqual({
+      usesPlaywright: true,
+      usesBrowser: false,
+    });
+    expect(buildBrowserTestingVars({ testing: { e2e: ['playwright'] } })).toEqual({
+      usesPlaywright: true,
+      usesBrowser: false,
+    });
+  });
+
+  it('detects cypress as a browser tool', () => {
+    expect(buildBrowserTestingVars({ testing: { e2e: ['cypress'] } })).toEqual({
+      usesPlaywright: false,
+      usesBrowser: true,
+    });
+  });
+
+  it('detects puppeteer as a browser tool', () => {
+    expect(buildBrowserTestingVars({ testing: { e2e: ['puppeteer'] } })).toEqual({
+      usesPlaywright: false,
+      usesBrowser: true,
+    });
+  });
+
+  it('detects webdriverio as a browser tool', () => {
+    expect(buildBrowserTestingVars({ testing: { e2e: ['webdriverio'] } })).toEqual({
+      usesPlaywright: false,
+      usesBrowser: true,
+    });
+  });
+
+  it('playwright takes precedence over other browser tools', () => {
+    expect(buildBrowserTestingVars({ testing: { e2e: ['playwright', 'cypress'] } })).toEqual({
+      usesPlaywright: true,
+      usesBrowser: false,
+    });
+  });
+
+  it('returns both false for unknown e2e tools', () => {
+    expect(buildBrowserTestingVars({ testing: { e2e: ['testcafe', 'nightwatch'] } })).toEqual({
+      usesPlaywright: false,
+      usesBrowser: false,
+    });
+  });
+
+  it('handles non-string entries gracefully', () => {
+    expect(buildBrowserTestingVars({ testing: { e2e: [null, 42, undefined] } })).toEqual({
+      usesPlaywright: false,
+      usesBrowser: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTeamCommandStem
+// ---------------------------------------------------------------------------
+describe('getTeamCommandStem', () => {
+  it('prepends team- when not already present', () => {
+    expect(getTeamCommandStem('backend')).toBe('team-backend');
+  });
+
+  it('returns the id unchanged when already prefixed with team-', () => {
+    expect(getTeamCommandStem('team-backend')).toBe('team-backend');
+  });
+
+  it('handles single-character ids', () => {
+    expect(getTeamCommandStem('q')).toBe('team-q');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isFeatureEnabled
+// ---------------------------------------------------------------------------
+describe('isFeatureEnabled', () => {
+  it('returns true when the feature var is undefined (graceful default)', () => {
+    expect(isFeatureEnabled('coding-rules', {})).toBe(true);
+  });
+
+  it('returns true when the feature var is true', () => {
+    expect(isFeatureEnabled('coding-rules', { feature_coding_rules: true })).toBe(true);
+  });
+
+  it('returns false when the feature var is explicitly false', () => {
+    expect(isFeatureEnabled('coding-rules', { feature_coding_rules: false })).toBe(false);
+  });
+
+  it('replaces hyphens with underscores in the feature var lookup', () => {
+    // 'mcp-integration' → 'feature_mcp_integration'
+    expect(isFeatureEnabled('mcp-integration', { feature_mcp_integration: false })).toBe(false);
+  });
+
+  it('returns true for non-false, non-undefined values (graceful)', () => {
+    // Only an explicit `false` disables; truthy strings, 0, null all stay enabled
+    expect(isFeatureEnabled('x', { feature_x: 'yes' })).toBe(true);
+    expect(isFeatureEnabled('x', { feature_x: null })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isItemFeatureEnabled
+// ---------------------------------------------------------------------------
+describe('isItemFeatureEnabled', () => {
+  it('returns true when the item has no requiredFeature', () => {
+    expect(isItemFeatureEnabled({}, {})).toBe(true);
+    expect(isItemFeatureEnabled({ name: 'foo' }, { feature_x: false })).toBe(true);
+  });
+
+  it('returns true when the requiredFeature is enabled', () => {
+    expect(
+      isItemFeatureEnabled({ requiredFeature: 'coding-rules' }, { feature_coding_rules: true })
+    ).toBe(true);
+  });
+
+  it('returns false when the requiredFeature is disabled', () => {
+    expect(
+      isItemFeatureEnabled({ requiredFeature: 'coding-rules' }, { feature_coding_rules: false })
+    ).toBe(false);
+  });
+
+  it('returns true (graceful default) when the requiredFeature var is undefined', () => {
+    expect(isItemFeatureEnabled({ requiredFeature: 'unknown' }, {})).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAreaRoutingTable
+// ---------------------------------------------------------------------------
+describe('buildAreaRoutingTable', () => {
+  it('returns the default routing string when no overrides are provided', () => {
+    const result = buildAreaRoutingTable({});
+    // Default routing should include all canonical areas
+    expect(result).toContain('`backend`→backend');
+    expect(result).toContain('`frontend`→frontend');
+    expect(result).toContain('`cli`→backend');
+    expect(result).toContain('`sync-engine`→devops');
+  });
+
+  it('returns the default routing string when teamsIntake is undefined', () => {
+    const result = buildAreaRoutingTable(undefined);
+    expect(result).toContain('`backend`→backend');
+  });
+
+  it('overrides specific areas while preserving other defaults', () => {
+    const result = buildAreaRoutingTable({ routing: { backend: 'platform', cli: 'devops' } });
+    expect(result).toContain('`backend`→platform');
+    expect(result).toContain('`cli`→devops');
+    // Frontend default still present
+    expect(result).toContain('`frontend`→frontend');
+  });
+
+  it('adds new areas not present in defaults', () => {
+    const result = buildAreaRoutingTable({ routing: { 'ml-ops': 'data' } });
+    expect(result).toContain('`ml-ops`→data');
+  });
+
+  it('separates entries with ", "', () => {
+    const result = buildAreaRoutingTable({});
+    // Must have a comma-space between entries
+    expect(result).toMatch(/, /);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCommandVars
+// ---------------------------------------------------------------------------
+describe('buildCommandVars', () => {
+  it('returns command variables with prompt trimmed and {{stateDir}} replaced', () => {
+    const cmd = {
+      name: 'check',
+      description: '  Run quality gates  ',
+      prompt: '  Read {{stateDir}}/note.md  ',
+      flags: [],
+    };
+    const result = buildCommandVars(cmd, { foo: 'bar' });
+    expect(result.foo).toBe('bar');
+    expect(result.commandName).toBe('check');
+    expect(result.commandDescription).toBe('Run quality gates');
+    expect(result.commandPrompt).toContain('.claude/state/note.md');
+    expect(result.commandPrompt.startsWith(' ')).toBe(false);
+  });
+
+  it('uses the provided stateDir override', () => {
+    const cmd = { name: 'plan', description: '', prompt: '{{stateDir}}/x', flags: [] };
+    const result = buildCommandVars(cmd, {}, '.agentkit/state');
+    expect(result.commandPrompt).toBe('.agentkit/state/x');
+  });
+
+  it('applies command prefix when commandPrefix is set', () => {
+    const cmd = { name: 'check', description: '', prompt: '', flags: [] };
+    const result = buildCommandVars(cmd, { commandPrefix: 'kits' });
+    expect(result.commandPrefixedName).toBe('kits-check');
+  });
+
+  it('uses bare command name when commandPrefix is null', () => {
+    const cmd = { name: 'check', description: '', prompt: '', flags: [] };
+    const result = buildCommandVars(cmd, {});
+    expect(result.commandPrefixedName).toBe('check');
+  });
+
+  it('flags isSyncBacklog true only for the sync-backlog command', () => {
+    expect(
+      buildCommandVars({ name: 'sync-backlog', description: '', prompt: '', flags: [] }, {})
+        .isSyncBacklog
+    ).toBe(true);
+    expect(
+      buildCommandVars({ name: 'check', description: '', prompt: '', flags: [] }, {}).isSyncBacklog
+    ).toBe(false);
+  });
+
+  it('falls back gracefully when prompt is missing or non-string', () => {
+    const result = buildCommandVars({ name: 'x', description: '', prompt: undefined }, {});
+    expect(result.commandPrompt).toBe('');
+    const result2 = buildCommandVars({ name: 'x', description: '', prompt: 42 }, {});
+    expect(result2.commandPrompt).toBe('');
+  });
+
+  it('handles non-string description gracefully', () => {
+    const result = buildCommandVars({ name: 'x', description: null, prompt: '' }, {});
+    expect(result.commandDescription).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTeamVars
+// ---------------------------------------------------------------------------
+describe('buildTeamVars', () => {
+  it('builds the full team variable set with explicit team config', () => {
+    const team = {
+      id: 'backend',
+      name: 'BACKEND',
+      focus: 'API',
+      scope: ['apps/api/**'],
+      accepts: ['implement', 'review'],
+      'handoff-chain': ['testing', 'docs'],
+      'max-task-turns': 50,
+      'max-handoff-chain-depth': 9,
+      'max-stagnation-turns': 7,
+    };
+    const vars = { teamSize: 'small', projectPhase: 'active' };
+    const teamsSpec = { teams: [team] };
+    const agentsSpec = { agents: {} };
+
+    const out = buildTeamVars(team, vars, teamsSpec, agentsSpec);
+    expect(out.teamId).toBe('backend');
+    expect(out.teamName).toBe('BACKEND');
+    expect(out.teamFocus).toBe('API');
+    expect(out.teamScope).toBe('apps/api/**');
+    expect(out.teamAccepts).toBe('implement, review');
+    expect(out.teamHandoffChain).toBe('testing → docs');
+    expect(out.maxTaskTurns).toBe(50);
+    expect(out.maxHandoffChainDepth).toBe(9);
+    expect(out.maxStagnationTurns).toBe(7);
+    expect(out.teamHasAgents).toBe(false);
+    expect(out.teamAgentSummaries).toBe('');
+  });
+
+  it('falls back to inferred values when team-specific tuning is missing', () => {
+    const team = { id: 'qa', name: 'QA', focus: 'Tests' };
+    const vars = { teamSize: 'solo', projectPhase: 'greenfield' };
+    const teamsSpec = { teams: [{ id: 'a' }, { id: 'b' }] };
+    const agentsSpec = { agents: {} };
+
+    const out = buildTeamVars(team, vars, teamsSpec, agentsSpec);
+    expect(out.maxTaskTurns).toBe(15); // solo
+    expect(out.maxHandoffChainDepth).toBe(3); // 2 teams ≤ 3
+    expect(out.maxStagnationTurns).toBe(15); // greenfield
+  });
+
+  it('uses default fallback (5 teams) when teamsSpec is missing', () => {
+    const team = { id: 'qa', name: 'QA' };
+    const out = buildTeamVars(team, {}, undefined, { agents: {} });
+    // 5 teams falls in the 4-6 bucket → 5
+    expect(out.maxHandoffChainDepth).toBe(5);
+  });
+
+  it('coerces non-array scope/accepts/handoff-chain to strings or empty', () => {
+    const team = {
+      id: 't',
+      name: 'T',
+      focus: 'F',
+      scope: 'single-scope-string',
+      accepts: 'just-string',
+      'handoff-chain': 'one-step',
+    };
+    const out = buildTeamVars(team, {}, { teams: [] }, { agents: {} });
+    expect(out.teamScope).toBe('single-scope-string');
+    expect(out.teamAccepts).toBe('just-string');
+    expect(out.teamHandoffChain).toBe('one-step');
+  });
+
+  it('emits agent summaries when the team has explicit agents', () => {
+    const agentsSpec = {
+      agents: {
+        engineering: [
+          { id: 'be', name: 'Backend Eng', role: '  Develops APIs.  ' },
+          { id: 'fe', name: 'Frontend Eng', role: 'Builds UI' },
+        ],
+      },
+    };
+    const team = { id: 'team-x', name: 'TEAM X', focus: 'F', agents: ['be', 'fe'] };
+    const out = buildTeamVars(team, {}, { teams: [] }, agentsSpec);
+
+    expect(out.teamHasAgents).toBe(true);
+    expect(out.teamAgentSummaries).toContain('Backend Eng');
+    expect(out.teamAgentSummaries).toContain('Frontend Eng');
+    // role should be trimmed
+    expect(out.teamAgentSummaries).toContain('Develops APIs.');
+  });
+
+  it('handles non-string role on agents gracefully', () => {
+    const agentsSpec = {
+      agents: { x: [{ id: 'a1', name: 'A1', role: { type: 'object' } }] },
+    };
+    const team = { id: 'x', name: 'X', focus: '', agents: ['a1'] };
+    const out = buildTeamVars(team, {}, { teams: [] }, agentsSpec);
+    expect(out.teamHasAgents).toBe(true);
+  });
+
+  it('falls back to team.id when name is missing', () => {
+    const team = { id: 'lonely' };
+    const out = buildTeamVars(team, {}, { teams: [] }, { agents: {} });
+    expect(out.teamName).toBe('lonely');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAgentVars
+// ---------------------------------------------------------------------------
+describe('buildAgentVars', () => {
+  const baseVars = { projectName: 'demo' };
+
+  it('builds full agent vars with all sub-sections populated', () => {
+    const agent = {
+      id: 'arch',
+      name: 'Architect',
+      role: '  Designs systems.  ',
+      focus: ['scalability'],
+      responsibilities: ['design APIs'],
+      'preferred-tools': ['miro'],
+      conventions: ['Use ADRs'],
+      examples: [{ title: 'ADR-001', code: '  some example code  ' }],
+      'anti-patterns': ['big-bang releases'],
+      'domain-rules': ['Document trade-offs'],
+      'decision-model': {
+        type: 'hybrid',
+        'hybrid-of': ['MCDA', 'BDI'],
+        description: '  blended  ',
+      },
+      'retry-policy': {
+        'max-retries': 3,
+        'failure-classification': { transient: 'retry', logic: 'escalate', permanent: 'fail' },
+        backoff: 'exponential',
+        'escalate-to': 'lead',
+      },
+      'belief-system': {
+        'state-reads': ['AGENT_BACKLOG.md'],
+        'task-reads': true,
+        'update-on': ['merge'],
+        'revision-strategy': 'reactive',
+      },
+      confidence: {
+        'output-threshold': 0.8,
+        'requires-validation': true,
+        'validation-agent': 'reviewer',
+        'low-confidence-action': 'escalate',
+      },
+      negotiation: {
+        'conflict-scope': 'team',
+        'resolution-strategy': 'voting',
+        'can-negotiate-with': ['be', 'fe'],
+      },
+      lookahead: { enabled: true, depth: 3, 'simulation-budget': 5 },
+    };
+
+    const out = buildAgentVars(agent, 'engineering', baseVars, new Map());
+
+    expect(out.agentId).toBe('arch');
+    expect(out.agentName).toBe('Architect');
+    expect(out.agentCategory).toBe('engineering');
+    expect(out.agentRole).toBe('Designs systems.');
+    expect(out.agentFocusList).toBe('- scalability');
+    expect(out.agentResponsibilitiesList).toBe('- design APIs');
+    expect(out.agentToolsList).toBe('- miro');
+    expect(out.agentConventions).toBe('- Use ADRs');
+    expect(out.agentExamples).toContain('### ADR-001');
+    expect(out.agentExamples).toContain('some example code');
+    expect(out.agentAntiPatterns).toBe('- big-bang releases');
+    expect(out.agentDomainRules).toBe('- Document trade-offs');
+
+    expect(out.agentDecisionModel).toContain('hybrid');
+    expect(out.agentDecisionModel).toContain('MCDA, BDI');
+    expect(out.agentDecisionModel).toContain('blended');
+
+    expect(out.agentRetryPolicy).toContain('Max retries:** 3');
+    expect(out.agentRetryPolicy).toContain('transient→retry');
+    expect(out.agentRetryPolicy).toContain('logic→escalate');
+    expect(out.agentRetryPolicy).toContain('permanent→fail');
+    expect(out.agentRetryPolicy).toContain('Backoff:** exponential');
+    expect(out.agentRetryPolicy).toContain('Escalate to:** lead');
+
+    expect(out.agentBeliefSystem).toContain('State reads:** AGENT_BACKLOG.md');
+    expect(out.agentBeliefSystem).toContain('Task reads:** true');
+    expect(out.agentBeliefSystem).toContain('Update on:** merge');
+    expect(out.agentBeliefSystem).toContain('Revision strategy:** reactive');
+
+    expect(out.agentConfidence).toContain('Output threshold:** 0.8');
+    expect(out.agentConfidence).toContain('Requires validation:** true');
+    expect(out.agentConfidence).toContain('Validation agent:** reviewer');
+    expect(out.agentConfidence).toContain('Low confidence action:** escalate');
+
+    expect(out.agentNegotiation).toContain('Conflict scope:** team');
+    expect(out.agentNegotiation).toContain('Resolution strategy:** voting');
+    expect(out.agentNegotiation).toContain('Can negotiate with:** be, fe');
+
+    expect(out.agentLookahead).toContain('Enabled:** true');
+    expect(out.agentLookahead).toContain('Depth:** 3');
+    expect(out.agentLookahead).toContain('Simulation budget:** 5 tool calls');
+
+    // collaborators is empty when registry is empty
+    expect(out.agentCollaborators).toBe('');
+  });
+
+  it('returns empty strings for missing optional sub-sections', () => {
+    const agent = { id: 'minimal', name: 'Minimal', role: 'Does little' };
+    const out = buildAgentVars(agent, 'misc', baseVars);
+
+    expect(out.agentFocusList).toBe('');
+    expect(out.agentResponsibilitiesList).toBe('');
+    expect(out.agentToolsList).toBe('');
+    expect(out.agentConventions).toBe('');
+    expect(out.agentExamples).toBe('');
+    expect(out.agentAntiPatterns).toBe('');
+    expect(out.agentDomainRules).toBe('');
+    expect(out.agentDecisionModel).toBe('');
+    expect(out.agentRetryPolicy).toBe('');
+    expect(out.agentBeliefSystem).toBe('');
+    expect(out.agentConfidence).toBe('');
+    expect(out.agentNegotiation).toBe('');
+    expect(out.agentLookahead).toBe('');
+  });
+
+  it('omits lookahead block when not enabled', () => {
+    const agent = {
+      id: 'a',
+      name: 'A',
+      role: '',
+      lookahead: { enabled: false, depth: 5 },
+    };
+    const out = buildAgentVars(agent, 'cat', {});
+    expect(out.agentLookahead).toBe('');
+  });
+
+  it('omits lookahead depth/budget when zero', () => {
+    const agent = {
+      id: 'a',
+      name: 'A',
+      role: '',
+      lookahead: { enabled: true, depth: 0, 'simulation-budget': 0 },
+    };
+    const out = buildAgentVars(agent, 'cat', {});
+    expect(out.agentLookahead).toContain('Enabled:** true');
+    expect(out.agentLookahead).not.toContain('Depth:**');
+    expect(out.agentLookahead).not.toContain('Simulation budget:**');
+  });
+
+  it("falls back to 'preferred-tools' over 'tools' (legacy field)", () => {
+    const agent = { id: 'a', name: 'A', role: '', tools: ['legacy'] };
+    const out = buildAgentVars(agent, 'cat', {});
+    expect(out.agentToolsList).toBe('- legacy');
+  });
+
+  it('handles non-string agent role gracefully', () => {
+    const out = buildAgentVars({ id: 'a', name: 'A', role: null }, 'c', {});
+    expect(out.agentRole).toBe('');
+
+    const out2 = buildAgentVars({ id: 'a', name: 'A', role: { x: 1 } }, 'c', {});
+    expect(out2.agentRole).toEqual({ x: 1 });
+  });
+
+  it('renders examples without title using the default heading', () => {
+    const agent = {
+      id: 'a',
+      name: 'A',
+      role: '',
+      examples: [{ code: 'code1' }],
+    };
+    const out = buildAgentVars(agent, 'cat', {});
+    expect(out.agentExamples).toContain('### Example');
+  });
+
+  it('uses agentRegistry to populate collaborators', () => {
+    const registry = buildAgentRegistry({
+      agents: {
+        x: [{ id: 'mate', name: 'Mate', role: 'Helps out.', accepts: ['review'] }],
+      },
+    });
+    const agent = {
+      id: 'lead',
+      name: 'Lead',
+      role: 'Leads',
+      'depends-on': ['mate'],
+    };
+    const out = buildAgentVars(agent, 'x', {}, registry);
+    expect(out.agentCollaborators).toContain('mate');
+    expect(out.agentCollaborators).toContain('Mate');
+  });
+
+  it('preserves base vars in output', () => {
+    const out = buildAgentVars({ id: 'a', name: 'A', role: '' }, 'cat', { projectName: 'demo' });
+    expect(out.projectName).toBe('demo');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAgentRegistry edge cases (string role with multiple sentences, no role)
+// ---------------------------------------------------------------------------
+describe('buildAgentRegistry edge cases', () => {
+  it('treats non-string role as empty role summary', () => {
+    const registry = buildAgentRegistry({
+      agents: { x: [{ id: 'a', name: 'A', role: 12345 }] },
+    });
+    expect(registry.get('a').roleSummary).toBe('');
+  });
+
+  it('falls back to id when name is missing', () => {
+    const registry = buildAgentRegistry({
+      agents: { x: [{ id: 'a', role: 'Some role.' }] },
+    });
+    expect(registry.get('a').name).toBe('a');
+  });
+
+  it('treats non-array accepts as empty array', () => {
+    const registry = buildAgentRegistry({
+      agents: { x: [{ id: 'a', name: 'A', role: '', accepts: 'review' }] },
+    });
+    expect(registry.get('a').accepts).toEqual([]);
+  });
+
+  it('handles multiple categories', () => {
+    const registry = buildAgentRegistry({
+      agents: {
+        engineering: [{ id: 'be', name: 'BE', role: 'Backend' }],
+        testing: [{ id: 'qa', name: 'QA', role: 'Testing' }],
+      },
+    });
+    expect(registry.size).toBe(2);
+    expect(registry.get('be').category).toBe('engineering');
+    expect(registry.get('qa').category).toBe('testing');
+  });
+});


### PR DESCRIPTION
## Summary

Adds ~1500 lines of test coverage targeting the four lowest-covered modules in the engine, with the goal of clearing the 80% global coverage gate that has been failing on \`dev\` since PR #503.

| Module | Before (lines / branches) | Target |
|---|---|---|
| sync-guard.mjs | 20% / 5% | covered by sync-guard-prompts.test.mjs (321 LoC) + +26 in sync-guard.test.mjs |
| scaffold-merge.mjs | 34% / 71% | covered by scaffold-merge.test.mjs (132 LoC) |
| var-builders.mjs | 64% / 58% | covered by var-builders-extra.test.mjs (692 LoC) |
| synchronize.mjs | 68% / 65% | covered by synchronize-helpers.test.mjs (205 LoC) |
| scaffold-engine.mjs | 67% / 75% | covered by scaffold-engine-extra.test.mjs (168 LoC) |

Also includes a small ubuntu-latest runner template change rolled into the same branch (this duplicates PR #518; will be resolved on rebase whichever lands first).

## Test plan

- [ ] CI green (esp. coverage thresholds: lines ≥80, branches ≥80, functions ≥80)
- [ ] Local: targeted suites pass

## Context

\`dev\` has been failing CI since 2026-04-26 because the 80% coverage gate (set in PR #503) wasn't met by the existing test suite. PR #517 takes an incremental approach (sync-guard + scaffold-merge only); this branch is the comprehensive version. Either may go first depending on which clears CI; the survivor should rebase-merge with the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added extensive test coverage for file management, synchronization, and configuration features to ensure stability and reliability across edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phoenixvc/retort/pull/519)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->