### PR TITLE
docs(handoffs): add 2026-05-11-06 session handoff

### DIFF
--- a/docs/handoffs/2026-05-11-06.md
+++ b/docs/handoffs/2026-05-11-06.md
@@ -1,0 +1,86 @@
+# Session Handoff
+
+**Date:** 2026-05-11T15:30:00Z
+**Branch:** feat/skills/gh-bot-reader (work) — continues 2026-05-11-05
+**Last Commit on branch:** 20f94bf2 — fix(skills/gh-bot-reader): vendor org-meta@f004389 pagination + 30-PR-cap fixes
+**Session Duration:** ~3h (continuation of -05)
+**Overall Status:** HEALTHY — all 13 CI checks green, 2 rounds of bot review feedback addressed, sync engine bug permanently fixed
+
+## What Was Done
+
+Continuation of 2026-05-11-05. Flipped retort#541 + org-meta#12 from draft to ready-for-review, then processed two rounds of bot feedback and root-caused/fixed the sync engine bug from the prior session's Open Risk #1.
+
+**Round 1 fixes (Copilot):**
+
+- Added `headRefOid` + `headRef.target.committedDate` to the canonical GraphQL query so the documented `new_since_push` contract is actually implementable. Previously the query didn't fetch the head-commit timestamp the contract referenced.
+- Moved cache path from CWD-relative `.claude/state/cache/` to home-relative `~/.claude/cache/gh-bot-reader/` to match the rest of the `.claude/` tooling conventions; reworded the "per-session" wording — the 60s TTL is the ephemerality mechanism, not directory deletion.
+- Algorithm step 2 in `SKILL.md` now explicitly notes the head-commit timestamp comes from the same review-threads query (instead of inviting reliance on `pr.updatedAt`).
+- Source: org-meta#12 commit `2e7ef19`; vendored: retort#541 commit `c3f0fa0a`.
+
+**Sync engine permanent fix (retort#541 commit `c67eeb30`):**
+
+- Root cause: `.agentkit/engines/node/src/platform-syncer.mjs:1243-1262` (`copyOrgMetaFile`) returned false on local divergence (skipping the tmpDir write), but `.agentkit/engines/node/src/scaffold-engine.mjs:388-426` (`cleanStaleFiles`) then deleted the local file as a stale orphan because it was absent from `newManifestFiles`. The two behaviours actively contradicted each other — "preserve" then "delete what you just preserved" — and only manifested on local re-syncs that had a previousManifest. CI was always green because it has no prior manifest.
+- Fix: on divergence, write LOCAL content (not src) to tmpDir so the file flows through manifest registration. `cleanStaleFiles` then sees it as still-known and leaves it alone. The post-sync write-back is a no-op against the existing on-disk file. Updated the existing "non-destructive contract" regression test from asserting the broken implementation to asserting the actual contract.
+- Verified: `pnpm --dir .agentkit retort:sync` now reports 0 stale cleanups; previously deleted 32 files. All 16 org-meta sync tests pass.
+
+**Round 2 fixes (Codex P1+P2 + Copilot nit):**
+
+- Renamed GraphQL cursor variable from `$after` to `$endCursor`. `gh api graphql --paginate` only auto-paginates when the variable is literally named `$endCursor` — with `$after`, the documented invocation silently fetches the first 100 threads and stops.
+- Added `--limit 1000` to the `gh pr list` invocation. Default cap is 30, was silently truncating older open PRs in busy repos and contradicting the "scans all open PRs" contract.
+- Switched `comments(first: 100)` to `comments(first: 1) { totalCount }`. The adapter only reads `nodes[0]` (originating bot comment); fetching all replies wasted payload and `nodes.length` was wrong for threads with more than 100 comments.
+- Source: org-meta#12 commit `f004389`; vendored: retort#541 commit `20f94bf2`.
+
+## Current Blockers
+
+None. retort#541 and org-meta#12 are ready-for-review, 13/13 CI green, mergeable. Pending human review pass.
+
+## Next 3 Actions
+
+1. **Review and merge retort#541 + org-meta#12 as a pair.** Same blocker shape as prior handoff, but the PR is now richer: 3 substantive Copilot fixes (round 1) + 3 substantive Codex/Copilot fixes (round 2) + the sync engine bug fix from Open Risk #1. All commits are atomic and revertable.
+2. **File a baton ticket for the deferred drift items in org-meta.** Bot reviewers flagged 5+ pre-existing items in vendored skill outputs that are *not* introduced by #541 and live in org-meta sources: `writing-skills/SKILL.md` line 643 numbering (1→3 skip), `react-components/SKILL.md` line 24 indentation, trailing whitespace in 4 SKILL.md files (writing-skills, subagent-task-execution, enhance-prompt, coding). Separate cleanup PR against org-meta `master`; out of scope for the foundation.
+3. **File a baton ticket for the secondary sync bug** — "legitimate upstream org-meta changes don't propagate without manual vendor copy". Today's engine fix only resolved the destructive cleanup; the "preserving local copy" branch still fires on every legitimate upstream update, requiring `cp` workarounds (commits `c3f0fa0a` and `20f94bf2` are both manual). Proper fix: port the managed-file three-way merge model from `scaffold-engine.mjs:144-218` to `copyOrgMetaFile` — hash-track the last-synced source content; if local hash equals stored hash, update; if local diverged, preserve+warn.
+
+Then resume from the prior handoff's queue: 5 adapter follow-up tickets (Renovate first as the most informative second adapter), then `/cleanup` ticket `fb2e982d`.
+
+## How to Validate
+
+```bash
+gh pr checks 541 --repo phoenixvc/retort | grep -cE "pass"
+gh pr view 541 --repo phoenixvc/retort --json mergeable,mergeStateStatus,isDraft
+gh pr view 12 --repo phoenixvc/org-meta --json mergeable,mergeStateStatus,isDraft
+
+git --no-pager log --oneline dev..feat/skills/gh-bot-reader
+
+# Engine fix repro — should report 0 stale cleanups
+pnpm --dir .agentkit retort:sync 2>&1 | grep -E "Cleaned|preserving local copy" | grep "Cleaned"
+
+# Regression test
+pnpm --dir .agentkit vitest run engines/node/src/__tests__/sync-org-meta-skills.test.mjs
+```
+
+## Open Risks
+
+- **Upstream propagation gap (unchanged from -05).** The engine fix in `c67eeb30` only resolved the destructive cleanup. The user-edit-vs-upstream-update distinction still doesn't exist for org-meta files — every legitimate upstream update will require manual file copy until hash-tracking lands. See Next Action #3. Without this, the same `cp` workaround will recur on every adapter follow-up PR.
+- **Architecture decisions still as tickets, not code.** `b2059c5d` (retort shippability strategy) and `a401eba1` (universal-vs-specialist placement policy) still unresolved. Today's two manual-vendor commits (`c3f0fa0a`, `20f94bf2`) are the symptom — the underlying decision about whether `source: org-meta` vendoring should be authoritative-upstream or local-overridable hasn't been made.
+- **Drift items deferred.** Bot reviewers flagged 5+ items in vendored output that are pre-existing org-meta content (numbering, whitespace, indent). They surface in #541 only because it touches `.agents/skills/` for the first time. Without a separate org-meta cleanup PR, the same items will resurface on every new skill registration (`/cleanup` and the 5 adapter follow-ups will all trip them).
+- **Bot review rate limits / token exhaustion.** First-round CodeRabbit review hit "Rate limit exceeded — out of usage credits" on retort#541 (free tier). Second round completed but only because review was limited to incremental diffs. Adapter follow-ups will hit the same wall — plan for CodeRabbit gaps and rely on Copilot/Codex as primary reviewers.
+
+## State Files
+
+- Orchestrator: `.claude/state/orchestrator.json` — unchanged this session
+- Events: `.claude/state/events.log` — appended with this handoff event
+- Backlog: `AGENT_BACKLOG.md` — unchanged (baton retort project is authoritative)
+- Tasks: `.claude/state/tasks/` — no task files created this session
+- Baton retort project (`597f4f94-…`): foundation ticket `62ccea85` still inprogress with `owner: claude-code`; no new tickets from this session (Next Actions #2 + #3 will add 2 new ones)
+
+## History doc
+
+Not creating one — work is still at "PR open, not merged" stage. Once retort#541 and org-meta#12 merge, a `feature` history doc covering both rounds of review fixes + the sync engine bug fix + the manual-vendor workaround pattern is warranted at `docs/history/feature/`.
+
+## PRs in flight
+
+| PR                    | Repo     | Base   | Status                                                                       |
+| --------------------- | -------- | ------ | ---------------------------------------------------------------------------- |
+| phoenixvc/retort#540  | retort   | dev    | open (prior handoffs)                                                        |
+| phoenixvc/retort#541  | retort   | dev    | open, ready-for-review, 13/13 CI green, mergeable_state=blocked (needs review) |
+| phoenixvc/org-meta#12 | org-meta | master | open, ready-for-review, CI green, mergeable_state=unstable                   |

--- a/docs/handoffs/2026-05-11-06.md
+++ b/docs/handoffs/2026-05-11-06.md
@@ -37,7 +37,7 @@ None. retort#541 and org-meta#12 are ready-for-review, 13/13 CI green, mergeable
 ## Next 3 Actions
 
 1. **Review and merge retort#541 + org-meta#12 as a pair.** Same blocker shape as prior handoff, but the PR is now richer: 3 substantive Copilot fixes (round 1) + 3 substantive Codex/Copilot fixes (round 2) + the sync engine bug fix from Open Risk #1. All commits are atomic and revertable.
-2. **File a baton ticket for the deferred drift items in org-meta.** Bot reviewers flagged 5+ pre-existing items in vendored skill outputs that are *not* introduced by #541 and live in org-meta sources: `writing-skills/SKILL.md` line 643 numbering (1→3 skip), `react-components/SKILL.md` line 24 indentation, trailing whitespace in 4 SKILL.md files (writing-skills, subagent-task-execution, enhance-prompt, coding). Separate cleanup PR against org-meta `master`; out of scope for the foundation.
+2. **File a baton ticket for the deferred drift items in org-meta.** Bot reviewers flagged 5+ pre-existing items in vendored skill outputs that are _not_ introduced by #541 and live in org-meta sources: `writing-skills/SKILL.md` line 643 numbering (1→3 skip), `react-components/SKILL.md` line 24 indentation, trailing whitespace in 4 SKILL.md files (writing-skills, subagent-task-execution, enhance-prompt, coding). Separate cleanup PR against org-meta `master`; out of scope for the foundation.
 3. **File a baton ticket for the secondary sync bug** — "legitimate upstream org-meta changes don't propagate without manual vendor copy". Today's engine fix only resolved the destructive cleanup; the "preserving local copy" branch still fires on every legitimate upstream update, requiring `cp` workarounds (commits `c3f0fa0a` and `20f94bf2` are both manual). Proper fix: port the managed-file three-way merge model from `scaffold-engine.mjs:144-218` to `copyOrgMetaFile` — hash-track the last-synced source content; if local hash equals stored hash, update; if local diverged, preserve+warn.
 
 Then resume from the prior handoff's queue: 5 adapter follow-up tickets (Renovate first as the most informative second adapter), then `/cleanup` ticket `fb2e982d`.
@@ -79,8 +79,8 @@ Not creating one — work is still at "PR open, not merged" stage. Once retort#5
 
 ## PRs in flight
 
-| PR                    | Repo     | Base   | Status                                                                       |
-| --------------------- | -------- | ------ | ---------------------------------------------------------------------------- |
-| phoenixvc/retort#540  | retort   | dev    | open (prior handoffs)                                                        |
+| PR                    | Repo     | Base   | Status                                                                         |
+| --------------------- | -------- | ------ | ------------------------------------------------------------------------------ |
+| phoenixvc/retort#540  | retort   | dev    | open (prior handoffs)                                                          |
 | phoenixvc/retort#541  | retort   | dev    | open, ready-for-review, 13/13 CI green, mergeable_state=blocked (needs review) |
-| phoenixvc/org-meta#12 | org-meta | master | open, ready-for-review, CI green, mergeable_state=unstable                   |
+| phoenixvc/org-meta#12 | org-meta | master | open, ready-for-review, CI green, mergeable_state=unstable                     |


### PR DESCRIPTION
## Summary

Session handoff continuing 2026-05-11-05. Captures:

- Flipped retort#541 + org-meta#12 from draft → ready-for-review
- Round-1 bot review fixes (`headRefOid` + `committedDate`, cache path, algorithm step 2)
- Permanent sync engine fix for the "preserving local copy + cleanStaleFiles" interaction (handoff -05 Open Risk #1)
- Round-2 bot review fixes (`$endCursor` pagination, `--limit 1000`, `comments(first: 1) + totalCount`)

## Test plan

- [x] Handoff file follows existing template at `docs/handoffs/`
- [x] All claimed commits exist on `feat/skills/gh-bot-reader` (`c3f0fa0a`, `c67eeb30`, `20f94bf2`)
- [x] All claimed CI checks green on retort#541 head
- [x] Validation commands in handoff are copy-paste runnable

🤖 Generated with [Claude Code](https://claude.com/claude-code)