### PR TITLE
docs(handoffs): add 2026-05-11 session handoff

### DIFF
--- a/docs/handoffs/2026-05-11.md
+++ b/docs/handoffs/2026-05-11.md
@@ -1,0 +1,63 @@
+# Session Handoff
+
+**Date:** 2026-05-11
+**Branch:** `dev`
+**Last Commit:** `5075b33f` — test(engine): push init.mjs coverage to 85.7% branches (#520 phase 2) (#531)
+**Session Duration:** ~3 hours (spanning 2026-05-10 evening into 2026-05-11 early morning)
+**Overall Status:** HEALTHY — 5 PRs landed; dev green
+
+## What Was Done
+
+- **Cleared green PR queue (4 merges):**
+  - **#528** `chore(coverage): bump suite branches threshold 65 → 70` — Phase 1 of #520 locked in.
+  - **#529** `fix(mcp): bump @modelcontextprotocol/sdk 1.27.1 → 1.29.0 + migrate to pnpm` — cleared 16 dependabot alerts (2 high); migrated `.mcp/server/` from npm to pnpm + corepack.
+  - **#530** `docs(handoffs): add 2026-05-10-02` — carry-over handoff doc.
+  - **#532** `docs(handoffs): add 2026-05-10-03` — green-queue handoff doc bundled per prior session's plan.
+- **Fixed and merged #531** `test(engine): push init.mjs coverage to 85.7% branches (#520 phase 2)`. Branches 36.93% → 85.75%, breaking the Phase 2 blocker.
+- **Diagnosed real root cause** for the Linux CI failures: GitHub Actions sets `process.env.CI=true`, which triggered init.mjs's non-interactive fast path (line 248) BEFORE the wizard ran. All my mock-mechanism iterations (`vi.resetModules` ordering, hoisted `vi.mock`, helper module indirection, static→dynamic import) were chasing the symptom. The actual fix was the one-liner at commit `d08f1054`: `(nonInteractive || process.env.CI) && !flags.__clackPrompts`.
+- Final test-injection pattern: tests pass `__clackPrompts: resolveTestClackPrompts` via `flags`; init.mjs (`.agentkit/engines/node/src/init.mjs:285`) checks `flags.__clackPrompts` first, then `globalThis.__RETORT_TEST_CLACK_PROMPTS__`, then falls back to the real dynamic import of `_clack-prompts.mjs`.
+- New file `.agentkit/engines/node/src/_clack-prompts.mjs` — thin helper wrapping the real `@clack/prompts` import; intentionally kept (provides a stable indirection point even though it's only one of the test escape hatches).
+
+## Current Blockers
+
+None. Dev is green, all 5 of this session's PRs merged, dependabot count dropped 38 → 23.
+
+## Next 3 Actions
+
+1. **Phase 2 of #520 — orchestrator.mjs coverage push.** Module is at branches ~42.30%. Same effort/structure as PR #524 (cost-tracker.mjs), #525 (check.mjs), and #531 (init.mjs). Aim for 85%+ branches and ratchet `vitest.config.mjs` thresholds again afterward.
+2. **Verify Railway deploy on #529 (now merged).** MCP server migrated to pnpm + corepack via nixpacks. First post-merge deploy needs manual check on the Railway dashboard — confirm the corepack-activated pnpm build succeeds. Revert path (if it fails): `.mcp/server/railway.toml` and `.mcp/server/nixpacks.toml` back to npm.
+3. **Phase 3 of #520 — discover.mjs + retort-config-wizard.mjs coverage.** The largest remaining gap; will close out the 80/80/80 target.
+
+## How to Validate
+
+```bash
+# Dev tip should match this session
+git fetch origin && git rev-parse origin/dev   # → 5075b33f
+
+# All PRs from this session merged
+gh pr list --state merged --search "528 OR 529 OR 530 OR 531 OR 532" --json number,title
+
+# Open PRs (only #522 left, unrelated)
+gh pr list --state open --json number,title,headRefName
+
+# Run init test suite locally to confirm wizard tests pass
+pnpm --dir .agentkit vitest run engines/node/src/__tests__/init-coverage.test.mjs
+
+# Threshold cushion vs floor
+grep -A2 "branches:" .agentkit/vitest.config.mjs
+```
+
+## Open Risks
+
+- **Railway deploy unverified** for #529. The corepack/pnpm nixpacks change is in production now. Watch for build failures on the MCP service.
+- **`process.env.CI` is a footgun.** Anywhere else init.mjs / discover.mjs / sync.mjs has `process.env.CI`-based branching is now suspect for the same class of bug (CI takes a different code path than test runs expect). Worth a brief grep before the next test push.
+- **Test-injection escape hatches in init.mjs** (`flags.__clackPrompts`, `globalThis.__RETORT_TEST_CLACK_PROMPTS__`) are now part of the public-ish API surface. They should be marked clearly as test-only and not exposed via the CLI flag parser.
+- **Dependabot still has 23 open alerts** (7 high, 16 moderate). #527's triage doc has the categorization; #529 brought 16 down. Remaining are mostly `.agentkit` and root `pnpm-lock` (vite/postcss/picomatch, mostly dev-only).
+- **Threshold cushion** is now ~74% branches vs the 70 floor (after #531 lands init.mjs Phase 2). Phase 3 will push it higher; current floor doesn't need bumping yet.
+
+## State Files
+
+- Orchestrator: `.claude/state/orchestrator.json` — stale (2026-03-15), not consulted this session
+- Events log: not appended this session
+- Backlog: `AGENT_BACKLOG.md` — not consulted (PR-driven session)
+- Handoff archive: this file is `docs/handoffs/2026-05-11.md`. Prior: `2026-05-10-03.md` (PR #532), `2026-05-10-02.md` (#530), `2026-05-10.md` (#523)


### PR DESCRIPTION
## Summary

- Carry-over handoff doc from the 2026-05-10/11 session that landed PRs #528, #529, #530, #531, #532.
- Records dev tip `5075b33f`, open risks (Railway deploy on #529, `process.env.CI` footgun in init.mjs), and next 3 actions (orchestrator.mjs Phase 2 — now in flight as #533, Railway verify, discover.mjs Phase 3).

## Test plan

- [x] No code changes; docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)