### PR TITLE
fix(engine): await fire-and-forget emit/appendEvent to fix test-pollution flake

### DIFF
--- a/.agentkit/engines/node/src/discover.mjs
+++ b/.agentkit/engines/node/src/discover.mjs
@@ -1130,7 +1130,7 @@ export async function runDiscover({ agentkitRoot, projectRoot, flags }) {
   );
 
   const fwCountForEvent = Object.values(report.frameworks).flat().length;
-  emitEvent(
+  await emitEvent(
     projectRoot,
     'discover_completed',
     {

--- a/.agentkit/engines/node/src/doctor.mjs
+++ b/.agentkit/engines/node/src/doctor.mjs
@@ -537,7 +537,7 @@ export async function runDoctor({ agentkitRoot, projectRoot, flags = {} }) {
     }
   }
 
-  emitEvent(
+  await emitEvent(
     projectRoot,
     'doctor_completed',
     {

--- a/.agentkit/engines/node/src/orchestrator.mjs
+++ b/.agentkit/engines/node/src/orchestrator.mjs
@@ -1070,7 +1070,7 @@ export async function runOrchestrate({ agentkitRoot, projectRoot, flags }) {
     const released = releaseLock(projectRoot);
     if (released) {
       console.log('[agentkit:orchestrate] Lock released.');
-      appendEvent(projectRoot, 'lock_force_released');
+      await appendEvent(projectRoot, 'lock_force_released');
     } else {
       console.log('[agentkit:orchestrate] No lock to release.');
     }
@@ -1104,7 +1104,7 @@ export async function runOrchestrate({ agentkitRoot, projectRoot, flags }) {
         return;
       }
       saveState(projectRoot, result.state);
-      appendEvent(projectRoot, 'phase_set', { phase, phase_name: PHASES[phase] });
+      await appendEvent(projectRoot, 'phase_set', { phase, phase_name: PHASES[phase] });
       console.log(`[agentkit:orchestrate] Phase set to ${phase} — ${PHASES[phase]}`);
       console.log(`Next action: ${result.state.next_action}`);
       return;
@@ -1117,7 +1117,7 @@ export async function runOrchestrate({ agentkitRoot, projectRoot, flags }) {
     console.log(`Current phase: ${state.current_phase}/5 — ${state.phase_name}`);
     console.log(`Next action: ${state.next_action}`);
 
-    appendEvent(projectRoot, 'orchestrate_invoked', {
+    await appendEvent(projectRoot, 'orchestrate_invoked', {
       phase: state.current_phase,
       phase_name: state.phase_name,
       ...(userContext ? { userContext } : {}),


### PR DESCRIPTION
## Summary

Root-causes and fixes the test-pollution flakes flagged in the 2026-05-11-03 handoff. **It is not module-state pollution** — it's five unawaited fire-and-forget `emitEvent` / `appendEvent` calls in `runDiscover`, `runDoctor`, and `runOrchestrate` leaving async I/O in flight after their async functions returned.

**Failure modes seen on CI run 25657195749 (#537's 78-floor attempt):**

- `orchestrator-coverage > default flow … appends event` — `readEvents()` ran before the unawaited `appendEvent('orchestrate_invoked', …)` finished, so the assertion saw `[]` instead of containing `orchestrate_invoked`.
- `discover-coverage > respects commitConvention=none …` (and the git-log-heuristic case) — the unawaited `emitEvent('discover_completed', …)` raced with the test's `afterEach` `rmSync`, recreating `.agentkit/state/` after cleanup had started and crashing teardown with `ENOTEMPTY: directory not empty, rmdir '/tmp/discover-cov-…/.agentkit'`.

The handoff doc's hypothesis (export `_resetForTesting()`, refactor module state) doesn't apply — the existing `clearTeamsSpecCache()` + `loadTeamIdsFromSpec(fx.agentkitRoot)` calls in `beforeEach` already cover that risk. The actual fix is much smaller: five `await` keywords.

The `doctor.mjs` emit was unawaited too — same `ENOENT` warning visible in CI stderr but doesn't trip a test failure because the doctor tests use a mock projectRoot. Awaited for consistency.

## Test plan

- [x] Run the two target test files 3× in succession — 89/89 passing each time, no `ENOTEMPTY` in afterEach.
- [x] Run the full engine suite — 1967/1975 passing (the 3 failures are pre-existing `sync-integration.test.mjs` timeouts under load, unrelated).
- [x] Confirm the affected functions (`runDiscover`, `runDoctor`, `runOrchestrate`) are all already `async`, so adding `await` is safe.
- [ ] CI green on this PR (no test-pollution failures, even if the branches floor is bumped past 75 in a follow-up).

## Diff

5-line `await` insertion across three source files. No test changes, no spec changes, no sync regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)