### PR TITLE
chore(skills): re-vendor 5 SKILL.md drift fixes from org-meta#13

### DIFF
--- a/.agents/skills/coding/SKILL.md
+++ b/.agents/skills/coding/SKILL.md
@@ -1,42 +1,48 @@
 ---
 name: coding
-description: "General coding best practices and software engineering principles to build robust, maintainable, and scalable software."
+description: 'General coding best practices and software engineering principles to build robust, maintainable, and scalable software.'
 ---
 
 # General Coding Best Practices
 
 ## Overview
+
 This skill provides a set of core principles and practices for software development. Use this when implementing new features, refactoring existing code, or reviewing code to ensure high quality and maintainability.
 
 ## Core Principles
+
 - **DRY (Don't Repeat Yourself):** Avoid logic duplication. If you find yourself writing the same code twice, abstract it.
 - **KISS (Keep It Simple, Stupid):** Prefer simple, straightforward solutions over complex ones. Avoid over-engineering.
 - **YAGNI (You Ain't Gonna Need It):** Don't implement features or abstractions until they are actually needed.
 - **SOLID Principles:**
-    - Single Responsibility: A class/function should have one reason to change.
-    - Open/Closed: Software entities should be open for extension but closed for modification.
-    - Liskov Substitution: Subtypes must be substitutable for their base types.
-    - Interface Segregation: Many client-specific interfaces are better than one general-purpose interface.
-    - Dependency Inversion: Depend on abstractions, not concretions.
+  - Single Responsibility: A class/function should have one reason to change.
+  - Open/Closed: Software entities should be open for extension but closed for modification.
+  - Liskov Substitution: Subtypes must be substitutable for their base types.
+  - Interface Segregation: Many client-specific interfaces are better than one general-purpose interface.
+  - Dependency Inversion: Depend on abstractions, not concretions.
 
 ## Implementation Guidelines
+
 - **Clean Code:** Use descriptive names for variables, functions, and classes. Write code that is easy to read and understand.
 - **Small Functions:** Keep functions small and focused on a single task.
 - **Error Handling:** Use proactive error handling. Validate inputs and handle exceptions gracefully.
-- **Documentation:** Document the *why*, not the *what*. Use self-documenting code where possible.
+- **Documentation:** Document the _why_, not the _what_. Use self-documenting code where possible.
 - **Security:** Sanitize inputs, avoid hardcoding secrets, and follow the principle of least privilege.
 - **Performance:** Be mindful of time and space complexity, but avoid premature optimization.
 
 ## Automated Analysis & Quality Control
-- **Static Analysis & Linting:** Every project MUST have automated linting, formatting and static analysis (e.g., ESLint, Prettier, Ruff, Sonar). 
-    - **Check:** Identify if these tools are configured.
-    - **Propose:** If missing, immediately propose adding them (e.g., `npm install --save-dev eslint`).
+
+- **Static Analysis & Linting:** Every project MUST have automated linting, formatting and static analysis (e.g., ESLint, Prettier, Ruff, Sonar).
+  - **Check:** Identify if these tools are configured.
+  - **Propose:** If missing, immediately propose adding them (e.g., `npm install --save-dev eslint`).
 - **Automated Tests:** Ensure there is a test runner configured (e.g., Jest, Pytest).
-    - **Check:** Look for `tests/` directory or test configurations in `package.json`/`pyproject.toml`.
-    - **Propose:** If missing, propose a testing framework and initial setup.
+  - **Check:** Look for `tests/` directory or test configurations in `package.json`/`pyproject.toml`.
+  - **Propose:** If missing, propose a testing framework and initial setup.
 
 ## Verifying Code Changes
+
 Before completing any task, you MUST perform the following verification loop:
+
 1.  **Simplification:** Use the code-simplifier plugin to make the code cleaner and more maintainable.
 2.  **Self-Code Review:**
     - Review the changes against the task requirements.
@@ -53,6 +59,7 @@ Before completing any task, you MUST perform the following verification loop:
     - **Verification:** Ensure all tests pass. If they fail, fix the implementation or the test.
 
 ## Key Principles
+
 - **Clarity over Cleverness:** Write code for humans first, machines second.
 - **Consistency:** Follow the established patterns and style of the existing codebase.
 - **Composition over Inheritance:** Prefer combining simple objects to build complex ones rather than creating deep inheritance hierarchies.

--- a/.agents/skills/enhance-prompt/SKILL.md
+++ b/.agents/skills/enhance-prompt/SKILL.md
@@ -2,8 +2,8 @@
 name: enhance-prompt
 description: Transforms vague UI ideas into polished, Stitch-optimized prompts. Enhances specificity, adds UI/UX keywords, injects design system context, and structures output for better generation results.
 allowed-tools:
-  - "Read"
-  - "Write"
+  - 'Read'
+  - 'Write'
 ---
 
 # Enhance Prompt for Stitch
@@ -21,6 +21,7 @@ This guide contains up-to-date recommendations that may supersede or complement 
 ## When to Use This Skill
 
 Activate when a user wants to:
+
 - Polish a UI prompt before sending to Stitch
 - Improve a prompt that produced poor results
 - Add design system consistency to a simple idea
@@ -34,31 +35,33 @@ Follow these steps to enhance any prompt:
 
 Evaluate what's missing from the user's prompt:
 
-| Element | Check for | If missing... |
-|---------|-----------|---------------|
-| **Platform** | "web", "mobile", "desktop" | Add based on context or ask |
-| **Page type** | "landing page", "dashboard", "form" | Infer from description |
-| **Structure** | Numbered sections/components | Create logical page structure |
-| **Visual style** | Adjectives, mood, vibe | Add appropriate descriptors |
-| **Colors** | Specific values or roles | Add design system or suggest |
-| **Components** | UI-specific terms | Translate to proper keywords |
+| Element          | Check for                           | If missing...                 |
+| ---------------- | ----------------------------------- | ----------------------------- |
+| **Platform**     | "web", "mobile", "desktop"          | Add based on context or ask   |
+| **Page type**    | "landing page", "dashboard", "form" | Infer from description        |
+| **Structure**    | Numbered sections/components        | Create logical page structure |
+| **Visual style** | Adjectives, mood, vibe              | Add appropriate descriptors   |
+| **Colors**       | Specific values or roles            | Add design system or suggest  |
+| **Components**   | UI-specific terms                   | Translate to proper keywords  |
 
 ### Step 2: Check for DESIGN.md
 
 Look for a `DESIGN.md` file in the current project:
 
 **If DESIGN.md exists:**
+
 1. Read the file to extract the design system block
 2. Include the color palette, typography, and component styles
 3. Format as a "DESIGN SYSTEM (REQUIRED)" section in the output
 
 **If DESIGN.md does not exist:**
+
 1. Add this note at the end of the enhanced prompt:
 
 ```
 ---
-💡 **Tip:** For consistent designs across multiple screens, create a DESIGN.md 
-file using the `design-md` skill. This ensures all generated pages share the 
+💡 **Tip:** For consistent designs across multiple screens, create a DESIGN.md
+file using the `design-md` skill. This ensures all generated pages share the
 same visual language.
 ```
 
@@ -70,24 +73,24 @@ Transform the input using these techniques:
 
 Replace vague terms with specific component names:
 
-| Vague | Enhanced |
-|-------|----------|
-| "menu at the top" | "navigation bar with logo and menu items" |
-| "button" | "primary call-to-action button" |
-| "list of items" | "card grid layout" or "vertical list with thumbnails" |
-| "form" | "form with labeled input fields and submit button" |
-| "picture area" | "hero section with full-width image" |
+| Vague             | Enhanced                                              |
+| ----------------- | ----------------------------------------------------- |
+| "menu at the top" | "navigation bar with logo and menu items"             |
+| "button"          | "primary call-to-action button"                       |
+| "list of items"   | "card grid layout" or "vertical list with thumbnails" |
+| "form"            | "form with labeled input fields and submit button"    |
+| "picture area"    | "hero section with full-width image"                  |
 
 #### B. Amplify the Vibe
 
 Add descriptive adjectives to set the mood:
 
-| Basic | Enhanced |
-|-------|----------|
-| "modern" | "clean, minimal, with generous whitespace" |
-| "professional" | "sophisticated, trustworthy, with subtle shadows" |
-| "fun" | "vibrant, playful, with rounded corners and bold colors" |
-| "dark mode" | "dark theme with high-contrast accents on deep backgrounds" |
+| Basic          | Enhanced                                                    |
+| -------------- | ----------------------------------------------------------- |
+| "modern"       | "clean, minimal, with generous whitespace"                  |
+| "professional" | "sophisticated, trustworthy, with subtle shadows"           |
+| "fun"          | "vibrant, playful, with rounded corners and bold colors"    |
+| "dark mode"    | "dark theme with high-contrast accents on deep backgrounds" |
 
 #### C. Structure the Page
 
@@ -95,6 +98,7 @@ Organize content into numbered sections:
 
 ```markdown
 **Page Structure:**
+
 1. **Header:** Navigation with logo and menu items
 2. **Hero Section:** Headline, subtext, and primary CTA
 3. **Content Area:** [Describe the main content]
@@ -104,11 +108,13 @@ Organize content into numbered sections:
 #### D. Format Colors Properly
 
 When colors are mentioned, format them as:
+
 ```
 Descriptive Name (#hexcode) for functional role
 ```
 
 Examples:
+
 - "Deep Ocean Blue (#1a365d) for primary buttons and links"
 - "Warm Cream (#faf5f0) for page background"
 - "Soft Gray (#6b7280) for secondary text"
@@ -121,6 +127,7 @@ Structure the enhanced prompt in this order:
 [One-line description of the page purpose and vibe]
 
 **DESIGN SYSTEM (REQUIRED):**
+
 - Platform: [Web/Mobile], [Desktop/Mobile]-first
 - Theme: [Light/Dark], [style descriptors]
 - Background: [Color description] (#hex)
@@ -129,9 +136,10 @@ Structure the enhanced prompt in this order:
 - [Additional design tokens...]
 
 **Page Structure:**
+
 1. **[Section]:** [Description]
 2. **[Section]:** [Description]
-...
+   ...
 ```
 
 ## Output Options
@@ -139,6 +147,7 @@ Structure the enhanced prompt in this order:
 **Default:** Return the enhanced prompt as text for the user to copy.
 
 **Optional file output:** If the user requests, write to a file:
+
 - `next-prompt.md` — for use with the `stitch-loop` skill
 - Custom filename specified by user
 
@@ -147,13 +156,16 @@ Structure the enhanced prompt in this order:
 ### Example 1: Vague Input → Structured Prompt
 
 **User input:**
+
 > "make me a login page"
 
 **Enhanced output:**
+
 ```markdown
 A clean, trustworthy login page with a centered form and subtle branding.
 
 **DESIGN SYSTEM (REQUIRED):**
+
 - Platform: Web, Desktop-first
 - Theme: Light, minimal, professional
 - Background: Clean White (#ffffff)
@@ -165,26 +177,31 @@ A clean, trustworthy login page with a centered form and subtle branding.
 - Cards: Gently rounded (12px), soft shadow for elevation
 
 **Page Structure:**
+
 1. **Header:** Minimal logo, centered
 2. **Login Card:** Centered form with email, password fields, "Forgot password?" link
 3. **Submit Button:** Primary blue "Sign In" button
 4. **Footer:** "Don't have an account? Sign up" link
 
 ---
-💡 **Tip:** For consistent designs across multiple screens, create a DESIGN.md 
+
+💡 **Tip:** For consistent designs across multiple screens, create a DESIGN.md
 file using the `design-md` skill.
 ```
 
 ### Example 2: Feature Request → Targeted Edit
 
 **User input:**
+
 > "add a search bar"
 
 **Enhanced output:**
+
 ```markdown
 Add a search bar to the header navigation.
 
 **Specific changes:**
+
 - Location: Header, right side before user avatar
 - Style: Pill-shaped input with subtle gray background (#f3f4f6)
 - Icon: Magnifying glass icon on the left, inside the input

--- a/.agents/skills/react-components/SKILL.md
+++ b/.agents/skills/react-components/SKILL.md
@@ -2,11 +2,11 @@
 name: react:components
 description: Converts Stitch designs into modular Vite and React components using system-level networking and AST-based validation.
 allowed-tools:
-  - "stitch*:*"
-  - "Bash"
-  - "Read"
-  - "Write"
-  - "web_fetch"
+  - 'stitch*:*'
+  - 'Bash'
+  - 'Read'
+  - 'Write'
+  - 'web_fetch'
 ---
 
 # Stitch to React Components
@@ -14,6 +14,7 @@ allowed-tools:
 You are a frontend engineer focused on transforming designs into clean React code. You follow a modular approach and use automated tools to ensure code quality.
 
 ## Retrieval and networking
+
 1. **Namespace discovery**: Run `list_tools` to find the Stitch MCP prefix. Use this prefix (e.g., `stitch:`) for all subsequent calls.
 2. **Metadata fetch**: Call `[prefix]:get_screen` to retrieve the design JSON.
 3. **Check for existing designs**: Before downloading, check if `.stitch/designs/{page}.html` and `.stitch/designs/{page}.png` already exist:
@@ -21,31 +22,34 @@ You are a frontend engineer focused on transforming designs into clean React cod
    - **If files do not exist**: Proceed to step 4.
 4. **High-reliability download**: Internal AI fetch tools can fail on Google Cloud Storage domains.
    - **HTML**: `bash scripts/fetch-stitch.sh "[htmlCode.downloadUrl]" ".stitch/designs/{page}.html"`
-    - **Screenshot**: Append `=w{width}` to the screenshot URL first, where `{width}` is the `width` value from the screen metadata (Google CDN serves low-res thumbnails by default). Then run: `bash scripts/fetch-stitch.sh "[screenshot.downloadUrl]=w{width}" ".stitch/designs/{page}.png"`
+   - **Screenshot**: Append `=w{width}` to the screenshot URL first, where `{width}` is the `width` value from the screen metadata (Google CDN serves low-res thumbnails by default). Then run: `bash scripts/fetch-stitch.sh "[screenshot.downloadUrl]=w{width}" ".stitch/designs/{page}.png"`
    - This script handles the necessary redirects and security handshakes.
 5. **Visual audit**: Review the downloaded screenshot (`.stitch/designs/{page}.png`) to confirm design intent and layout details.
 
 ## Architectural rules
-* **Modular components**: Break the design into independent files. Avoid large, single-file outputs.
-* **Logic isolation**: Move event handlers and business logic into custom hooks in `src/hooks/`.
-* **Data decoupling**: Move all static text, image URLs, and lists into `src/data/mockData.ts`.
-* **Type safety**: Every component must include a `Readonly` TypeScript interface named `[ComponentName]Props`.
-* **Project specific**: Focus on the target project's needs and constraints. Leave Google license headers out of the generated React components.
-* **Style mapping**:
-    * Extract the `tailwind.config` from the HTML `<head>`.
-    * Sync these values with `resources/style-guide.json`.
-    * Use theme-mapped Tailwind classes instead of arbitrary hex codes.
+
+- **Modular components**: Break the design into independent files. Avoid large, single-file outputs.
+- **Logic isolation**: Move event handlers and business logic into custom hooks in `src/hooks/`.
+- **Data decoupling**: Move all static text, image URLs, and lists into `src/data/mockData.ts`.
+- **Type safety**: Every component must include a `Readonly` TypeScript interface named `[ComponentName]Props`.
+- **Project specific**: Focus on the target project's needs and constraints. Leave Google license headers out of the generated React components.
+- **Style mapping**:
+  - Extract the `tailwind.config` from the HTML `<head>`.
+  - Sync these values with `resources/style-guide.json`.
+  - Use theme-mapped Tailwind classes instead of arbitrary hex codes.
 
 ## Execution steps
+
 1. **Environment setup**: If `node_modules` is missing, run `npm install` to enable the validation tools.
 2. **Data layer**: Create `src/data/mockData.ts` based on the design content.
 3. **Component drafting**: Use `resources/component-template.tsx` as a base. Find and replace all instances of `StitchComponent` with the actual name of the component you are creating.
 4. **Application wiring**: Update the project entry point (like `App.tsx`) to render the new components.
 5. **Quality check**:
-    * Run `npm run validate <file_path>` for each component.
-    * Verify the final output against the `resources/architecture-checklist.md`.
-    * Start the dev server with `npm run dev` to verify the live result.
+   - Run `npm run validate <file_path>` for each component.
+   - Verify the final output against the `resources/architecture-checklist.md`.
+   - Start the dev server with `npm run dev` to verify the live result.
 
 ## Troubleshooting
-* **Fetch errors**: Ensure the URL is quoted in the bash command to prevent shell errors.
-* **Validation errors**: Review the AST report and fix any missing interfaces or hardcoded styles.
+
+- **Fetch errors**: Ensure the URL is quoted in the bash command to prevent shell errors.
+- **Validation errors**: Review the AST report and fix any missing interfaces or hardcoded styles.

--- a/.agents/skills/subagent-task-execution/SKILL.md
+++ b/.agents/skills/subagent-task-execution/SKILL.md
@@ -6,10 +6,12 @@ description: Use when executing tasks from a task breakdown document in the curr
 # Subagent Task Execution
 
 ## Overview
+
 This skill is used to execute a set of tasks (typically from a task breakdown or plan). It focuses on high-quality execution by dispatching specialized subagents for each task, ensuring each task is performed correctly and verified before moving to the next.
 
 ## Core Principle
-**One Task, One Subagent, Multi-Stage Review.** 
+
+**One Task, One Subagent, Multi-Stage Review.**
 By isolating each task and applying a structured review process, we ensure high quality and prevent context pollution.
 
 ## The Process
@@ -25,20 +27,22 @@ By isolating each task and applying a structured review process, we ensure high 
     - **Interactive Clarification:** If the subagent has questions, answer them clearly before they proceed with implementation.
     - **Task Implementation:** The subagent performs the task, following the identified best practices and skills.
     - **Verification & Review:**
-        - **Spec Compliance Review:** A separate subagent verifies that the result exactly matches the task requirements (no more, no less).
-        - **Quality Review:** A final review stage to ensure the output meets the highest standards of the domain (e.g., code quality, documentation clarity, etc.).
+      - **Spec Compliance Review:** A separate subagent verifies that the result exactly matches the task requirements (no more, no less).
+      - **Quality Review:** A final review stage to ensure the output meets the highest standards of the domain (e.g., code quality, documentation clarity, etc.).
     - **Completion:** Mark the task as completed in the todo list.
 
 3.  **Finalization:**
     - Once all tasks are complete, perform a final holistic review of the entire body of work to ensure consistency and overall quality.
 
 ## Key Principles
+
 - **Discovery First:** Always look for and apply the most relevant skills for the specific task at hand.
 - **Isolation:** Each task should be treated as a distinct unit of work.
 - **Review Loops:** Never move to the next task if the current one has open issues from either the spec or quality reviews.
 - **Subagent Specialization:** Use subagents as specialized workers, providing them with all the context they need upfront.
 
 ## Red Flags
+
 - Skipping the skill discovery phase.
 - Combining multiple tasks into a single subagent invocation.
 - Proceeding with a task while reviews are still pending or failing.

--- a/.agents/skills/writing-skills/SKILL.md
+++ b/.agents/skills/writing-skills/SKILL.md
@@ -9,7 +9,7 @@ description: Use when creating new skills, editing existing skills, or verifying
 
 **Writing skills IS Test-Driven Development applied to process documentation.**
 
-**Personal skills live in agent-specific directories (`~/.claude/skills` for Claude Code, `~/.agents/skills/` for Codex)** 
+**Personal skills live in agent-specific directories (`~/.claude/skills` for Claude Code, `~/.agents/skills/` for Codex)**
 
 You write test cases (pressure scenarios with subagents), watch them fail (baseline behavior), write the skill (documentation), watch tests pass (agents comply), and refactor (close loopholes).
 
@@ -29,30 +29,32 @@ A **skill** is a reference guide for proven techniques, patterns, or tools. Skil
 
 ## TDD Mapping for Skills
 
-| TDD Concept | Skill Creation |
-|-------------|----------------|
-| **Test case** | Pressure scenario with subagent |
-| **Production code** | Skill document (SKILL.md) |
-| **Test fails (RED)** | Agent violates rule without skill (baseline) |
-| **Test passes (GREEN)** | Agent complies with skill present |
-| **Refactor** | Close loopholes while maintaining compliance |
-| **Write test first** | Run baseline scenario BEFORE writing skill |
-| **Watch it fail** | Document exact rationalizations agent uses |
-| **Minimal code** | Write skill addressing those specific violations |
-| **Watch it pass** | Verify agent now complies |
-| **Refactor cycle** | Find new rationalizations → plug → re-verify |
+| TDD Concept             | Skill Creation                                   |
+| ----------------------- | ------------------------------------------------ |
+| **Test case**           | Pressure scenario with subagent                  |
+| **Production code**     | Skill document (SKILL.md)                        |
+| **Test fails (RED)**    | Agent violates rule without skill (baseline)     |
+| **Test passes (GREEN)** | Agent complies with skill present                |
+| **Refactor**            | Close loopholes while maintaining compliance     |
+| **Write test first**    | Run baseline scenario BEFORE writing skill       |
+| **Watch it fail**       | Document exact rationalizations agent uses       |
+| **Minimal code**        | Write skill addressing those specific violations |
+| **Watch it pass**       | Verify agent now complies                        |
+| **Refactor cycle**      | Find new rationalizations → plug → re-verify     |
 
 The entire skill creation process follows RED-GREEN-REFACTOR.
 
 ## When to Create a Skill
 
 **Create when:**
+
 - Technique wasn't intuitively obvious to you
 - You'd reference this again across projects
 - Pattern applies broadly (not project-specific)
 - Others would benefit
 
 **Don't create for:**
+
 - One-off solutions
 - Standard practices well-documented elsewhere
 - Project-specific conventions (put in CLAUDE.md)
@@ -61,16 +63,18 @@ The entire skill creation process follows RED-GREEN-REFACTOR.
 ## Skill Types
 
 ### Technique
+
 Concrete method with steps to follow (condition-based-waiting, root-cause-tracing)
 
 ### Pattern
+
 Way of thinking about problems (flatten-with-flags, test-invariants)
 
 ### Reference
+
 API docs, syntax guides, tool documentation (office docs)
 
 ## Directory Structure
-
 
 ```
 skills/
@@ -82,10 +86,12 @@ skills/
 **Flat namespace** - all skills in one searchable namespace
 
 **Separate files for:**
+
 1. **Heavy reference** (100+ lines) - API docs, comprehensive syntax
 2. **Reusable tools** - Scripts, utilities, templates
 
 **Keep inline:**
+
 - Principles and concepts
 - Code patterns (< 50 lines)
 - Everything else
@@ -93,6 +99,7 @@ skills/
 ## SKILL.md Structure
 
 **Frontmatter (YAML):**
+
 - Only two fields supported: `name` and `description`
 - Max 1024 characters total
 - `name`: Use letters, numbers, and hyphens only (no parentheses, special chars)
@@ -111,31 +118,37 @@ description: Use when [specific triggering conditions and symptoms]
 # Skill Name
 
 ## Overview
+
 What is this? Core principle in 1-2 sentences.
 
 ## When to Use
+
 [Small inline flowchart IF decision non-obvious]
 
 Bullet list with SYMPTOMS and use cases
 When NOT to use
 
 ## Core Pattern (for techniques/patterns)
+
 Before/after code comparison
 
 ## Quick Reference
+
 Table or bullets for scanning common operations
 
 ## Implementation
+
 Inline code for simple patterns
 Link to file for heavy reference or reusable tools
 
 ## Common Mistakes
+
 What goes wrong + fixes
 
 ## Real-World Impact (optional)
+
 Concrete results
 ```
-
 
 ## Claude Search Optimization (CSO)
 
@@ -172,8 +185,9 @@ description: Use when implementing any feature or bugfix, before writing impleme
 ```
 
 **Content:**
+
 - Use concrete triggers, symptoms, and situations that signal this skill applies
-- Describe the *problem* (race conditions, inconsistent behavior) not *language-specific symptoms* (setTimeout, sleep)
+- Describe the _problem_ (race conditions, inconsistent behavior) not _language-specific symptoms_ (setTimeout, sleep)
 - Keep triggers technology-agnostic unless the skill itself is technology-specific
 - If skill is technology-specific, make that explicit in the trigger
 - Write in third person (injected into system prompt)
@@ -199,6 +213,7 @@ description: Use when using React Router and handling authentication redirects
 ### 2. Keyword Coverage
 
 Use words Claude would search for:
+
 - Error messages: "Hook timed out", "ENOTEMPTY", "race condition"
 - Symptoms: "flaky", "hanging", "zombie", "pollution"
 - Synonyms: "timeout/hang/freeze", "cleanup/teardown/afterEach"
@@ -207,6 +222,7 @@ Use words Claude would search for:
 ### 3. Descriptive Naming
 
 **Use active voice, verb-first:**
+
 - ✅ `creating-skills` not `skill-creation`
 - ✅ `condition-based-waiting` not `async-test-helpers`
 
@@ -215,6 +231,7 @@ Use words Claude would search for:
 **Problem:** getting-started and frequently-referenced skills load into EVERY conversation. Every token counts.
 
 **Target word counts:**
+
 - getting-started workflows: <150 words each
 - Frequently-loaded skills: <200 words total
 - Other skills: <500 words (still be concise)
@@ -222,6 +239,7 @@ Use words Claude would search for:
 **Techniques:**
 
 **Move details to tool help:**
+
 ```bash
 # ❌ BAD: Document all flags in SKILL.md
 search-conversations supports --text, --both, --after DATE, --before DATE, --limit N
@@ -231,34 +249,42 @@ search-conversations supports multiple modes and filters. Run --help for details
 ```
 
 **Use cross-references:**
+
 ```markdown
 # ❌ BAD: Repeat workflow details
+
 When searching, dispatch subagent with template...
 [20 lines of repeated instructions]
 
 # ✅ GOOD: Reference other skill
+
 Always use subagents (50-100x context savings). REQUIRED: Use [other-skill-name] for workflow.
 ```
 
 **Compress examples:**
+
 ```markdown
 # ❌ BAD: Verbose example (42 words)
+
 your human partner: "How did we handle authentication errors in React Router before?"
 You: I'll search past conversations for React Router authentication patterns.
 [Dispatch subagent with search query: "React Router authentication error handling 401"]
 
 # ✅ GOOD: Minimal example (20 words)
+
 Partner: "How did we handle auth errors in React Router?"
 You: Searching...
 [Dispatch subagent → synthesis]
 ```
 
 **Eliminate redundancy:**
+
 - Don't repeat what's in cross-referenced skills
 - Don't explain what's obvious from command
 - Don't include multiple examples of same pattern
 
 **Verification:**
+
 ```bash
 wc -w skills/path/SKILL.md
 # getting-started workflows: aim for <150 each
@@ -266,12 +292,14 @@ wc -w skills/path/SKILL.md
 ```
 
 **Name by what you DO or core insight:**
+
 - ✅ `condition-based-waiting` > `async-test-helpers`
 - ✅ `using-skills` not `skill-usage`
 - ✅ `flatten-with-flags` > `data-structure-refactoring`
 - ✅ `root-cause-tracing` > `debugging-techniques`
 
 **Gerunds (-ing) work well for processes:**
+
 - `creating-skills`, `testing-skills`, `debugging-with-logs`
 - Active, describes the action you're taking
 
@@ -280,6 +308,7 @@ wc -w skills/path/SKILL.md
 **When writing documentation that references other skills:**
 
 Use skill name only, with explicit requirement markers:
+
 - ✅ Good: `**REQUIRED SUB-SKILL:** Use superpowers:test-driven-development`
 - ✅ Good: `**REQUIRED BACKGROUND:** You MUST understand superpowers:systematic-debugging`
 - ❌ Bad: `See skills/testing/test-driven-development` (unclear if required)
@@ -303,11 +332,13 @@ digraph when_flowchart {
 ```
 
 **Use flowcharts ONLY for:**
+
 - Non-obvious decision points
 - Process loops where you might stop too early
 - "When to use A vs B" decisions
 
 **Never use flowcharts for:**
+
 - Reference material → Tables, lists
 - Code examples → Markdown blocks
 - Linear instructions → Numbered lists
@@ -316,6 +347,7 @@ digraph when_flowchart {
 See @graphviz-conventions.dot for graphviz style rules.
 
 **Visualizing for your human partner:** Use `render-graphs.js` in this directory to render a skill's flowcharts to SVG:
+
 ```bash
 ./render-graphs.js ../some-skill           # Each diagram separately
 ./render-graphs.js ../some-skill --combine # All diagrams in one SVG
@@ -326,11 +358,13 @@ See @graphviz-conventions.dot for graphviz style rules.
 **One excellent example beats many mediocre ones**
 
 Choose most relevant language:
+
 - Testing techniques → TypeScript/JavaScript
 - System debugging → Shell/Python
 - Data processing → Python
 
 **Good example:**
+
 - Complete and runnable
 - Well-commented explaining WHY
 - From real scenario
@@ -338,6 +372,7 @@ Choose most relevant language:
 - Ready to adapt (not generic template)
 
 **Don't:**
+
 - Implement in 5+ languages
 - Create fill-in-the-blank templates
 - Write contrived examples
@@ -347,21 +382,26 @@ You're good at porting - one great example is enough.
 ## File Organization
 
 ### Self-Contained Skill
+
 ```
 defense-in-depth/
   SKILL.md    # Everything inline
 ```
+
 When: All content fits, no heavy reference needed
 
 ### Skill with Reusable Tool
+
 ```
 condition-based-waiting/
   SKILL.md    # Overview + patterns
   example.ts  # Working helpers to adapt
 ```
+
 When: Tool is reusable code, not just narrative
 
 ### Skill with Heavy Reference
+
 ```
 pptx/
   SKILL.md       # Overview + workflows
@@ -369,6 +409,7 @@ pptx/
   ooxml.md       # 500 lines XML structure
   scripts/       # Executable tools
 ```
+
 When: Reference material too large for inline
 
 ## The Iron Law (Same as TDD)
@@ -383,6 +424,7 @@ Write skill before testing? Delete it. Start over.
 Edit skill without testing? Same violation.
 
 **No exceptions:**
+
 - Not for "simple additions"
 - Not for "just adding a section"
 - Not for "documentation updates"
@@ -401,6 +443,7 @@ Different skill types need different test approaches:
 **Examples:** TDD, verification-before-completion, designing-before-coding
 
 **Test with:**
+
 - Academic questions: Do they understand the rules?
 - Pressure scenarios: Do they comply under stress?
 - Multiple pressures combined: time + sunk cost + exhaustion
@@ -413,6 +456,7 @@ Different skill types need different test approaches:
 **Examples:** condition-based-waiting, root-cause-tracing, defensive-programming
 
 **Test with:**
+
 - Application scenarios: Can they apply the technique correctly?
 - Variation scenarios: Do they handle edge cases?
 - Missing information tests: Do instructions have gaps?
@@ -424,6 +468,7 @@ Different skill types need different test approaches:
 **Examples:** reducing-complexity, information-hiding concepts
 
 **Test with:**
+
 - Recognition scenarios: Do they recognize when pattern applies?
 - Application scenarios: Can they use the mental model?
 - Counter-examples: Do they know when NOT to apply?
@@ -435,6 +480,7 @@ Different skill types need different test approaches:
 **Examples:** API documentation, command references, library guides
 
 **Test with:**
+
 - Retrieval scenarios: Can they find the right information?
 - Application scenarios: Can they use what they found correctly?
 - Gap testing: Are common use cases covered?
@@ -443,16 +489,16 @@ Different skill types need different test approaches:
 
 ## Common Rationalizations for Skipping Testing
 
-| Excuse | Reality |
-|--------|---------|
-| "Skill is obviously clear" | Clear to you ≠ clear to other agents. Test it. |
-| "It's just a reference" | References can have gaps, unclear sections. Test retrieval. |
-| "Testing is overkill" | Untested skills have issues. Always. 15 min testing saves hours. |
-| "I'll test if problems emerge" | Problems = agents can't use skill. Test BEFORE deploying. |
-| "Too tedious to test" | Testing is less tedious than debugging bad skill in production. |
-| "I'm confident it's good" | Overconfidence guarantees issues. Test anyway. |
-| "Academic review is enough" | Reading ≠ using. Test application scenarios. |
-| "No time to test" | Deploying untested skill wastes more time fixing it later. |
+| Excuse                         | Reality                                                          |
+| ------------------------------ | ---------------------------------------------------------------- |
+| "Skill is obviously clear"     | Clear to you ≠ clear to other agents. Test it.                   |
+| "It's just a reference"        | References can have gaps, unclear sections. Test retrieval.      |
+| "Testing is overkill"          | Untested skills have issues. Always. 15 min testing saves hours. |
+| "I'll test if problems emerge" | Problems = agents can't use skill. Test BEFORE deploying.        |
+| "Too tedious to test"          | Testing is less tedious than debugging bad skill in production.  |
+| "I'm confident it's good"      | Overconfidence guarantees issues. Test anyway.                   |
+| "Academic review is enough"    | Reading ≠ using. Test application scenarios.                     |
+| "No time to test"              | Deploying untested skill wastes more time fixing it later.       |
 
 **All of these mean: Test before deploying. No exceptions.**
 
@@ -477,11 +523,13 @@ Write code before test? Delete it.
 Write code before test? Delete it. Start over.
 
 **No exceptions:**
+
 - Don't keep it as "reference"
 - Don't "adapt" it while writing tests
 - Don't look at it
 - Delete means delete
-```
+
+````
 </Good>
 
 ### Address "Spirit vs Letter" Arguments
@@ -490,7 +538,7 @@ Add foundational principle early:
 
 ```markdown
 **Violating the letter of the rules is violating the spirit of the rules.**
-```
+````
 
 This cuts off entire class of "I'm following the spirit" rationalizations.
 
@@ -499,10 +547,10 @@ This cuts off entire class of "I'm following the spirit" rationalizations.
 Capture rationalizations from baseline testing (see Testing section below). Every excuse agents make goes in the table:
 
 ```markdown
-| Excuse | Reality |
-|--------|---------|
-| "Too simple to test" | Simple code breaks. Test takes 30 seconds. |
-| "I'll test after" | Tests passing immediately prove nothing. |
+| Excuse                           | Reality                                                                 |
+| -------------------------------- | ----------------------------------------------------------------------- |
+| "Too simple to test"             | Simple code breaks. Test takes 30 seconds.                              |
+| "I'll test after"                | Tests passing immediately prove nothing.                                |
 | "Tests after achieve same goals" | Tests-after = "what does this do?" Tests-first = "what should this do?" |
 ```
 
@@ -537,6 +585,7 @@ Follow the TDD cycle:
 ### RED: Write Failing Test (Baseline)
 
 Run pressure scenario with subagent WITHOUT the skill. Document exact behavior:
+
 - What choices did they make?
 - What rationalizations did they use (verbatim)?
 - Which pressures triggered violations?
@@ -554,6 +603,7 @@ Run same scenarios WITH skill. Agent should now comply.
 Agent found new rationalization? Add explicit counter. Re-test until bulletproof.
 
 **Testing methodology:** See @testing-skills-with-subagents.md for the complete testing methodology:
+
 - How to write pressure scenarios
 - Pressure types (time, sunk cost, authority, exhaustion)
 - Plugging holes systematically
@@ -562,21 +612,26 @@ Agent found new rationalization? Add explicit counter. Re-test until bulletproof
 ## Anti-Patterns
 
 ### ❌ Narrative Example
+
 "In session 2025-10-03, we found empty projectDir caused..."
 **Why bad:** Too specific, not reusable
 
 ### ❌ Multi-Language Dilution
+
 example-js.js, example-py.py, example-go.go
 **Why bad:** Mediocre quality, maintenance burden
 
 ### ❌ Code in Flowcharts
+
 ```dot
 step1 [label="import fs"];
 step2 [label="read file"];
 ```
+
 **Why bad:** Can't copy-paste, hard to read
 
 ### ❌ Generic Labels
+
 helper1, helper2, step3, pattern4
 **Why bad:** Labels should have semantic meaning
 
@@ -585,6 +640,7 @@ helper1, helper2, step3, pattern4
 **After writing ANY skill, you MUST STOP and complete the deployment process.**
 
 **Do NOT:**
+
 - Create multiple skills in batch without testing each
 - Move to next skill before current one is verified
 - Skip testing because "batching is more efficient"
@@ -598,11 +654,13 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 **IMPORTANT: Use TodoWrite to create todos for EACH checklist item below.**
 
 **RED Phase - Write Failing Test:**
+
 - [ ] Create pressure scenarios (3+ combined pressures for discipline skills)
 - [ ] Run scenarios WITHOUT skill - document baseline behavior verbatim
 - [ ] Identify patterns in rationalizations/failures
 
 **GREEN Phase - Write Minimal Skill:**
+
 - [ ] Name uses only letters, numbers, hyphens (no parentheses/special chars)
 - [ ] YAML frontmatter with only name and description (max 1024 chars)
 - [ ] Description starts with "Use when..." and includes specific triggers/symptoms
@@ -615,6 +673,7 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 - [ ] Run scenarios WITH skill - verify agents now comply
 
 **REFACTOR Phase - Close Loopholes:**
+
 - [ ] Identify NEW rationalizations from testing
 - [ ] Add explicit counters (if discipline skill)
 - [ ] Build rationalization table from all test iterations
@@ -622,6 +681,7 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 - [ ] Re-test until bulletproof
 
 **Quality Checks:**
+
 - [ ] Small flowchart only if decision non-obvious
 - [ ] Quick reference table
 - [ ] Common mistakes section
@@ -629,6 +689,7 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 - [ ] Supporting files only for tools or heavy reference
 
 **Deployment:**
+
 - [ ] Commit skill to git and push to your fork (if configured)
 - [ ] Consider contributing back via PR (if broadly useful)
 
@@ -637,10 +698,10 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 How future Claude finds your skill:
 
 1. **Encounters problem** ("tests are flaky")
-3. **Finds SKILL** (description matches)
-4. **Scans overview** (is this relevant?)
-5. **Reads patterns** (quick reference table)
-6. **Loads example** (only when implementing)
+2. **Finds SKILL** (description matches)
+3. **Scans overview** (is this relevant?)
+4. **Reads patterns** (quick reference table)
+5. **Loads example** (only when implementing)
 
 **Optimize for this flow** - put searchable terms early and often.
 


### PR DESCRIPTION
## Summary

Manual re-vendor of 5 SKILL.md files matching the formatting drift cleanup in phoenixvc/org-meta#13. Pairs with that PR — should land together so org-meta source and retort vendor stay aligned.

## What changed

| File | Substantive | Formatting |
|------|-------------|------------|
| `writing-skills/SKILL.md` | Renumber Discovery Workflow list 1-5 (was 1,3,4,5,6) | prettier normalization |
| `react-components/SKILL.md` | Fix Screenshot bullet indent under step 4 | prettier normalization |
| `coding/SKILL.md` | — | prettier normalization |
| `enhance-prompt/SKILL.md` | — | prettier normalization |
| `subagent-task-execution/SKILL.md` | — | prettier normalization |

Prettier normalization includes: blank-line-after-heading, 2-space sub-list indent, italic style `_x_` instead of `*x*`, `singleQuote` frontmatter, trailing whitespace stripped.

## Motivation

Bot reviewers (CodeRabbit, Codex) flagged 5+ pre-existing items in vendored skill outputs from #541 — items that live in org-meta and surfaced only because #541 was the first retort PR to vendor `.agents/skills/`. Source fix landed in org-meta#13; this PR vendors it forward.

Manual `cp` workaround until baton task `56e1fcc9` lands the three-way merge for `copyOrgMetaFile` (per handoff 2026-05-11-06 Open Risk #1).

## Test plan

- [x] `pnpm --dir .agentkit exec prettier --check .agents/skills/{coding,enhance-prompt,react-components,subagent-task-execution,writing-skills}/SKILL.md` passes locally
- [x] No semantic content changes beyond the 2 substantive fixes above
- [ ] CI pass (Test, prettier, markdownlint)

## References

- baton task `60eed24a` (drift cleanup ticket)
- Source PR: phoenixvc/org-meta#13
- Origin: retort#541 review threads (CodeRabbit + Codex)
- Open Risk reference: `docs/handoffs/2026-05-11-06.md` Open Risk #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced skill documentation with improved formatting, table restructuring, and consistent markdown styling for better clarity and consistency across guides.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phoenixvc/retort/pull/545)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->