### PR TITLE
docs(handoffs): add 2026-05-11-05 session handoff

### DIFF
--- a/docs/handoffs/2026-05-11-05.md
+++ b/docs/handoffs/2026-05-11-05.md
@@ -74,8 +74,8 @@ Not creating one — the foundation work is at the "PR open, not merged" stage. 
 
 ## PRs in flight
 
-| PR                      | Repo               | Base   | Status                              |
-| ----------------------- | ------------------ | ------ | ----------------------------------- |
-| phoenixvc/retort#540    | retort             | dev    | open (prior session's handoff)      |
-| phoenixvc/retort#541    | retort             | dev    | draft, CI green, mergeable          |
-| phoenixvc/org-meta#12   | org-meta           | master | draft, mergeable, clean             |
+| PR                    | Repo     | Base   | Status                         |
+| --------------------- | -------- | ------ | ------------------------------ |
+| phoenixvc/retort#540  | retort   | dev    | open (prior session's handoff) |
+| phoenixvc/retort#541  | retort   | dev    | draft, CI green, mergeable     |
+| phoenixvc/org-meta#12 | org-meta | master | draft, mergeable, clean        |

--- a/docs/handoffs/2026-05-11-05.md
+++ b/docs/handoffs/2026-05-11-05.md
@@ -1,0 +1,81 @@
+# Session Handoff
+
+**Date:** 2026-05-11T12:15:00Z
+**Branch:** feat/skills/gh-bot-reader (work) + docs/handoff-2026-05-11-05 (this doc)
+**Last Commit on dev:** 8eb21690 — fix(engine): await fire-and-forget emitEvent/appendEvent to prevent test-pollution flakes (#539)
+**Session Duration:** ~2h
+**Overall Status:** HEALTHY — foundation PR for gh-bot-reader landed in draft, all CI green, follow-up tickets filed
+
+## What Was Done
+
+- **Picked up baton ticket `62ccea85-…` (gh-bot-reader skill)** per the 2026-05-11-04 handoff's "Next 3 Actions" list. Confirmed prior session's #2 → #1 → #3 order is still the right shape; started with #2 because it's the reusable primitive consumed by #1.
+- **Caught a layout mismatch in the ticket spec.** Ticket assumed `packages/gh-bot-reader/` (TS pnpm package) + `.agentkit/templates/skills/gh-bot-reader/`. Neither directory exists in retort. All 32 `source: org-meta` skills are pure markdown agent-instruction files (e.g. `plugin-review-router/SKILL.md`). Pivoted to markdown-skill-in-org-meta to match existing convention. Companion path is flat (`adapter-coderabbit.md`) because the sync engine rejects subdirectory companions.
+- **Opened paired draft PRs:**
+  - **phoenixvc/retort#541** — registers `gh-bot-reader` in `.agentkit/spec/skills.yaml` with `source: org-meta`, `scope: global`, `companions: [adapter-coderabbit.md]`. Includes `chore(sync)` commit cleaning up pre-existing drift across 32 SKILL.md files (CRLF→LF, frontmatter quote style, indentation), plus a follow-up restore commit for two `settings.json` files that local sync misleadingly flagged as stale. All 14 CI checks green.
+  - **phoenixvc/org-meta#12** — `skills/gh-bot-reader/SKILL.md` (API contract, severity heuristics, GraphQL query shape, caching, bot identification by username) + `adapter-coderabbit.md` (canonical reference adapter with field mapping, severity table, body sanitisation, known gotchas).
+- **Filed 5 adapter follow-up tickets in baton** (Copilot `5d55f3ae`, Renovate `2c2b3e2c`, Codecov `13f27dc8`, Sonatype `009f87ff`, Claude `80353338`) — each with concrete acceptance bars referencing the CodeRabbit adapter as the canonical shape. Renovate ticket explicitly notes the REST-fetch fallback for body-posting bots so future body-only adapters follow the same pattern.
+- **Filed 2 architecture tickets in baton** capturing long-term concerns the user raised mid-session:
+  - `b2059c5d-…` — retort shippability strategy (vendor-on-sync vs npm publish vs git subtree vs status quo). 32 `source: org-meta` skills already create a hidden cross-repo dependency.
+  - `a401eba1-…` — universal-vs-specialist skill placement policy (org-meta vs `scope: project` vs consuming-repo specialist). No written rule today.
+- **Updated baton ticket `62ccea85`** to `inprogress`, owner `claude-code`, with full agent-message audit log linking the PRs, follow-up tickets, architecture tickets, and design-pivot rationale.
+
+## Current Blockers
+
+None for the foundation work. PRs #541 and #12 are draft pending human pass + merge. Adapter follow-ups are blocked-by both merging.
+
+## Next 3 Actions
+
+1. **Review and merge phoenixvc/retort#541 + phoenixvc/org-meta#12 as a pair.** They are independently mergeable but conceptually one change — the spec entry in retort would dangle if org-meta content is not also merged, and vice versa. Convert both from draft to ready-for-review when comfortable. Foundation PR scope is deliberately minimal (one reference adapter); each remaining bot adapter is its own follow-up PR.
+2. **Pick up the 5 adapter tickets** (`5d55f3ae` Copilot, `2c2b3e2c` Renovate, `13f27dc8` Codecov, `009f87ff` Sonatype, `80353338` Claude). They can ship in any order or in parallel because they are independent companion files. Renovate is the most informative second adapter because it's the first body-posting bot (vs review-comment) and locks in the REST-fetch pattern other body-only adapters will reuse.
+3. **Then move to ticket `fb2e982d-…` `/cleanup` command** (baton `feat(commands): add /cleanup`). gh-bot-reader is its dependency — once the foundation merges, the `bots` scope of `/cleanup` can call the skill and surface findings. Aggregator ticket `b33a9248-…` follows after `/cleanup --json` schema v1 is stable.
+
+## How to Validate
+
+```bash
+# Confirm foundation PR is in scope and green
+gh api repos/phoenixvc/retort/pulls/541 --jq '{title, mergeable, draft}'
+gh api repos/phoenixvc/retort/commits/feat/skills/gh-bot-reader/check-runs \
+  --jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped")] | length'
+
+# Confirm paired org-meta PR exists
+gh api repos/phoenixvc/org-meta/pulls/12 --jq '{title, mergeable, draft}'
+
+# Confirm baton ticket state
+curl -s -H "Accept: application/json" \
+  -H "Authorization: $BATON_AUTH" \
+  "https://baton-backend.up.railway.app/api/tasks/62ccea85-975f-4b4c-ae0b-9582098346ee" \
+  | jq '{status, owner_type, agent_name}'
+
+# Confirm 5 adapter follow-ups + 2 architecture tickets land in the retort baton project
+curl -s -H "Accept: application/json" \
+  -H "Authorization: $BATON_AUTH" \
+  "https://baton-backend.up.railway.app/api/tasks?projectId=597f4f94-4540-4001-a4ed-58ede68d0e47" \
+  | jq '[.[] | select(.title | test("gh-bot-reader|shippability|placement policy"))] | length'
+```
+
+## Open Risks
+
+- **Sync engine non-determinism** between local Windows and CI Linux runners. Local sync flagged `.cursor/settings.json` and `.windsurf/settings.json` as stale and removed them; CI's sync regenerated them, breaking the drift check. Worked around via a restore commit. Worth investigating separately — file as a baton ticket if it bites a second time. Suspect: scaffold-once cleanup logic firing differently when a new skill is registered.
+- **Companion-path constraint not documented.** The sync engine rejects subdirectory companion paths with `must be a .md filename, no subdirectories` but the `.agentkit/spec/skills.yaml` header comment block describes companions as relative paths under the skill directory. Worth updating the header comment, or relaxing the constraint to allow `adapters/` subdirs (the latter would make adapter naming cleaner — `adapters/coderabbit.md` reads better than `adapter-coderabbit.md`).
+- **Architecture decisions sitting as tickets, not in code.** Foundation PR chose markdown-skill-in-org-meta defensibly, but neither baton ticket (`b2059c5d` shippability, `a401eba1` placement policy) is actually decided. If `/cleanup` work starts before those land, the same questions resurface for any new skill it spins out.
+- **org-meta default branch is `master`, not `main`.** PR #12 targets `master` correctly, but anyone working in org-meta should be aware — most other phoenixvc repos use `main` or `dev`.
+
+## State Files
+
+- Orchestrator: `.claude/state/orchestrator.json` — last updated 2026-03-11, unaffected this session
+- Events: `.claude/state/events.log` — unchanged this session (work is tracked in baton, not events.log)
+- Backlog: `AGENT_BACKLOG.md` — unchanged (real backlog is the baton retort project, 175 tasks)
+- Tasks: `.claude/state/tasks/` — no task files created this session; baton is the authoritative task graph
+- **Baton retort project (`597f4f94-…`)**: foundation ticket inprogress with owner `claude-code` + agent-message audit log; 5 new adapter tickets and 2 architecture tickets added (`todo`)
+
+## History doc
+
+Not creating one — the foundation work is at the "PR open, not merged" stage. Once retort#541 and org-meta#12 merge, a `feature` history doc at `docs/history/feature/` would capture the architectural decisions (markdown-skill vs TS-package, companion-path flatness, drift-check workaround) for future reference. Worth doing then, not now.
+
+## PRs in flight
+
+| PR                      | Repo               | Base   | Status                              |
+| ----------------------- | ------------------ | ------ | ----------------------------------- |
+| phoenixvc/retort#540    | retort             | dev    | open (prior session's handoff)      |
+| phoenixvc/retort#541    | retort             | dev    | draft, CI green, mergeable          |
+| phoenixvc/org-meta#12   | org-meta           | master | draft, mergeable, clean             |


### PR DESCRIPTION
## Summary

Session handoff covering the gh-bot-reader foundation work:

- Paired draft PRs **phoenixvc/retort#541** + **phoenixvc/org-meta#12** (foundation: spec entry + SKILL.md + CodeRabbit reference adapter)
- 5 adapter follow-up tickets filed in baton (Copilot, Renovate, Codecov, Sonatype, Claude)
- 2 architecture tickets filed in baton (retort shippability strategy, skill placement policy)
- Sync-engine non-determinism risk documented for future investigation

## Test plan

- [ ] No code changes — handoff doc only
- [ ] Conventional Commits format on title (`docs(handoffs)`)
- [ ] Targets `dev` (integration branch)