### PR TITLE
docs(handoffs): add 2026-05-10-03 — green queue + #531 triage handoff

### DIFF
--- a/docs/handoffs/2026-05-10-03.md
+++ b/docs/handoffs/2026-05-10-03.md
@@ -1,0 +1,61 @@
+# Session Handoff
+
+**Date:** 2026-05-10 (third session today)
+**Branch:** `dev` (was `chore/coverage-threshold-bump`, `fix/mcp-sdk-bump-528`, `docs/handoff-2026-05-10-02`, `feat/agent-testing/phase2-init-coverage`)
+**Last Commit on dev:** `24dce24c` — docs(security): triage 38 open dependabot alerts (2026-05-10) (#527)
+**Session Duration:** ~2 hours
+**Overall Status:** 3 PRs ready, 1 PR blocked on CI
+
+## What Was Done
+
+Picked up the three "Next 3 Actions" from the prior session's handoff (`docs/handoffs/2026-05-10-02.md`).
+
+- **PR #528 — `chore(coverage): bump suite branches threshold 65 → 70`.** Locks in Phase 1 of #520. Suite branches at 71.51% gives a 1.51% cushion above the new floor. Comment block in `vitest.config.mjs` rewritten to reflect Phase 1 done, Phase 2 in progress, Phase 3 pending. CI status: not yet checked at handoff time.
+- **PR #529 — `fix(mcp): bump @modelcontextprotocol/sdk 1.27.1 → 1.29.0 + migrate to pnpm`.** Clears 16 dependabot alerts (incl. 2 high) on `.mcp/server/`, all transitive via SDK (hono, fast-uri, ip-address, @hono/node-server). Also migrated `.mcp/server/` from npm to pnpm so it matches the rest of the repo. Touches package.json, deletes package-lock.json, adds pnpm-lock.yaml + .npmrc (with `ignore-workspace=true`), updates railway.toml (`pnpm install --frozen-lockfile && pnpm run build`) and nixpacks.toml (corepack + pnpm@9.15.0 in install phase). Verified locally: typecheck clean, build clean (`dist/index.js` 9.5kb), `pnpm audit --ignore-workspace` reports no known vulnerabilities. **Railway deploy needs manual verification on the PR check.**
+- **PR #530 — `docs(handoffs): add 2026-05-10-02`.** Carry-over of the prior session's handoff doc per the memory rule that handoffs must always be committed and pushed.
+- **PR #531 — `test(engine): push init.mjs coverage to 85.75% branches (#520 phase 2)`.** Created by a delegated background subagent that died on an API connection error mid-flight (95 tool uses, 42 minutes). Init.mjs coverage went 36.93% → 85.75% branches. Source change: exported 11 internal helpers from init.mjs (mirrors the pattern of #525). **CI Test job is failing on 5 assertions in init-coverage.test.mjs (lines 934, 1019, 1124, 1184, 1288).** Tests pass locally individually but fail on Linux/CI in the full suite — suspected cross-test mock isolation issue with `vi.doMock('@clack/prompts', ...)` and `cancelMarker` Symbol identity. Detailed debug notes posted as a comment on the PR. **Do not merge until investigated.**
+
+## Bonus
+
+- Saved memory note `feedback_pnpm_consistency.md`: pnpm everywhere in retort. Sub-projects with `package-lock.json` should be flagged as migration candidates.
+
+## Current Blockers
+
+- **PR #531** CI failing — needs Linux/CI repro and a fix to the wizard mocking pattern. See PR comment for hypotheses and possible fixes (1-4).
+- **Phase 2 orchestrator.mjs** — agent died before starting it. No commits exist; nothing to recover.
+
+## Next 3 Actions
+
+1. **Triage PR #531.** Reproduce the 5 CI failures locally (try `--pool=threads --poolOptions.threads.singleThread` or `--no-isolate`), then apply fix (1-4) from the PR comment. If unfixable in <1 hour, close the PR and re-do init.mjs Phase 2 with `vi.mock` (hoisted) instead of `vi.doMock` (per-test).
+2. **Phase 2 orchestrator.mjs** (init.mjs blocker permitting). Module is at branches 42.30%. Same effort as PR #524/#525.
+3. **Verify Railway deploy on PR #529** before merging. The MCP server migrated from npm to pnpm; Railway nixpacks now activates pnpm via corepack. A failed Railway build would block the dependabot remediation.
+
+## How to Validate
+
+```bash
+# This session's PRs
+gh pr list --state open --author "@me" --json number,title,headRefName
+
+# PR #531 CI status
+gh pr view 531 --json statusCheckRollup --jq '.statusCheckRollup[] | select(.name == "Test")'
+
+# Reproduce PR #531 CI failures locally
+cd .agentkit && pnpm vitest run --pool=threads --poolOptions.threads.singleThread engines/node/src/__tests__/init-coverage.test.mjs
+
+# Threshold bump (PR #528) ratchet status
+grep -A2 "branches:" .agentkit/vitest.config.mjs
+```
+
+## Open Risks
+
+- **PR #531 CI red** — handing off as triage item. Do not merge.
+- **Railway deploy** for PR #529 — first build in pnpm/corepack mode. Retry path: revert nixpacks.toml + railway.toml to npm if corepack fails on Railway's nixpacks build.
+- **Branches threshold cushion is thin** (71.51% vs 70 floor on PR #528). Phase 2 (init.mjs alone) takes it to ~74%; adding orchestrator.mjs takes it higher.
+- **Dependabot alerts** — 30 still open after PR #527 (8 already cleared somehow before this session); PR #529 takes that to ~14 once merged. Remaining are .agentkit + root pnpm-lock vite/postcss/picomatch (mostly dev-only).
+
+## State Files
+
+- Orchestrator: stale (2026-03-15), not consulted
+- Events log: not appended this session
+- Handoff archive: this file is `docs/handoffs/2026-05-10-03.md`. Prior: `-02.md` (PR #530), `-01.md` (PR #523)
+- Memory: added `feedback_pnpm_consistency.md` and indexed it in `MEMORY.md`


### PR DESCRIPTION
## Summary

- Adds `docs/handoffs/2026-05-10-03.md` capturing the third session of 2026-05-10.
- Per the always-commit-handoffs memory rule.

## Session recap (covered in the doc)

- **#528** — coverage suite branches threshold 65 → 70 (Phase 1 of #520 locked in)
- **#529** — `@modelcontextprotocol/sdk` 1.27.1 → 1.29.0 + `.mcp/server/` npm → pnpm migration; clears 16 dependabot alerts
- **#530** — handoff -02 carry-over
- **#531** — init.mjs coverage 36.93 → 85.75% branches; **CI red on 5 assertions**, suspected cross-test mock isolation issue with `vi.doMock`

## Next 3 actions (deferred to next session)

1. Triage PR #531 — reproduce CI failures locally, apply fix from PR comment, or close + redo with hoisted `vi.mock`
2. Phase 2 orchestrator.mjs (after #531 unblocks)
3. Verify Railway deploy on #529 (first build in pnpm/corepack mode)

## Test plan

- [x] Doc renders correctly
- [x] No secrets in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added internal development session documentation recording progress tracking, completed actions, identified blockers, upcoming action items, and validation procedures for the development workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phoenixvc/retort/pull/532)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->