### PR TITLE
docs(handoffs): add 2026-05-10-02 — phase 1 ratchet + dependabot triage

### DIFF
--- a/docs/handoffs/2026-05-10-02.md
+++ b/docs/handoffs/2026-05-10-02.md
@@ -1,0 +1,65 @@
+# Session Handoff
+
+**Date:** 2026-05-10
+**Branch:** `dev` (was `test/cost-tracker-coverage`, `test/check-coverage`, `fix/run-cli-cleanup-flake`, `docs/dependabot-triage-2026-05-10`, `docs/handoff-2026-05-10`)
+**Last Commit:** `24dce24c` — docs(security): triage 38 open dependabot alerts (2026-05-10) (#527)
+**Session Duration:** ~3.5 hours
+**Overall Status:** HEALTHY
+
+## What Was Done
+
+Executed all three next-actions from the prior session's handoff and merged all five resulting PRs.
+
+- **Phase 1 of #520 branch-coverage ratchet — both modules complete.**
+  - `cost-tracker.mjs`: branches **39.5% → 93.8%**, functions **68.8% → 100%**, lines **58.1% → 99.2%** via new `cost-tracker-coverage.test.mjs` (25 cases targeting `parsePeriodDays`, `runCost` CLI, `formatMs`, `formatReportTable`, edge cases). PR #524 merged at `26ef8b4c`.
+  - `check.mjs`: branches **39.7% → 92.6%**, functions **85.7% → 100%**, lines **56.3% → 98.2%** via new `check-coverage.test.mjs` (58 cases targeting `resolveTypecheckCommand`, `buildSteps` warn paths, `loadCoverageThreshold`, `auditUnresolvedPlaceholders`, `detectStacks` wildcard, `runCheck` advanced paths). Source change: exported four internal helpers for unit-testability. PR #525 merged at `6823e360`.
+  - Suite-wide branch coverage: **65% → ~73%** (threshold still 65, deferred bump).
+- **`run-cli.test.mjs` ENOTEMPTY flake fixed** (PR #526 at `0a605d1d`). Bumped `maxRetries` 3 → 10, `retryDelay` 100 → 200, wrapped in try/catch. Hit reproduced exactly on PR #527's CI on Linux (not just Windows) — proved the fix necessary.
+- **Dependabot triage written** to `docs/security/audit-log.md` (PR #527 at `24dce24c`). All 38 alerts are transitive; bumping `@modelcontextprotocol/sdk` in `.mcp/server/` alone clears 16 (incl. 2 high). Most "high" vite alerts are dev-server-only, not exploitable in retort's vitest-only usage. Authored the planned-but-empty `audit-log.md` slot from `docs.yaml`.
+- **Prior session's handoff committed** (PR #523 at `6bdcb474`) — was left uncommitted; carried over, fixed off-by-one counts (3 follow-up commits not 2; 6 follow-up changes not 4) and replaced hardcoded `C:/Users/smitj/repos/retort` validation paths with repo-relative ones, per Copilot/CodeRabbit/Codex review feedback.
+- **Bot reviews actioned on all 5 PRs before merge.** Three Copilot `||` markdown table comments on #527 were false positives (file uses single pipes) and skipped.
+
+## Current Blockers
+
+None.
+
+## Next 3 Actions
+
+1. **Bump branches threshold 65 → 70 in `.agentkit/vitest.config.mjs`.** Phase 1 cleanup chore. Small PR. Suite branches are now ~73% — comfortable headroom. Update the comment to reference Phase 2 modules.
+2. **Phase 2 of #520:** `init.mjs` (36.9% branches) + `orchestrator.mjs` (42.3% branches). Same pattern as cost-tracker / check — a focused `*-coverage.test.mjs` file plus minimal helper exports if needed. Each module its own PR; threshold bump 70 → 73 after both land.
+3. **Open remediation PR for `.mcp/server/`** — `cd .mcp/server && npm update` (or bump `@modelcontextprotocol/sdk` directly). Clears 16 alerts including 2 high. Check whether Renovate already has this queued before opening manually.
+
+## How to Validate
+
+Run from the repo root (`retort/`):
+
+```bash
+# Dev is at 24dce24c with all 5 PRs in
+git log --oneline -5
+
+# All checks pass on the latest dev
+(cd .agentkit && pnpm vitest run)
+
+# Threshold still honored at 77/65/80 (bump to 70 is action #1)
+grep -A 3 thresholds .agentkit/vitest.config.mjs
+
+# 38 dependabot alerts unchanged until remediation PRs land
+gh api repos/phoenixvc/retort/dependabot/alerts --jq '[.[] | select(.state=="open")] | length'
+
+# Confirm new audit-log doc exists
+test -f docs/security/audit-log.md && echo "ok"
+```
+
+## Open Risks
+
+- **Sync-integration tests timed out** during a single Windows full-suite run mid-session (5 tests, 15–45s timeouts each) — under FS contention with parallel test runners. Sync-integration passes 93/93 in isolation. Pre-existing flaky behavior, not introduced this session. CI runs on Ubuntu, where it's reliably green.
+- **Coverage branches threshold still at 65** — long-term 80% target not yet restored. Phase 1 done; ratchet will continue across Phase 2 (init + orchestrator) and beyond per #520. Action #1 above starts that.
+- **38 dependabot alerts still open** until remediation PRs land. The triage doc gives the smallest-fix-largest-impact ordering. Most "high" alerts are CVSS-overstated for retort's actual usage (vite dev-server-only, picomatch on trusted globs, js-yaml on trusted spec files).
+- **Orchestrator state file (`.claude/state/orchestrator.json`) is stale from 2026-03-15** — not consulted in this PR-clearing flow. Not a problem for the current /handoff but worth noting if a future session uses /orchestrate phase tracking.
+
+## State Files
+
+- Orchestrator: `.claude/state/orchestrator.json` — stale (2026-03-15), not consulted this session
+- Events: `.claude/state/events.log` — 123 entries pre-session; appending HANDOFF entry now
+- Backlog: `AGENT_BACKLOG.md` — not consulted
+- History: `docs/history/.index.json` — no history doc created (PR-clearing + small fixes; the audit-log.md is itself the institutional record for the dependabot triage)


### PR DESCRIPTION
## Summary

Carries over the prior session's handoff (covering PRs #523-#527: phase 1 of the #520 ratchet, run-cli ENOTEMPTY flake fix, dependabot triage). Per the memory rule, handoff docs must always be committed and pushed.

## Test plan

- [x] File diff is documentation-only (single new file under `docs/handoffs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)