### PR TITLE
test(engine): push discover.mjs + wizard.mjs coverage (#520 phase 3)

### DIFF
--- a/.agentkit/engines/node/src/__tests__/discover-coverage.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/discover-coverage.test.mjs
@@ -1,0 +1,663 @@
+/**
+ * Coverage tests for discover.mjs (#520 phase 3).
+ *
+ * Covers branches not exercised by discover.test.mjs:
+ *   - Each tech stack detector (dotnet, rust, python, go, ruby, java)
+ *   - Framework detection from package.json deps (frontend, backend, css, orm, stateManagement)
+ *   - Testing tool detection paths
+ *   - Documentation artifact detection (dirs vs files)
+ *   - Design system detection (dirs vs files)
+ *   - Cross-cutting concern detection (every category)
+ *   - Infrastructure markers (docker, k8s, terraform, bicep, pulumi)
+ *   - CI markers (gitlab, circleci, jenkins, azure-devops)
+ *   - Monorepo: pnpm-workspace, nx, turbo, lerna, cargo workspace, npm workspaces
+ *   - getPythonDeps: poetry, project.dependencies, project.optional-dependencies
+ *   - detectFromList: csprojRefs, cargoRefs, gemfileRefs, pomRefs, fileExt
+ *   - runDiscover output format: yaml (default) and markdown
+ *   - formatMarkdown: all sections populated + empty-stacks branch
+ *   - .agentkit-repo marker read path
+ *   - Recommendations branches (testing missing, cicd missing, agentkit overlay missing)
+ */
+import { execFileSync } from 'child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runDiscover } from '../discover.mjs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir() {
+  const dir = join(
+    tmpdir(),
+    `discover-cov-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeFile(filePath, content = '') {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, 'utf-8');
+}
+
+function gitInit(cwd) {
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd, stdio: 'ignore' });
+}
+
+function gitCommit(cwd, message) {
+  execFileSync('git', ['add', '-A'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', message], { cwd, stdio: 'ignore' });
+}
+
+async function runOnFixture(projectRoot, flags = {}) {
+  return runDiscover({
+    agentkitRoot: null,
+    projectRoot,
+    flags: { output: 'json', ...flags },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tech stack detection — every detector type
+// ---------------------------------------------------------------------------
+
+describe('runDiscover — stack detection branches', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('detects dotnet stack from .csproj marker', async () => {
+    writeFile(join(tmpDir, 'App.csproj'), '<Project Sdk="Microsoft.NET.Sdk"/>');
+    writeFile(join(tmpDir, 'Program.cs'), '// program');
+    const report = await runOnFixture(tmpDir);
+    expect(report.techStacks.map((s) => s.name)).toContain('dotnet');
+  });
+
+  it('detects rust stack from Cargo.toml', async () => {
+    writeFile(join(tmpDir, 'Cargo.toml'), '[package]\nname = "p"\n');
+    writeFile(join(tmpDir, 'src/main.rs'), 'fn main() {}');
+    const report = await runOnFixture(tmpDir);
+    expect(report.techStacks.map((s) => s.name)).toContain('rust');
+  });
+
+  it('detects python stack from pyproject.toml', async () => {
+    writeFile(join(tmpDir, 'pyproject.toml'), '[project]\nname = "p"\n');
+    writeFile(join(tmpDir, 'app.py'), '# python');
+    const report = await runOnFixture(tmpDir);
+    expect(report.techStacks.map((s) => s.name)).toContain('python');
+  });
+
+  it('detects go stack from go.mod', async () => {
+    writeFile(join(tmpDir, 'go.mod'), 'module example\n');
+    writeFile(join(tmpDir, 'main.go'), 'package main');
+    const report = await runOnFixture(tmpDir);
+    expect(report.techStacks.map((s) => s.name)).toContain('go');
+  });
+
+  it('detects ruby stack from Gemfile', async () => {
+    writeFile(join(tmpDir, 'Gemfile'), 'source "https://rubygems.org"\ngem "rails"\n');
+    writeFile(join(tmpDir, 'app.rb'), '# ruby');
+    const report = await runOnFixture(tmpDir);
+    expect(report.techStacks.map((s) => s.name)).toContain('ruby');
+  });
+
+  it('detects java stack from pom.xml', async () => {
+    writeFile(
+      join(tmpDir, 'pom.xml'),
+      '<project xmlns="http://maven.apache.org/POM/4.0.0"></project>'
+    );
+    writeFile(join(tmpDir, 'src/Main.java'), 'class Main {}');
+    const report = await runOnFixture(tmpDir);
+    expect(report.techStacks.map((s) => s.name)).toContain('java');
+  });
+
+  it('picks primaryStack by file count', async () => {
+    writeFile(join(tmpDir, 'package.json'), '{}');
+    writeFile(join(tmpDir, 'Cargo.toml'), '[package]\nname = "p"\n');
+    for (let i = 0; i < 5; i++) writeFile(join(tmpDir, `src/file${i}.rs`), '');
+    writeFile(join(tmpDir, 'index.js'), '');
+    const report = await runOnFixture(tmpDir);
+    expect(report.primaryStack).toBe('rust');
+  });
+
+  it('no recognised stacks → recommendation emitted', async () => {
+    const report = await runOnFixture(tmpDir);
+    expect(report.techStacks).toEqual([]);
+    expect(report.recommendations.some((r) => r.includes('No recognised tech stacks'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Framework / cross-cutting detection from package.json deps
+// ---------------------------------------------------------------------------
+
+describe('runDiscover — framework + crosscutting detection from npm deps', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('detects react + next.js + tailwind + prisma + redux + winston + auth0', async () => {
+    writeFile(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({
+        dependencies: {
+          react: '^18',
+          next: '^14',
+          tailwindcss: '^3',
+          prisma: '^5',
+          '@reduxjs/toolkit': '^2',
+          winston: '^3',
+          auth0: '^4',
+          redis: '^4',
+          jsonwebtoken: '^9',
+          'launchdarkly-node-server-sdk': '^7',
+        },
+        devDependencies: {
+          vitest: '^4',
+          '@playwright/test': '^1',
+        },
+        peerDependencies: {
+          '@nestjs/swagger': '^7',
+        },
+      })
+    );
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.frontend).toContain('react');
+    expect(report.frameworks.frontend).toContain('next.js');
+    expect(report.frameworks.css).toContain('tailwind');
+    expect(report.frameworks.orm).toContain('prisma');
+    expect(report.frameworks.stateManagement).toContain('redux');
+    expect(report.testing).toContain('vitest');
+    expect(report.testing).toContain('playwright');
+    expect(report.crosscutting.logging).toContain('winston');
+    expect(report.crosscutting.authentication).toContain('auth0');
+    expect(report.crosscutting.authentication).toContain('custom-jwt');
+    expect(report.crosscutting.caching).toContain('redis');
+    expect(report.crosscutting.featureFlags).toContain('launchdarkly');
+    expect(report.crosscutting.apiPatterns).toContain('swagger');
+  });
+
+  it('detects framework from config file when deps are absent', async () => {
+    writeFile(join(tmpDir, 'package.json'), JSON.stringify({ dependencies: {} }));
+    writeFile(join(tmpDir, 'tailwind.config.js'), 'module.exports = {};');
+    writeFile(join(tmpDir, 'next.config.js'), 'module.exports = {};');
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.css).toContain('tailwind');
+    expect(report.frameworks.frontend).toContain('next.js');
+  });
+
+  it('detects asp.net-core via Program.cs marker', async () => {
+    writeFile(join(tmpDir, 'Program.cs'), 'using Microsoft.AspNetCore.Builder;');
+    writeFile(join(tmpDir, 'App.csproj'), '<Project></Project>');
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.backend).toContain('asp.net-core');
+  });
+
+  it('detects ef-core via .csproj reference', async () => {
+    writeFile(
+      join(tmpDir, 'App.csproj'),
+      `<Project Sdk="Microsoft.NET.Sdk">
+         <ItemGroup>
+           <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+         </ItemGroup>
+       </Project>`
+    );
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.orm).toContain('ef-core');
+  });
+
+  it('detects axum via cargo ref', async () => {
+    writeFile(
+      join(tmpDir, 'Cargo.toml'),
+      `[package]
+name = "p"
+
+[dependencies]
+axum = "0.7"
+`
+    );
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.backend).toContain('axum');
+  });
+
+  it('detects rails via Gemfile ref', async () => {
+    writeFile(join(tmpDir, 'Gemfile'), 'gem "rails", "~> 7.0"\n');
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.backend).toContain('rails');
+  });
+
+  it('detects spring-boot via pom.xml ref', async () => {
+    writeFile(
+      join(tmpDir, 'pom.xml'),
+      `<project>
+         <dependencies>
+           <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter</artifactId></dependency>
+         </dependencies>
+       </project>`
+    );
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.backend).toContain('spring-boot');
+  });
+
+  it('detects sass via .scss file extension', async () => {
+    writeFile(join(tmpDir, 'package.json'), JSON.stringify({ dependencies: {} }));
+    writeFile(join(tmpDir, 'styles/main.scss'), '// scss');
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.css).toContain('sass');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Python deps — section-aware parsing
+// ---------------------------------------------------------------------------
+
+describe('runDiscover — getPythonDeps parser branches', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('parses poetry-style dependencies', async () => {
+    writeFile(
+      join(tmpDir, 'pyproject.toml'),
+      `[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.110"
+django = "^5"
+`
+    );
+    writeFile(join(tmpDir, 'app.py'), '# py');
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.backend).toContain('fastapi');
+    expect(report.frameworks.backend).toContain('django');
+  });
+
+  it('parses PEP 621 [project] dependencies array (single-line)', async () => {
+    writeFile(
+      join(tmpDir, 'pyproject.toml'),
+      `[project]
+name = "p"
+dependencies = ["flask", "sqlalchemy"]
+`
+    );
+    writeFile(join(tmpDir, 'app.py'), '# py');
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.backend).toContain('flask');
+    expect(report.frameworks.orm).toContain('sqlalchemy');
+  });
+
+  it('parses PEP 621 [project] dependencies array (multi-line)', async () => {
+    writeFile(
+      join(tmpDir, 'pyproject.toml'),
+      `[project]
+name = "p"
+dependencies = [
+  "flask",
+  "pytest",
+]
+`
+    );
+    writeFile(join(tmpDir, 'app.py'), '# py');
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.backend).toContain('flask');
+    expect(report.testing).toContain('pytest');
+  });
+
+  it('parses [project.optional-dependencies] section', async () => {
+    writeFile(
+      join(tmpDir, 'pyproject.toml'),
+      `[project]
+name = "p"
+
+[project.optional-dependencies]
+dev = ["pytest", "fastapi"]
+`
+    );
+    writeFile(join(tmpDir, 'app.py'), '# py');
+    const report = await runOnFixture(tmpDir);
+    expect(report.testing).toContain('pytest');
+    expect(report.frameworks.backend).toContain('fastapi');
+  });
+
+  it('parses requirements.txt', async () => {
+    writeFile(
+      join(tmpDir, 'requirements.txt'),
+      `flask>=2.0
+django==5.0
+pytest # for testing
+sqlalchemy[asyncio]>=2
+`
+    );
+    writeFile(join(tmpDir, 'app.py'), '# py');
+    writeFile(join(tmpDir, 'pyproject.toml'), '[project]\nname = "p"\n');
+    const report = await runOnFixture(tmpDir);
+    expect(report.frameworks.backend).toContain('flask');
+    expect(report.frameworks.backend).toContain('django');
+    expect(report.testing).toContain('pytest');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Documentation / design system / infra / CI detection
+// ---------------------------------------------------------------------------
+
+describe('runDiscover — documentation, design, infra, CI markers', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('detects PRD dir, ADR dir, OpenAPI file, technical specs dir', async () => {
+    mkdirSync(join(tmpDir, 'docs/prd'), { recursive: true });
+    mkdirSync(join(tmpDir, 'adr'), { recursive: true });
+    writeFile(join(tmpDir, 'docs/api/openapi.yaml'), 'openapi: 3.0.0\n');
+    mkdirSync(join(tmpDir, 'docs/specs'), { recursive: true });
+    const report = await runOnFixture(tmpDir);
+    const names = report.documentation.map((d) => d.name);
+    expect(names).toContain('prd');
+    expect(names).toContain('adr');
+    expect(names).toContain('apiSpec');
+    expect(names).toContain('technicalSpec');
+  });
+
+  it('detects design system markers: storybook, figma-tokens, brand-guide', async () => {
+    mkdirSync(join(tmpDir, '.storybook'), { recursive: true });
+    writeFile(join(tmpDir, 'figma-tokens.json'), '{}');
+    writeFile(join(tmpDir, 'brand.yaml'), 'brand: name\n');
+    const report = await runOnFixture(tmpDir);
+    expect(report.designSystem).toContain('storybook');
+    expect(report.designSystem).toContain('figma-tokens');
+    expect(report.designSystem).toContain('brand-guide');
+  });
+
+  it('detects infra markers: docker, terraform, bicep, pulumi', async () => {
+    writeFile(join(tmpDir, 'Dockerfile'), 'FROM node:22');
+    writeFile(join(tmpDir, 'main.tf'), 'resource "x" "y" {}');
+    writeFile(join(tmpDir, 'main.bicep'), 'param name string');
+    writeFile(join(tmpDir, 'Pulumi.yaml'), 'name: p');
+    const report = await runOnFixture(tmpDir);
+    expect(report.infrastructure).toContain('docker');
+    expect(report.infrastructure).toContain('terraform');
+    expect(report.infrastructure).toContain('bicep');
+    expect(report.infrastructure).toContain('pulumi');
+  });
+
+  it('detects CI systems: gitlab-ci, circleci, jenkins, azure-devops', async () => {
+    writeFile(join(tmpDir, '.gitlab-ci.yml'), 'stages: [build]');
+    writeFile(join(tmpDir, '.circleci/config.yml'), 'version: 2');
+    writeFile(join(tmpDir, 'Jenkinsfile'), 'pipeline {}');
+    writeFile(join(tmpDir, 'azure-pipelines.yml'), 'trigger: main');
+    const report = await runOnFixture(tmpDir);
+    expect(report.cicd).toContain('gitlab-ci');
+    expect(report.cicd).toContain('circleci');
+    expect(report.cicd).toContain('jenkins');
+    expect(report.cicd).toContain('azure-devops');
+  });
+
+  it('no CI/CD → recommendation emitted', async () => {
+    writeFile(join(tmpDir, 'package.json'), JSON.stringify({ name: 'p' }));
+    const report = await runOnFixture(tmpDir);
+    expect(report.cicd).toEqual([]);
+    expect(report.recommendations.some((r) => r.includes('No CI/CD'))).toBe(true);
+  });
+
+  it('emits recommendation when techStacks present but no testing tool', async () => {
+    writeFile(join(tmpDir, 'package.json'), JSON.stringify({ name: 'p' }));
+    const report = await runOnFixture(tmpDir);
+    expect(report.testing).toEqual([]);
+    expect(report.recommendations.some((r) => r.includes('No testing frameworks'))).toBe(true);
+  });
+
+  it('emits recommendation when .agentkit-repo marker is missing', async () => {
+    const report = await runOnFixture(tmpDir);
+    expect(report.recommendations.some((r) => r.includes('.agentkit-repo'))).toBe(true);
+  });
+
+  it('reads .agentkit-repo marker and records overlay', async () => {
+    writeFile(join(tmpDir, '.agentkit-repo'), 'my-overlay\n');
+    const report = await runOnFixture(tmpDir);
+    expect(report.repository.agentkitOverlay).toBe('my-overlay');
+  });
+
+  it('detects .env config marker', async () => {
+    writeFile(join(tmpDir, '.env.example'), 'FOO=bar');
+    const report = await runOnFixture(tmpDir);
+    expect(report.crosscutting.envConfig).toBe('env-vars');
+  });
+
+  it('detects appsettings.json config marker', async () => {
+    writeFile(join(tmpDir, 'appsettings.json'), '{}');
+    const report = await runOnFixture(tmpDir);
+    expect(report.crosscutting.envConfig).toBe('config-files');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Monorepo detection
+// ---------------------------------------------------------------------------
+
+describe('runDiscover — monorepo detection', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('detects pnpm-workspace + turborepo + nx + lerna', async () => {
+    writeFile(join(tmpDir, 'pnpm-workspace.yaml'), 'packages:\n  - "apps/*"\n');
+    writeFile(join(tmpDir, 'turbo.json'), '{}');
+    writeFile(join(tmpDir, 'nx.json'), '{}');
+    writeFile(join(tmpDir, 'lerna.json'), '{}');
+    const report = await runOnFixture(tmpDir);
+    expect(report.monorepo.detected).toBe(true);
+    expect(report.monorepo.tools).toEqual(
+      expect.arrayContaining(['pnpm-workspace', 'turborepo', 'nx', 'lerna'])
+    );
+  });
+
+  it('detects npm workspaces from package.json', async () => {
+    writeFile(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'mono', workspaces: ['packages/*'] })
+    );
+    const report = await runOnFixture(tmpDir);
+    expect(report.monorepo.detected).toBe(true);
+    expect(report.monorepo.tools).toContain('npm-workspaces');
+  });
+
+  it('detects cargo workspace', async () => {
+    writeFile(
+      join(tmpDir, 'Cargo.toml'),
+      `[workspace]
+members = ["crates/a", "crates/b"]
+`
+    );
+    writeFile(join(tmpDir, 'crates/a/src/lib.rs'), '');
+    const report = await runOnFixture(tmpDir);
+    expect(report.monorepo.detected).toBe(true);
+    expect(report.monorepo.tools).toContain('cargo-workspace');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Output formats
+// ---------------------------------------------------------------------------
+
+describe('runDiscover — output formats', () => {
+  let tmpDir;
+  let logSpy;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    writeFile(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'p', dependencies: { react: '^18' } })
+    );
+    writeFile(join(tmpDir, 'src/x.ts'), '');
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('default yaml output emits yaml-shaped string', async () => {
+    await runDiscover({ agentkitRoot: null, projectRoot: tmpDir, flags: {} });
+    const calls = logSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((c) => /techStacks:/.test(c))).toBe(true);
+  });
+
+  it('markdown output renders sections + recommendations', async () => {
+    writeFile(join(tmpDir, 'Dockerfile'), 'FROM node:22');
+    mkdirSync(join(tmpDir, 'docs/prd'), { recursive: true });
+    writeFile(join(tmpDir, 'figma-tokens.json'), '{}');
+    writeFile(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({ dependencies: { react: '^18', winston: '^3' } })
+    );
+    writeFile(join(tmpDir, 'pnpm-workspace.yaml'), 'packages:\n  - "apps/*"\n');
+    writeFile(join(tmpDir, '.github/workflows/ci.yml'), 'name: CI');
+
+    await runDiscover({ agentkitRoot: null, projectRoot: tmpDir, flags: { output: 'markdown' } });
+    const calls = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(calls).toMatch(/# Discovery Report/);
+    expect(calls).toMatch(/## Tech Stacks/);
+    expect(calls).toMatch(/## Frameworks/);
+    expect(calls).toMatch(/## Documentation/);
+    expect(calls).toMatch(/## Design System/);
+    expect(calls).toMatch(/## Cross-Cutting/);
+    expect(calls).toMatch(/## Monorepo/);
+    expect(calls).toMatch(/## Infrastructure/);
+    expect(calls).toMatch(/## CI\/CD/);
+    expect(calls).toMatch(/## Project Structure/);
+  });
+
+  it('markdown output handles empty techStacks gracefully', async () => {
+    rmSync(join(tmpDir, 'package.json'));
+    rmSync(join(tmpDir, 'src'), { recursive: true });
+    await runDiscover({ agentkitRoot: null, projectRoot: tmpDir, flags: { output: 'markdown' } });
+    const calls = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(calls).toMatch(/No recognised tech stacks detected\./);
+    expect(calls).toMatch(/## Recommendations/);
+  });
+
+  it('userContext arg is logged and emitted', async () => {
+    await runDiscover({
+      agentkitRoot: null,
+      projectRoot: tmpDir,
+      flags: { output: 'json', _args: ['migrate', 'to', 'next15'] },
+    });
+    const calls = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(calls).toMatch(/Context: migrate to next15/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agentkitRoot integration — project.yaml respects explicit commit convention
+// ---------------------------------------------------------------------------
+
+describe('runDiscover — agentkitRoot integration', () => {
+  let tmpDir;
+  let agentkitRoot;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    agentkitRoot = join(tmpDir, '.agentkit');
+    mkdirSync(join(agentkitRoot, 'spec'), { recursive: true });
+    writeFile(join(tmpDir, 'package.json'), JSON.stringify({ name: 'p' }));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('respects commitConvention=none in spec/project.yaml', async () => {
+    writeFile(
+      join(agentkitRoot, 'spec/project.yaml'),
+      `process:
+  commitConvention: none
+`
+    );
+    writeFile(join(tmpDir, '.commitlintrc.json'), '{}');
+    const report = await runDiscover({
+      agentkitRoot,
+      projectRoot: tmpDir,
+      flags: { output: 'json' },
+    });
+    expect(report.commitConvention).toBe('none');
+  });
+
+  it('runs git-log heuristic when no file config + project.yaml has explicit value', async () => {
+    writeFile(
+      join(agentkitRoot, 'spec/project.yaml'),
+      `process:
+  commitConvention: conventional
+`
+    );
+    gitInit(tmpDir);
+    writeFileSync(join(tmpDir, 'a.txt'), '');
+    gitCommit(tmpDir, 'feat: initial');
+
+    const report = await runDiscover({
+      agentkitRoot,
+      projectRoot: tmpDir,
+      flags: { output: 'json' },
+    });
+    // Either matches via git log heuristic or remains null — both are valid outcomes
+    expect(['conventional', null]).toContain(report.commitConvention);
+  });
+
+  it('handles malformed project.yaml gracefully', async () => {
+    writeFile(join(agentkitRoot, 'spec/project.yaml'), '%%%not yaml%%%');
+    const report = await runDiscover({
+      agentkitRoot,
+      projectRoot: tmpDir,
+      flags: { output: 'json' },
+    });
+    expect(report).toBeDefined();
+  });
+});

--- a/.agentkit/engines/node/src/__tests__/retort-config-wizard-coverage.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/retort-config-wizard-coverage.test.mjs
@@ -1,0 +1,812 @@
+/**
+ * Coverage tests for retort-config-wizard.mjs (#520 phase 3).
+ *
+ * Covers branches not exercised by retort-config-wizard.test.mjs:
+ *   - loadAgentCatalog edge cases (missing dir, malformed yaml, non-object docs,
+ *     non-array categories, agents without id)
+ *   - loadFeatureList edge cases (missing file, malformed yaml, no features key)
+ *   - detectContextFromRepo edge cases (missing marker, unreadable marker,
+ *     missing project.yaml, malformed project.yaml)
+ *   - serializeConfig list-null path
+ *   - Full interactive wizard path with all branches, using the
+ *     flags.__clackPrompts injection point (matches init.mjs pattern).
+ *   - Cancellation at each prompt
+ *   - Agent management opt-in + remap workflow
+ *   - Feature override opt-in (deviation tracking)
+ *   - clack import failure → non-interactive fallback
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import yaml from 'js-yaml';
+import { tmpdir } from 'os';
+import { resolve } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir() {
+  const dir = resolve(
+    tmpdir(),
+    `retort-config-wizard-cov-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Build a clack mock that returns the queued answers in order.
+ * Returns the mock factory plus a `prompts` array for assertions.
+ */
+function makeClackMock(answers) {
+  const queue = [...answers];
+  const next = () => {
+    if (queue.length === 0) throw new Error('clack mock answer queue exhausted');
+    return queue.shift();
+  };
+  const cancelMarker = Symbol('cancel');
+  return {
+    cancelMarker,
+    factory: () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      isCancel: (v) => v === cancelMarker,
+      text: vi.fn(async () => next()),
+      select: vi.fn(async () => next()),
+      multiselect: vi.fn(async () => next()),
+      confirm: vi.fn(async () => next()),
+      group: vi.fn(),
+      spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// loadAgentCatalog / loadFeatureList / detectContextFromRepo edge cases
+// (exercised indirectly via the wizard's non-interactive path)
+// ---------------------------------------------------------------------------
+
+describe('retort-config-wizard.mjs — spec loaders edge cases', () => {
+  let tmpRoot;
+  let projectRoot;
+  let agentkitRoot;
+
+  beforeEach(() => {
+    tmpRoot = makeTmpDir();
+    projectRoot = resolve(tmpRoot, 'project');
+    agentkitRoot = resolve(tmpRoot, 'agentkit');
+    mkdirSync(projectRoot, { recursive: true });
+    mkdirSync(agentkitRoot, { recursive: true });
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('handles missing spec/agents and spec/features.yaml gracefully', async () => {
+    // No spec/ directory at all
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { 'non-interactive': true },
+      prefill: { projectName: 'no-spec', stacks: [], enabledFeatures: null },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed?.project?.name).toBe('no-spec');
+  });
+
+  it('skips malformed agent yaml files', async () => {
+    const agentsDir = resolve(agentkitRoot, 'spec', 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    // Mix of malformed, non-object, non-array category, and agent missing id
+    writeFileSync(resolve(agentsDir, 'broken.yaml'), '%%%not yaml%%%', 'utf-8');
+    writeFileSync(resolve(agentsDir, 'null.yaml'), 'null\n', 'utf-8');
+    writeFileSync(
+      resolve(agentsDir, 'scalar.yaml'),
+      yaml.dump({ engineering: 'not-an-array' }),
+      'utf-8'
+    );
+    writeFileSync(
+      resolve(agentsDir, 'no-id.yaml'),
+      yaml.dump({ engineering: [{ name: 'no-id-agent' }] }),
+      'utf-8'
+    );
+    // Non-yaml extension — should be filtered out by readdir filter
+    writeFileSync(resolve(agentsDir, 'readme.md'), '# not yaml', 'utf-8');
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { 'non-interactive': true },
+      prefill: { projectName: 'malformed-specs', stacks: [], enabledFeatures: null },
+    });
+
+    expect(existsSync(resolve(projectRoot, '.retortconfig'))).toBe(true);
+  });
+
+  it('handles malformed features.yaml', async () => {
+    const specDir = resolve(agentkitRoot, 'spec');
+    mkdirSync(specDir, { recursive: true });
+    writeFileSync(resolve(specDir, 'features.yaml'), '%%%not yaml%%%', 'utf-8');
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { 'non-interactive': true },
+      prefill: { projectName: 'bad-features', stacks: [], enabledFeatures: null },
+    });
+
+    expect(existsSync(resolve(projectRoot, '.retortconfig'))).toBe(true);
+  });
+
+  it('handles features.yaml without features key', async () => {
+    const specDir = resolve(agentkitRoot, 'spec');
+    mkdirSync(specDir, { recursive: true });
+    writeFileSync(resolve(specDir, 'features.yaml'), yaml.dump({ presets: {} }), 'utf-8');
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { 'non-interactive': true },
+      prefill: { projectName: 'no-features-key', stacks: [], enabledFeatures: null },
+    });
+
+    expect(existsSync(resolve(projectRoot, '.retortconfig'))).toBe(true);
+  });
+
+  it('detectContextFromRepo: marker present, project.yaml malformed', async () => {
+    // Marker present, project.yaml malformed → stacks default to []
+    writeFileSync(resolve(projectRoot, '.agentkit-repo'), 'my-detected\n', 'utf-8');
+    const specDir = resolve(agentkitRoot, 'spec');
+    mkdirSync(specDir, { recursive: true });
+    writeFileSync(resolve(specDir, 'project.yaml'), '%%%not yaml%%%', 'utf-8');
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { 'non-interactive': true },
+      // No prefill — exercises detectContextFromRepo
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed?.project?.name).toBe('my-detected');
+  });
+
+  it('detectContextFromRepo: marker present but empty', async () => {
+    writeFileSync(resolve(projectRoot, '.agentkit-repo'), '   \n', 'utf-8');
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { 'non-interactive': true },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    // Falls back to basename(projectRoot) when marker is whitespace-only
+    expect(parsed?.project?.name).toBeTruthy();
+  });
+
+  it('detectContextFromRepo: project.yaml present with stacks + features', async () => {
+    const specDir = resolve(agentkitRoot, 'spec');
+    mkdirSync(specDir, { recursive: true });
+    writeFileSync(
+      resolve(specDir, 'project.yaml'),
+      yaml.dump({
+        stack: { languages: ['typescript', 'python'] },
+        features: { 'team-orchestration': true, 'cost-tracking': false },
+      }),
+      'utf-8'
+    );
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { 'non-interactive': true },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed?.project?.stacks).toEqual(['typescript', 'python']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Interactive wizard — full happy path + branches
+// ---------------------------------------------------------------------------
+
+describe('runRetortConfigWizard — interactive path', () => {
+  let tmpRoot;
+  let projectRoot;
+  let agentkitRoot;
+  let originalIsTTY;
+
+  beforeEach(() => {
+    tmpRoot = makeTmpDir();
+    projectRoot = resolve(tmpRoot, 'project');
+    agentkitRoot = resolve(tmpRoot, 'agentkit');
+    mkdirSync(projectRoot, { recursive: true });
+
+    // Set up a minimal agentkitRoot with one agent and one non-core feature
+    const specDir = resolve(agentkitRoot, 'spec');
+    const agentsDir = resolve(specDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(
+      resolve(agentsDir, 'engineering.yaml'),
+      yaml.dump({
+        engineering: [
+          { id: 'backend', name: 'Backend Engineer', accepts: ['implement'] },
+          { id: 'frontend', name: 'Frontend Engineer', accepts: ['implement'] },
+        ],
+      }),
+      'utf-8'
+    );
+    writeFileSync(
+      resolve(specDir, 'features.yaml'),
+      yaml.dump({
+        features: [
+          {
+            id: 'team-orchestration',
+            name: 'Orch',
+            category: 'core',
+            alwaysOn: true,
+            default: true,
+          },
+          { id: 'cost-tracking', name: 'Cost', category: 'infra', alwaysOn: false, default: true },
+          {
+            id: 'drift-check',
+            name: 'Drift',
+            category: 'quality',
+            alwaysOn: false,
+            default: false,
+          },
+        ],
+      }),
+      'utf-8'
+    );
+
+    // Force interactive path
+    originalIsTTY = process.stdout.isTTY;
+    process.stdout.isTTY = true;
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.stdout.isTTY = originalIsTTY;
+    rmSync(tmpRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('full happy path: prompts → write config with all sections', async () => {
+    const mock = makeClackMock([
+      'my-interactive-project', // projectName text
+      'service', // projectType text
+      ['typescript', 'node'], // stacks multiselect
+      ['gdpr', 'none', 'soc2'], // compliance multiselect (none filtered)
+      true, // configureAgents confirm
+      ['backend'], // disabledAgents multiselect
+      true, // wantRemap confirm
+      ['frontend'], // remapChoices multiselect
+      'quality', // remap team text
+      true, // configureFeatures confirm
+      ['drift-check'], // selectedFeatures multiselect (drift-check is off by default, cost-tracking on by default)
+    ]);
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: ['typescript'], enabledFeatures: null },
+    });
+
+    const raw = readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8');
+    const parsed = yaml.load(raw.replace(/^#.*$/gm, '').trim());
+
+    expect(parsed.project.name).toBe('my-interactive-project');
+    expect(parsed.project.type).toBe('service');
+    expect(parsed.project.stacks).toEqual(['typescript', 'node']);
+    // 'none' filtered out of compliance
+    expect(parsed.project.compliance).toEqual(['gdpr', 'soc2']);
+    // Disabled agent is null
+    expect(parsed.agents.backend).toBeNull();
+    // Remapped agent has team
+    expect(parsed.agents.frontend).toEqual({ team: 'quality' });
+    // drift-check is OFF by default but user enabled it → recorded as true
+    expect(parsed.features['drift-check']).toBe(true);
+    // cost-tracking is ON by default and user disabled it (not in selectedFeatures) → recorded as false
+    expect(parsed.features['cost-tracking']).toBe(false);
+  });
+
+  it('cancel at projectName prompt aborts', async () => {
+    const mock = makeClackMock([]);
+    mock.factory = () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      isCancel: () => true,
+      text: vi.fn(async () => mock.cancelMarker),
+      select: vi.fn(async () => mock.cancelMarker),
+      multiselect: vi.fn(async () => mock.cancelMarker),
+      confirm: vi.fn(async () => mock.cancelMarker),
+    });
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+
+    expect(existsSync(resolve(projectRoot, '.retortconfig'))).toBe(false);
+  });
+
+  it('cancel at projectType prompt aborts', async () => {
+    const mock = makeClackMock([
+      'my-project',
+      // next prompt (type) returns the cancel marker
+    ]);
+    // Override to return cancel after first text answer
+    const origFactory = mock.factory;
+    let callCount = 0;
+    mock.factory = () => {
+      const base = origFactory();
+      base.text = vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) return 'my-project';
+        return mock.cancelMarker;
+      });
+      return base;
+    };
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+
+    expect(existsSync(resolve(projectRoot, '.retortconfig'))).toBe(false);
+  });
+
+  it('cancel at stacks multiselect aborts', async () => {
+    const mock = makeClackMock([]);
+    let mCount = 0;
+    mock.factory = () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      isCancel: (v) => v === mock.cancelMarker,
+      text: vi.fn(async () => 'ok'),
+      select: vi.fn(async () => 'ok'),
+      multiselect: vi.fn(async () => {
+        mCount++;
+        if (mCount === 1) return mock.cancelMarker; // first multiselect (stacks)
+        return [];
+      }),
+      confirm: vi.fn(async () => false),
+    });
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+    expect(existsSync(resolve(projectRoot, '.retortconfig'))).toBe(false);
+  });
+
+  it('cancel at compliance multiselect aborts', async () => {
+    const mock = makeClackMock([]);
+    let mCount = 0;
+    mock.factory = () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      isCancel: (v) => v === mock.cancelMarker,
+      text: vi.fn(async () => 'ok'),
+      multiselect: vi.fn(async () => {
+        mCount++;
+        if (mCount === 1) return [];
+        if (mCount === 2) return mock.cancelMarker; // compliance
+        return [];
+      }),
+      confirm: vi.fn(async () => false),
+    });
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+    expect(existsSync(resolve(projectRoot, '.retortconfig'))).toBe(false);
+  });
+
+  it('cancel at configureAgents confirm aborts', async () => {
+    const mock = makeClackMock([]);
+    mock.factory = () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      isCancel: (v) => v === mock.cancelMarker,
+      text: vi.fn(async () => 'ok'),
+      multiselect: vi.fn(async () => []),
+      confirm: vi.fn(async () => mock.cancelMarker), // first confirm = configureAgents
+    });
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+    expect(existsSync(resolve(projectRoot, '.retortconfig'))).toBe(false);
+  });
+
+  it('cancel at disabledAgents multiselect aborts', async () => {
+    const mock = makeClackMock([]);
+    let mCount = 0;
+    mock.factory = () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      isCancel: (v) => v === mock.cancelMarker,
+      text: vi.fn(async () => 'ok'),
+      multiselect: vi.fn(async () => {
+        mCount++;
+        if (mCount === 1) return []; // stacks
+        if (mCount === 2) return []; // compliance
+        if (mCount === 3) return mock.cancelMarker; // disabledAgents
+        return [];
+      }),
+      confirm: vi.fn(async () => true), // configureAgents = true
+    });
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+    expect(existsSync(resolve(projectRoot, '.retortconfig'))).toBe(false);
+  });
+
+  it('cancel at configureFeatures confirm aborts', async () => {
+    const mock = makeClackMock([]);
+    let confirmCount = 0;
+    mock.factory = () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      isCancel: (v) => v === mock.cancelMarker,
+      text: vi.fn(async () => 'ok'),
+      multiselect: vi.fn(async () => []),
+      confirm: vi.fn(async () => {
+        confirmCount++;
+        if (confirmCount === 1) return false; // configureAgents = false
+        return mock.cancelMarker; // configureFeatures = cancel
+      }),
+    });
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+    expect(existsSync(resolve(projectRoot, '.retortconfig'))).toBe(false);
+  });
+
+  it('cancel at selectedFeatures multiselect aborts', async () => {
+    const mock = makeClackMock([]);
+    let mCount = 0;
+    let confirmCount = 0;
+    mock.factory = () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      isCancel: (v) => v === mock.cancelMarker,
+      text: vi.fn(async () => 'ok'),
+      multiselect: vi.fn(async () => {
+        mCount++;
+        if (mCount === 1 || mCount === 2) return []; // stacks, compliance
+        return mock.cancelMarker; // features multiselect = cancel
+      }),
+      confirm: vi.fn(async () => {
+        confirmCount++;
+        return confirmCount === 1 ? false : true; // skip agents, configure features
+      }),
+    });
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+    expect(existsSync(resolve(projectRoot, '.retortconfig'))).toBe(false);
+  });
+
+  it('agent step skipped when catalog is empty', async () => {
+    // Remove agents to make catalog empty
+    rmSync(resolve(agentkitRoot, 'spec', 'agents'), { recursive: true, force: true });
+
+    const mock = makeClackMock([
+      'p',
+      's',
+      [],
+      [],
+      false, // configureFeatures = no
+    ]);
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed.agents).toBeUndefined();
+  });
+
+  it('features step skipped when no non-core features exist', async () => {
+    // Replace features with only alwaysOn ones
+    writeFileSync(
+      resolve(agentkitRoot, 'spec', 'features.yaml'),
+      yaml.dump({
+        features: [
+          { id: 'core-only', name: 'Core', category: 'core', alwaysOn: true, default: true },
+        ],
+      }),
+      'utf-8'
+    );
+
+    const mock = makeClackMock([
+      'p',
+      's',
+      [],
+      [],
+      false, // configureAgents = no
+    ]);
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed.features).toBeUndefined();
+  });
+
+  it('feature deviations from defaults are recorded; matches are omitted', async () => {
+    // Defaults: cost-tracking=on, drift-check=off
+    // User selects only drift-check → cost-tracking off (deviation), drift-check on (deviation)
+    const mock = makeClackMock([
+      'p',
+      's',
+      [],
+      [],
+      false, // configureAgents = no
+      true, // configureFeatures = yes
+      ['drift-check'], // user wants only drift-check
+    ]);
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed.features['drift-check']).toBe(true);
+    expect(parsed.features['cost-tracking']).toBe(false);
+  });
+
+  it('no agent overrides written when configureAgents = no', async () => {
+    const mock = makeClackMock([
+      'p',
+      's',
+      [],
+      [],
+      false, // configureAgents = no
+      false, // configureFeatures = no
+    ]);
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed.agents).toBeUndefined();
+    expect(parsed.features).toBeUndefined();
+  });
+
+  it('remap step skipped when wantRemap = no', async () => {
+    const mock = makeClackMock([
+      'p',
+      's',
+      [],
+      [],
+      true, // configureAgents = yes
+      ['backend'], // disable backend
+      false, // wantRemap = no
+      false, // configureFeatures = no
+    ]);
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: null },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed.agents).toEqual({ backend: null });
+  });
+
+  it('clack import failure falls back to non-interactive', async () => {
+    const failFactory = () => {
+      throw new Error('clack unavailable');
+    };
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: failFactory },
+      prefill: { projectName: 'fallback-project', stacks: ['rust'], enabledFeatures: null },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed.project.name).toBe('fallback-project');
+    expect(parsed.project.stacks).toEqual(['rust']);
+  });
+
+  it('prefill enabledFeatures filters features that exist in spec', async () => {
+    const mock = makeClackMock([
+      'p',
+      's',
+      [],
+      [],
+      false, // skip agents
+      true, // configure features
+      ['drift-check'], // user picks only drift-check
+    ]);
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      // enabledFeatures includes a feature not in spec — should be filtered
+      prefill: { projectName: 'seed', stacks: [], enabledFeatures: ['drift-check', 'nonexistent'] },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed.features['drift-check']).toBe(true);
+  });
+
+  it('initialStacks filters out unknown stacks from prefill', async () => {
+    const mock = makeClackMock([
+      'p',
+      's',
+      ['typescript'], // user keeps typescript
+      [],
+      false,
+      false,
+    ]);
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { __clackPrompts: mock.factory },
+      // 'foobar' is not in stackOptions → filtered out of initialStacks
+      prefill: { projectName: 'seed', stacks: ['typescript', 'foobar'], enabledFeatures: null },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed.project.stacks).toEqual(['typescript']);
+  });
+
+  it('falls back to non-interactive when isTTY is false', async () => {
+    process.stdout.isTTY = false;
+
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: {},
+      prefill: { projectName: 'tty-off', stacks: [], enabledFeatures: null },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed.project.name).toBe('tty-off');
+  });
+
+  it('falls back to non-interactive when ci flag is set', async () => {
+    const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+    await runRetortConfigWizard({
+      agentkitRoot,
+      projectRoot,
+      flags: { ci: true },
+      prefill: { projectName: 'ci-mode', stacks: [], enabledFeatures: null },
+    });
+
+    const parsed = yaml.load(
+      readFileSync(resolve(projectRoot, '.retortconfig'), 'utf-8').replace(/^#.*$/gm, '').trim()
+    );
+    expect(parsed.project.name).toBe('ci-mode');
+  });
+});

--- a/.agentkit/engines/node/src/retort-config-wizard.mjs
+++ b/.agentkit/engines/node/src/retort-config-wizard.mjs
@@ -210,7 +210,14 @@ export async function runRetortConfigWizard({ agentkitRoot, projectRoot, flags =
   // --- Interactive wizard ---
   let clack;
   try {
-    clack = await import('@clack/prompts');
+    if (typeof flags.__clackPrompts === 'function') {
+      clack = await flags.__clackPrompts();
+    } else if (typeof globalThis.__RETORT_TEST_CLACK_PROMPTS__ === 'function') {
+      clack = await globalThis.__RETORT_TEST_CLACK_PROMPTS__();
+    } else {
+      const { resolveClackPrompts } = await import('./_clack-prompts.mjs');
+      clack = await resolveClackPrompts();
+    }
   } catch {
     console.warn(
       '[retort] @clack/prompts not available — falling back to non-interactive config generation.'


### PR DESCRIPTION
## Summary

Final leg of the #520 coverage ratchet. Pushes branch/line/function coverage on the two remaining files in the engine well past the 80/80/80 target.

| File | Branches | Lines | Functions |
|------|----------|-------|-----------|
| `discover.mjs` | 52.1% → **93.2%** | 65.0% → **97.7%** | 70.0% → **98.3%** |
| `retort-config-wizard.mjs` | 26.7% → **83.1%** | 38.9% → **96.1%** | 40.0% → **100%** |

## Changes

- **New** `engines/node/src/__tests__/discover-coverage.test.mjs` — 41 tests covering every stack detector, framework detection (deps / config / csproj / cargo / gemfile / pom refs), `getPythonDeps` parser branches (poetry, PEP 621 `[project]` single + multi-line, `[project.optional-dependencies]`, requirements.txt), monorepo indicators (pnpm, turbo, nx, lerna, npm workspaces, cargo workspace), docs/design/infra/CI markers, `agentkitRoot` + `project.yaml` `commitConvention` integration, and yaml/markdown/json output formats.

- **New** `engines/node/src/__tests__/retort-config-wizard-coverage.test.mjs` — 26 tests covering all spec-loader edge cases (missing dir, malformed yaml, non-object docs, non-array categories, agents missing id, missing/malformed features.yaml, missing features key), `detectContextFromRepo` branches (marker present/empty, project.yaml present/malformed), the full interactive wizard (happy path with all sections + cancellation at every prompt + agent management + remap + feature deviation tracking), the clack-import-failure fallback, and TTY/CI mode detection.

- **Source change**: `retort-config-wizard.mjs` adopts the same `flags.__clackPrompts` / `globalThis.__RETORT_TEST_CLACK_PROMPTS__` / `_clack-prompts.mjs` pattern that `init.mjs` already uses. This enables deterministic interactive-path tests without the `vi.mock` race that `_clack-prompts.mjs` exists to avoid.

## Test plan

- [x] `pnpm --dir .agentkit vitest run engines/node/src/__tests__/retort-config-wizard-coverage.test.mjs engines/node/src/__tests__/retort-config-wizard.test.mjs --coverage --coverage.include="engines/node/src/retort-config-wizard.mjs"` → 36 tests pass, 83.06% branch coverage
- [x] `pnpm --dir .agentkit vitest run engines/node/src/__tests__/discover-coverage.test.mjs engines/node/src/__tests__/discover.test.mjs --coverage --coverage.include="engines/node/src/discover.mjs"` → 63 tests pass, 93.16% branch coverage
- [x] `pnpm --dir .agentkit exec prettier --check` on all touched files → clean
- [x] Full suite run: 1879 passed, 2 pre-existing flakes (sync-integration `--overwrite` tests and one git-log timing test under load — not introduced by this PR)

## Follow-ups

This unlocks the threshold bump (currently `branches: 70`); a separate PR will raise the floor once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)