### PR TITLE
fix(engine): preserve editor-theme outputs across scaffold-once syncs

### DIFF
--- a/.agentkit/engines/node/src/platform-syncer.mjs
+++ b/.agentkit/engines/node/src/platform-syncer.mjs
@@ -329,8 +329,20 @@ ${GITATTR_END}
  * @param {Function} log - Logging function
  * @param {{ force?: boolean }} [flags] - Optional flags (force skips scaffold-once check)
  * @param {Set<string>} [skipOutputs] - Output paths to skip (scaffold-once)
+ * @param {string} [projectRoot] - When provided, scaffold-once-skipped outputs are
+ *   copied byte-identical from projectRoot into tmpDir so they appear in the new
+ *   manifest. Without this, the second sync run would orphan-delete them — see
+ *   the editor-theme oscillation bug.
  */
-export async function syncEditorTheme(agentkitRoot, tmpDir, vars, log, flags, skipOutputs) {
+export async function syncEditorTheme(
+  agentkitRoot,
+  tmpDir,
+  vars,
+  log,
+  flags,
+  skipOutputs,
+  projectRoot
+) {
   if (!vars.editorThemeEnabled) return;
 
   const brandSpec = readYaml(resolve(agentkitRoot, 'spec', 'brand.yaml'));
@@ -465,9 +477,35 @@ export async function syncEditorTheme(agentkitRoot, tmpDir, vars, log, flags, sk
   for (const [tool, outputPath] of Object.entries(outputs)) {
     if (!outputPath) continue; // null = skip this target
 
-    // Scaffold-once: skip targets that already exist in projectRoot (unless --overwrite/--force)
+    // Scaffold-once: target already exists in projectRoot (unless --overwrite/--force).
+    // Copy the existing content into tmpDir so it appears in the new manifest and
+    // survives orphan cleanup. Without this carry-forward, the second sync run
+    // sees the file in previousManifest, never in newManifestFiles, and deletes it.
     if (skipOutputs && skipOutputs.has(outputPath)) {
-      log(`[retort:sync] Editor theme: ${outputPath} exists (scaffold-once) — skipping`);
+      const normalizedRel = String(outputPath).replace(/^\/+/, '');
+      if (projectRoot) {
+        const existingPath = resolve(projectRoot, normalizedRel);
+        const destFile = resolve(tmpDir, normalizedRel);
+        if (existsSync(existingPath)) {
+          writePromises.push(
+            (async () => {
+              const content = await readFile(existingPath, 'utf-8');
+              await ensureDir(dirname(destFile));
+              await writeFile(destFile, content, 'utf-8');
+              log(`[retort:sync] Editor theme: ${outputPath} preserved (scaffold-once)`);
+            })()
+          );
+        } else {
+          log(
+            `[retort:sync] Editor theme: ${outputPath} marked existing but missing on disk — skipping`
+          );
+        }
+      } else {
+        // Legacy callers that don't pass projectRoot: log and skip, matching prior
+        // behaviour. The oscillation bug will reappear on next sync — pass
+        // projectRoot to opt into the fix.
+        log(`[retort:sync] Editor theme: ${outputPath} exists (scaffold-once) — skipping`);
+      }
       continue;
     }
 

--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -615,7 +615,10 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
     await Promise.all(alwaysOnTasks);
 
     // --- Editor theme (must run after vscode template copy to merge into settings) ---
-    // Scaffold-once: per-output target — only skip targets that already exist in projectRoot
+    // Scaffold-once: per-output target — preserve existing targets, write new ones.
+    // syncEditorTheme is always called so it can copy existing outputs into tmpDir;
+    // without this carry-forward, scaffold-engine's orphan cleanup would delete them
+    // on the second sync run.
     const forceTheme = flags?.overwrite || flags?.force;
     if (forceTheme) {
       await syncEditorTheme(agentkitRoot, tmpDir, vars, log, flags);
@@ -628,11 +631,10 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
           existingOutputs.add(outputPath);
         }
       }
-      if (existingOutputs.size < Object.keys(outputs).length) {
-        await syncEditorTheme(agentkitRoot, tmpDir, vars, log, flags, existingOutputs);
-      } else {
+      await syncEditorTheme(agentkitRoot, tmpDir, vars, log, flags, existingOutputs, projectRoot);
+      if (existingOutputs.size === Object.keys(outputs).length) {
         log(
-          '[retort:sync] Editor theme: all output targets exist (scaffold-once) — skipping. Use --overwrite to regenerate.'
+          '[retort:sync] Editor theme: all output targets exist (scaffold-once) — preserving existing content. Use --overwrite to regenerate.'
         );
       }
     }


### PR DESCRIPTION
## Summary

Fixes the editor-theme scaffold-once oscillation: outputs (`.vscode/`, `.cursor/`, `.windsurf/` settings.json) were being orphan-deleted on the second sync run when all targets already existed in `projectRoot`.

## Root cause

\`synchronize.mjs:617-638\` short-circuited the entire \`syncEditorTheme\` call when every output existed, so the files never reached \`tmpDir\` and didn't appear in \`newManifestFiles\`. \`cleanStaleFiles()\` then saw them in \`previousManifest\`, missing from \`newManifestFiles\`, and deleted them.

CI never observed this because \`previousManifest\` is null on first run. Locally, the bug oscillates: sync 1 writes the files, sync 2 deletes them, sync 3 writes them again. The flickering misled a previous session into removing them as \"orphans\" in commit \`6a9300a1\` (reverted in \`0c54c20b\` after CI broke).

## Fix

Two-part, both small:

1. **\`platform-syncer.mjs\`** — \`syncEditorTheme\` accepts an optional \`projectRoot\` parameter. When a target is in \`skipOutputs\`, the existing file content is copied byte-identical from \`projectRoot\` into \`tmpDir\`. The file lands in \`newManifestFiles\` and survives orphan cleanup. Legacy callers that don't pass \`projectRoot\` retain the prior silent-skip (back-compat).
2. **\`synchronize.mjs\`** — always calls \`syncEditorTheme\`, even when every output already exists. The \"all targets exist\" branch previously early-returned; it's now folded into the normal call path with \`existingOutputs\` as the skip set.

## Test plan

- [x] Local: run \`pnpm --dir .agentkit retort:sync\` three times in succession on a tree with editor-theme outputs already present. Each run logs \`.cursor/settings.json preserved (scaffold-once)\` (etc.); \`git status\` remains clean across all three.
- [x] Existing tests pass: \`synchronize-helpers\`, \`scaffold-engine\`, \`scaffold-merge\`, \`brand-resolver\`, \`scaffold-engine-extra\` — all green. One unrelated flaky test (\`sync-integration\` \`--only windsurf\` at 14s vs 15s timeout) passes in isolation.
- [x] Prettier-formatted.
- [ ] CI

## Resolves

baton ticket \`376cacd9\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)