### PR TITLE
chore(coverage): bump suite branches threshold 65 -> 70

### DIFF
--- a/.agentkit/vitest.config.mjs
+++ b/.agentkit/vitest.config.mjs
@@ -14,14 +14,14 @@ export default defineConfig({
       reporter: ['text', 'text-summary', 'json-summary'],
       // Thresholds are set at the realistic current floor with a small cushion
       // (lines/branches: enough to fail on regression, not block normal PRs).
-      // The 80/80/80 target was unachievable across the whole engine without
-      // a multi-day per-module branch-coverage push — see `#520` for the plan
-      // to ratchet branches back to 80 by improving coverage on check.mjs,
-      // cost-tracker.mjs, init.mjs, orchestrator.mjs, discover.mjs, and
-      // retort-config-wizard.mjs.
+      // The 80/80/80 target is being approached via the `#520` ratchet:
+      //   - Phase 1 (cost-tracker.mjs, check.mjs) — landed; branches → 70.
+      //   - Phase 2 (init.mjs, orchestrator.mjs) — in progress.
+      //   - Phase 3 (discover.mjs, retort-config-wizard.mjs) — pending.
+      // The branches floor is bumped each phase as headroom is earned.
       thresholds: {
         lines: 77,
-        branches: 65,
+        branches: 70,
         functions: 80,
       },
     },


### PR DESCRIPTION
## Summary

Locks in the Phase 1 coverage gains from #520 by raising the suite-wide branches threshold in `.agentkit/vitest.config.mjs` from 65 to 70.

- PR #524 (cost-tracker.mjs: 39.5% -> 93.8% branches) and PR #525 (check.mjs: 39.7% -> 92.6% branches) both intentionally deferred this bump.
- Current suite branches: **71.51%** (1.5% cushion over the new floor).
- Comment block rewritten to reflect Phase 1 done, Phase 2 (init.mjs + orchestrator.mjs) in progress, Phase 3 (discover.mjs + retort-config-wizard.mjs) pending.

## Test plan

- [x] `cd .agentkit && pnpm vitest run` — 1765 passed, 1 skipped, 67 files
- [x] Threshold validation runs as part of vitest coverage; PR will exercise it on CI
- [ ] CI green on this branch

## Refs

- Refs #520
- Follows: #524, #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)