### PR TITLE
test(run-cli): make tmp-dir cleanup resilient to Windows ENOTEMPTY race

### DIFF
--- a/.agentkit/engines/node/src/__tests__/run-cli.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/run-cli.test.mjs
@@ -18,7 +18,8 @@ beforeEach(() => {
 afterEach(() => {
   // Windows occasionally hits ENOTEMPTY when a freshly-deleted file's handle
   // hasn't been released by the OS yet. Retry generously, then swallow —
-  // the OS will reap /tmp on its own.
+  // a leftover dir under the system tmpdir is acceptable for tests/CI, and
+  // accepting that residue is preferable to a flaky failure here.
   try {
     rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
   } catch {

--- a/.agentkit/engines/node/src/__tests__/run-cli.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/run-cli.test.mjs
@@ -16,7 +16,14 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  // Windows occasionally hits ENOTEMPTY when a freshly-deleted file's handle
+  // hasn't been released by the OS yet. Retry generously, then swallow —
+  // the OS will reap /tmp on its own.
+  try {
+    rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
+  } catch {
+    /* best-effort cleanup */
+  }
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Summary

Tiny fix for the Windows-only flake the prior session's handoff flagged: \`afterEach\` in \`run-cli.test.mjs\` hit \`rmdir <path>/.agentkit/state ENOTEMPTY\` during the full-suite run because a freshly-deleted file's handle hadn't been released by the time rmSync walked back up to the parent.

## Change

Two adjustments to the cleanup hook:

1. **More retry budget** — bump maxRetries 3 → 10 and retryDelay 100 → 200 ms (~2s of total contention budget vs the previous 300 ms).
2. **Best-effort cleanup** — wrap in try/catch and swallow. /tmp gets reaped by the OS regardless, and a stale dir doesn't impact test correctness.

## Why not just bump retries

Even with high retry counts, the race is theoretically unbounded — the OS handle release is asynchronous. Treating cleanup as best-effort closes the gap permanently. Other tests in the suite already use the same belt-and-braces pattern in places.

## Test plan

- [x] \`pnpm vitest run src/__tests__/run-cli.test.mjs\` — 23 tests pass
- [x] \`pnpm exec prettier --check\` — clean
- [x] No source code changes — test-only edit

## Refs

- 2026-05-10 session handoff, next-action #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability on Windows systems with enhanced cleanup procedures for temporary directories, featuring more aggressive retry logic and error handling to reduce flaky test failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phoenixvc/retort/pull/526)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->