### PR TITLE
docs(handoffs): add 2026-05-11-07 session handoff

### DIFF
--- a/docs/handoffs/2026-05-11-07.md
+++ b/docs/handoffs/2026-05-11-07.md
@@ -76,7 +76,7 @@ done
 ## State Files
 
 - Orchestrator: `.claude/state/orchestrator.json` — unchanged this session
-- Events: `.claude/state/events.log` — 130 entries before this handoff; appending below
+- Events: `.claude/state/events.log` — appended locally during session (gitignored; not committed)
 - Backlog: `AGENT_BACKLOG.md` — 157 lines; baton retort project is authoritative
 - Tasks: `.claude/state/tasks/` — no task files created this session
 - Baton retort project (`597f4f94-…`): `60eed24a` closed this session; `56e1fcc9` filed this session (open, high); foundation ticket `62ccea85` still in progress
@@ -91,4 +91,4 @@ Not creating one — the drift loop produced PR-level documentation (org-meta#13
 | -------------------- | ------ | ---- | -------------------------------------------- |
 | phoenixvc/retort#540 | retort | dev  | open (prior handoffs — decision needed)      |
 | phoenixvc/retort#544 | retort | ?    | not opened this session (number was skipped) |
-| phoenixvc/retort#NNN | retort | dev  | this handoff PR (to be opened on push)       |
+| phoenixvc/retort#546 | retort | dev  | open (this handoff PR)                        |

--- a/docs/handoffs/2026-05-11-07.md
+++ b/docs/handoffs/2026-05-11-07.md
@@ -1,0 +1,94 @@
+# Session Handoff
+
+**Date:** 2026-05-11T15:20:00Z
+**Branch:** dev (work done across feature branches, all merged)
+**Last Commit on dev:** c6a4eb36 — chore(skills): re-vendor 5 SKILL.md files from org-meta drift cleanup (#545)
+**Session Duration:** ~2h (continuation of -06)
+**Overall Status:** HEALTHY — 4 retort PRs and 2 org-meta PRs merged this session; queue is clean
+
+## What Was Done
+
+Continuation of 2026-05-11-06. Picked up the handoff with retort#541 + org-meta#12 ready-for-review and the 2 deferred drift tickets to file. Closed the full drift loop end-to-end.
+
+**Foundation pair merged (Next Action #1 from -06):**
+
+- org-meta#12 (gh-bot-reader source) → MERGED 2026-05-11T13:31Z
+- retort#541 (gh-bot-reader registration + sync engine fix) → MERGED 2026-05-11T13:32Z
+
+**Handoff doc PRs merged after prettier fixes:**
+
+- retort#542 (handoff 2026-05-11-05) — required `prettier --write docs/handoffs/2026-05-11-05.md` (commit `4ef58cf8`); CI prettier check rejected the unformatted handoff doc
+- retort#543 (handoff 2026-05-11-06) — same issue; commit `e9cd7a42` fixed it (italics `*not*` → `_not_` and table column widths)
+- Both merged after Test re-ran green
+
+**Baton tickets filed (Next Actions #2 + #3 from -06):**
+
+- `60eed24a` — Cleanup: drift items in vendored org-meta SKILL.md files (priority low) — now CLOSED
+- `56e1fcc9` — fix(engine): port managed-file three-way merge to copyOrgMetaFile (priority high) — still open
+
+**Drift cleanup loop closed (addresses baton `60eed24a`):**
+
+- org-meta#13 (drift cleanup at source) → MERGED 2026-05-11T15:13Z
+  - `writing-skills/SKILL.md`: renumbered Discovery Workflow list 1-5 (was 1, 3, 4, 5, 6)
+  - `react-components/SKILL.md`: fixed Screenshot bullet indent under step 4
+  - Prettier normalization across 5 SKILL.md files (coding, enhance-prompt, react-components, subagent-task-execution, writing-skills): blank-line-after-heading, 2-space sub-list indent, italic `_x_` style, trailing whitespace stripped
+  - Follow-up commit aligned `singleQuote` frontmatter to match retort's `.prettierrc`
+- retort#545 (manual re-vendor) → MERGED 2026-05-11T15:19Z
+
+**Investigation finding (not actioned):**
+
+- retort has no pre-commit hook (no husky, no lefthook, no pre-commit). Prettier only runs in CI, which is why handoff docs keep failing on first push. Directly relates to baton ticket `d706a5ef` / retort#195 (prettier formatting drift) but proper fix is bigger than this session — likely add husky + lint-staged for staged-file format-on-commit.
+
+## Current Blockers
+
+None. dev is healthy. Drift loop is complete.
+
+## Next 3 Actions
+
+1. **Address baton `56e1fcc9` (three-way merge for `copyOrgMetaFile`).** Priority `high`. Today's drift cleanup required a manual `cp` from `../org-meta/skills/` into `.agents/skills/` (commit `3e7e17ed`) because the "preserving local copy" branch in `platform-syncer.mjs:1243-1262` fires on every legitimate upstream update. Reference implementation already exists at `.agentkit/engines/node/src/scaffold-engine.mjs:144-218`. Until this lands, every adapter follow-up PR (Renovate, CodeRabbit, Sourcery, etc.) will need the same `cp` workaround.
+2. **Merge or close retort#540 (handoff 2026-05-11-04).** Still open from prior sessions — only stragglers in the handoff queue. Either merge it (if content is still relevant) or close (if superseded by -05/-06/-07). Check whether its content is stale.
+3. **Resume from prior queue: 5 adapter follow-up tickets, starting with Renovate.** Per -06 Next 3 Actions, Renovate is the most informative second adapter to test the gh-bot-reader skill abstractions against. Then `/cleanup` ticket `fb2e982d`. Caveat: action #1 above is the higher-leverage move — fixing the three-way merge first means action #3's PRs ship cleanly without manual vendor noise.
+
+## How to Validate
+
+```bash
+gh pr view 540 --repo phoenixvc/retort --json state,mergeStateStatus
+gh pr list --repo phoenixvc/retort --state open --limit 20
+git --no-pager log --oneline -10 origin/dev
+
+# Drift loop confirmation — all 5 should report identical content
+for f in coding enhance-prompt react-components subagent-task-execution writing-skills; do
+  diff --strip-trailing-cr ".agents/skills/$f/SKILL.md" "../org-meta/skills/$f/SKILL.md"
+done
+
+# Baton state
+# 60eed24a should be done; 56e1fcc9 should be open + high priority
+```
+
+## Open Risks
+
+- **Upstream propagation gap unchanged.** Baton `56e1fcc9` is still open. Every future org-meta vendor PR will require a manual `cp` until the three-way merge lands. This session's retort#545 was the third manual-vendor PR in two days (after `c3f0fa0a` and `20f94bf2` in #541). Frequency suggests it should be picked up next.
+- **No pre-commit prettier hook.** Handoff doc commits fail CI prettier check on first push (this session: #542 and #543 both needed manual prettier fixes; this handoff PR may need one too if I missed something). Lives under baton `d706a5ef` / retort#195. Easy to add husky + lint-staged.
+- **Singleton retort#540 still open.** From prior sessions; may be stale. Should be decided (merge or close) so the handoff queue is empty.
+- **Architecture decisions still as tickets, not code.** `b2059c5d` (retort shippability strategy) and `a401eba1` (universal-vs-specialist placement policy) remain unresolved — same as in -06.
+- **Bot reviewer rate limits.** Carried over from -06: CodeRabbit free tier hit "out of usage credits" on the first round of #541. Plan adapter follow-ups expecting CodeRabbit gaps; Copilot + Codex are reliable.
+
+## State Files
+
+- Orchestrator: `.claude/state/orchestrator.json` — unchanged this session
+- Events: `.claude/state/events.log` — 130 entries before this handoff; appending below
+- Backlog: `AGENT_BACKLOG.md` — 157 lines; baton retort project is authoritative
+- Tasks: `.claude/state/tasks/` — no task files created this session
+- Baton retort project (`597f4f94-…`): `60eed24a` closed this session; `56e1fcc9` filed this session (open, high); foundation ticket `62ccea85` still in progress
+
+## History doc
+
+Not creating one — the drift loop produced PR-level documentation (org-meta#13 + retort#545 body text); a separate history doc would duplicate without adding institutional context. The pattern (manual-vendor as workaround for missing three-way merge) is already captured in `docs/handoffs/2026-05-11-06.md`.
+
+## PRs in flight
+
+| PR                   | Repo   | Base | Status                                       |
+| -------------------- | ------ | ---- | -------------------------------------------- |
+| phoenixvc/retort#540 | retort | dev  | open (prior handoffs — decision needed)      |
+| phoenixvc/retort#544 | retort | ?    | not opened this session (number was skipped) |
+| phoenixvc/retort#NNN | retort | dev  | this handoff PR (to be opened on push)       |


### PR DESCRIPTION
## Summary

Session handoff for 2026-05-11-07 — continuation of -06.

Closed the drift cleanup loop end-to-end:

- Merged retort#541 + org-meta#12 pair (gh-bot-reader foundation)
- Merged retort#542 + #543 after applying prettier to handoff docs (#05 + #06)
- Filed 2 baton tickets (`60eed24a`, `56e1fcc9`) from -06 Next Actions #2 + #3
- Merged org-meta#13 (drift cleanup at source — 5 SKILL.md files: numbering fix, indent fix, prettier normalization, singleQuote alignment)
- Merged retort#545 (manual re-vendor of the 5 SKILL.md files) — baton `60eed24a` closed

## Next session priority

baton `56e1fcc9` — port managed-file three-way merge to `copyOrgMetaFile` (high priority). Today's drift cleanup needed a manual `cp` workaround because the "preserving local copy" branch in `platform-syncer.mjs:1243-1262` fires on every legitimate upstream update. Reference implementation already exists at `.agentkit/engines/node/src/scaffold-engine.mjs:144-218`.

## Test plan

- [x] Handoff file written to `docs/handoffs/2026-05-11-07.md`
- [x] Pre-applied prettier locally (so CI Test step won't fail like #542/#543 did)
- [x] Events log appended locally (`.claude/state/events.log` is gitignored — not committed)
- [ ] CI green (Test, prettier, markdownlint, validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal handoff documentation with session metadata, progress summary, and action items.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal process documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phoenixvc/retort/pull/546)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->