### PR TITLE
docs(handoffs): add 2026-05-12 session handoff

### DIFF
--- a/docs/handoffs/2026-05-12.md
+++ b/docs/handoffs/2026-05-12.md
@@ -1,0 +1,93 @@
+# Session Handoff
+
+**Date:** 2026-05-12T11:00:00Z
+**Branch:** docs/handoff-2026-05-12 (this doc) — work on `feat/skills/gh-bot-reader-renovate-adapter`, `feat/skills/gh-bot-reader-codecov-adapter`, `fix/editor-theme-scaffold-once-oscillation`
+**Last commit on dev:** d5a78439 — docs(handoffs): add 2026-05-11-08 session handoff
+**Session Duration:** ~3h
+**Overall Status:** HEALTHY — 5 retort PRs and 2 org-meta PRs open and green; all three handoff actions from `2026-05-11-08` cleared, plus the editor-theme oscillation bug fixed end-to-end.
+
+## What Was Done
+
+Resumed from `docs/handoffs/2026-05-11-08.md`. Worked Actions 1+2+3 in sequence; all completed.
+
+**Action 1 — Renovate adapter ground-truthed.** Captured 4 scenarios from `phoenixvc/mystira-workspace` into `org-meta/skills/gh-bot-reader/renovate.sample.json` (25KB): plain-patch update (#1525), major monorepo bump (#1495, commitlint v21), non-major group (#1494, azure-sdk), and the only Renovate-authored conversation comment found in the org's recent history (#1516, Renovate Ignore Notification). Cross-referenced the fixture against `adapter-renovate.md` and corrected five distinct drifts from documented to actual output: (1) package-table header is `| Package | Change | Age | Confidence |`, not the legacy `| Package | Type | Update |`; (2) no `Update: major` row exists — major detection now uses the `(major)` title suffix or version-transition in the Change column; (3) `<!--renovate-debug:BASE64-->` is single-line base64 (decoded payload typically has `createdInVer/updatedInVer/targetBranch/labels` but no `retryCount` in current Mend Renovate); (4) HTML-comment patterns updated to match actual output (`<!-- rebase-check -->` is an unclosed inline placeholder); (5) added `ignore-notification` to `meta.comment_kind` enum. Pushed both files to the existing `feat/skills/gh-bot-reader-renovate-adapter` branch in org-meta (PR #14 updated, mergeable_state=CLEAN) and re-vendored byte-identical to retort PR #548 (mergeable_state=BLOCKED on review, 16/16 CI green).
+
+**Action 2 — Codecov adapter shipped.** Codecov is not installed in phoenixvc, so captured 3 scenarios from public OSS: full-coverage success (`chrisvogt/gatsby-theme-chronogrove#620`), patch-coverage failure (`frappe/frappe#39193`, the `:x: Your patch check has failed` blocking signal), and a flags-only success (`spegel-org/spegel#1341`). Wrote `adapter-codecov.md` (217 lines) modelled on the Renovate adapter but capturing Codecov-specific shape: single conversation comment per PR (Codecov is not the PR author), comment is edited in place across pushes (stable id, refreshed `updated_at`), `codecov[bot]` and `codecov-commenter` aliases. Severity heuristics distinguish patch-check failure (`blocking`) from project-check failure (`blocking`) from soft regression (`suggestion`, no `:x:` line) from clean reports (`info`). `meta.comment_kind` enum: `coverage-report` | `patch-check-failure` | `project-check-failure` | `soft-regression` | `other`. Updated SKILL.md adapter list. Opened paired PRs: org-meta#15 (CLEAN) and retort#550 (BLOCKED on review, 15/15 CI green).
+
+**Action 3 — Editor-theme oscillation fix.** Resolved baton ticket `376cacd9` (filed in `2026-05-11-08`). Root cause confirmed via code-read: `synchronize.mjs:617-638` short-circuits the entire `syncEditorTheme` call when all outputs exist in `projectRoot`, so the files never reach `tmpDir`, never appear in `newManifestFiles`, and `cleanStaleFiles()` deletes them as orphans on every second sync run. CI never observed this because `previousManifest` is null on first run. Fix in two parts: (a) `platform-syncer.mjs` `syncEditorTheme` accepts an optional `projectRoot` parameter — when a target is in `skipOutputs`, the existing file content is copied byte-identical from `projectRoot` into `tmpDir` so it lands in `newManifestFiles` and survives orphan cleanup; (b) `synchronize.mjs` always calls `syncEditorTheme`, even when all outputs exist (the early-return branch is gone). Backward-compatible — legacy callers that don't pass `projectRoot` retain prior silent-skip behaviour. Validated by 3 successive `retort:sync` runs with clean `git status` across all three. PR retort#551 opened (mergeable_state=BLOCKED, 12/15 CI passing — last 3 queuing).
+
+Branch `docs/handoff-2026-05-11-08` was cut clean from dev; this handoff lives on `docs/handoff-2026-05-12` (same pattern).
+
+## Current Blockers
+
+None for any open PR. All 7 (retort#546/547/548/550/551 + org-meta#14/#15) are CI-green or queuing and waiting on review.
+
+One pre-existing test flake noticed during validation: `sync-integration.test.mjs > --only windsurf produces no cursor command files` lives at a 15s timeout and passes in 14s in isolation. The editor-theme fix adds a few ms per sync, which nudges this test closer to the edge but doesn't push it over. Worth bumping to 30s like its siblings in a separate PR.
+
+## Next 3 Actions
+
+1. **Review and merge the review-queue stack in dependency order.** Five retort PRs are mine and BLOCKED on review: #546 (handoff -07), #547 (three-way merge port — unblocks future adapter UPDATEs), #548 (Renovate adapter registration), #550 (Codecov adapter registration), #551 (editor-theme oscillation fix). #547 is the most consequential (engine change). Plus org-meta#14 + #15 land as pairs with retort#548 + #550 respectively. If #548 lands before #550, retort#550 needs a one-line rebase of the companions list to `[adapter-coderabbit.md, adapter-renovate.md, adapter-codecov.md]` (opposite case is symmetric).
+2. **Continue the adapter follow-up queue with Copilot** (baton `5d55f3ae`). Copilot is the next most informative because it validates the GraphQL **review-thread** path with a different bot — distinct from the body-posting work in Renovate/Codecov. Pattern: review-thread bot like CodeRabbit but with different markers and severity conventions. After Copilot, Sonatype (`009f87ff`) and Claude (`80353338`) round out the set.
+3. **Bump the flaky `sync-integration` test timeout to 30s** in a one-line PR (`engines/node/src/__tests__/sync-integration.test.mjs:760`). The test passes in isolation but is dangerous under parallel load — and rumour has it the prettier failure under load also stems from the same test suite running concurrently with other I/O-heavy tests. Out of scope for #551 but worth doing.
+
+Then ticket `fb2e982d-…` `/cleanup` command — gh-bot-reader will be at 4/6 adapter coverage by then (CodeRabbit + Renovate + Codecov + Copilot), which is enough to ship a useful `bots` scope.
+
+## How to Validate
+
+```bash
+# Confirm all 5 retort PRs are green
+for pr in 546 547 548 550 551; do gh pr view $pr --repo phoenixvc/retort --json mergeable,mergeStateStatus --jq "\"#$pr: \" + .mergeable + \"/\" + .mergeStateStatus"; done
+
+# Confirm both org-meta PRs are green
+for pr in 14 15; do gh pr view $pr --repo phoenixvc/org-meta --json mergeable,mergeStateStatus --jq "\"#$pr: \" + .mergeable + \"/\" + .mergeStateStatus"; done
+
+# Renovate fixture verification — adapter byte-identical between repos
+diff ~/repos/org-meta/skills/gh-bot-reader/adapter-renovate.md \
+     .agents/skills/gh-bot-reader/adapter-renovate.md
+diff ~/repos/org-meta/skills/gh-bot-reader/adapter-codecov.md \
+     .agents/skills/gh-bot-reader/adapter-codecov.md
+
+# Editor-theme oscillation reproduction (must show "preserved" not orphan-delete)
+git checkout fix/editor-theme-scaffold-once-oscillation
+pnpm --dir .agentkit retort:sync 2>&1 | grep -iE "editor theme|orphan|stale" | tail -10
+git status   # expect clean (only .claude/scheduled_tasks.lock)
+pnpm --dir .agentkit retort:sync 2>&1 | grep -iE "preserved|orphan" | tail -5
+git status   # still clean
+
+# Baton state
+# 2c2b3e2c — Renovate adapter — should remain inprogress (PRs not merged yet)
+# 376cacd9 — editor-theme oscillation bug — should be inprogress with PR link
+# 13f27dc8 — Codecov adapter — should be inprogress with PR links
+```
+
+## Open Risks
+
+- **Three new PRs (550, 551, plus org-meta#15) joined an already-deep single-author review queue.** Total open mine: retort#546/547/548/550/551 + org-meta#14/#15. Reviewer fatigue is a real risk; each PR touches a distinct concern but the queue length means reviewer context-switch tax is high. Mitigation: order matters — #547 (engine) and #551 (engine fix) before adapter PRs.
+- **Codecov adapter is OSS-sourced, not phoenixvc-sourced.** The three captured scenarios come from `chrisvogt/gatsby-theme-chronogrove`, `frappe/frappe`, and `spegel-org/spegel`. The shape is stable but Codecov's per-install config (project threshold, flag conventions) can vary. The adapter notes this in "Known gotchas" but consumers may hit local overrides we haven't seen.
+- **Renovate ignore-notification is a single-sample finding.** Across all of phoenixvc + JustAGhosT recent history, only **one** Renovate-authored conversation comment was captured (PR#1516's "Renovate Ignore Notification"). The adapter's `comment_kind` enum (`automerge-failure`, `edited-blocked`, `status-check-failure`, `rebase-failed`, `ignore-notification`, `other`) is documented from Renovate's public docs but four of those kinds have no captured exemplar in the fixture. Worth sweeping for samples once a long-lived rebase-conflict PR surfaces.
+- **Editor-theme fix carries forward existing content unconditionally.** If a user manually edits `.cursor/settings.json` to inject their own colors, the second sync will preserve those edits (good) but the spec → settings flow won't propagate them back into `brand.yaml` (expected, but worth documenting in a future ADR). `--overwrite` bypasses the carry-forward and regenerates from spec — works as before.
+- **Same `sync-integration` test flake under parallel load.** The fix narrows the timing budget by a few ms; under full-suite parallel runs the 15s ceiling can break. Pre-existing; not introduced by this session, but worth fixing before someone else's PR trips on it.
+
+## State Files
+
+- Orchestrator: `.claude/state/orchestrator.json` — unchanged this session
+- Events: `.claude/state/events.log` — unchanged this session (baton is authoritative)
+- Backlog: `AGENT_BACKLOG.md` — unchanged (baton retort project is authoritative)
+- Tasks: `.claude/state/tasks/` — no task files created this session
+- Baton retort project (`597f4f94-…`): `2c2b3e2c` remains inprogress; `376cacd9` and `13f27dc8` moved to inprogress with PR-link agent messages
+
+## History doc
+
+Not creating one — adapter follow-up PRs are routine continuation of the gh-bot-reader foundation work, and the editor-theme fix is a small targeted bug fix. When the full adapter set lands (Copilot, Codecov, Sonatype, Claude all merged + the test-fixture harness for CodeRabbit), a single `feature` history doc at `docs/history/feature/` covering the body-posting-vs-review-thread split, the fixture-driven validation pattern, and the scaffold-once carry-forward fix would be worth writing. Suggested title: "gh-bot-reader adapter set + fixture-driven validation pattern."
+
+## PRs in flight
+
+| PR                    | Repo     | Base   | Status                                                                                                  |
+| --------------------- | -------- | ------ | ------------------------------------------------------------------------------------------------------- |
+| phoenixvc/retort#546  | retort   | dev    | docs handoff -07, 13/13 CI green, mergeable_state=BLOCKED (review)                                      |
+| phoenixvc/retort#547  | retort   | dev    | three-way merge port, mergeable_state=BLOCKED — unblocks future adapter UPDATE-path                     |
+| phoenixvc/retort#548  | retort   | dev    | Renovate adapter spec + ground-truth fixes + sample, 16/16 CI green, mergeable_state=BLOCKED            |
+| phoenixvc/retort#550  | retort   | dev    | Codecov adapter spec + companion vendoring, 15/15 CI green, mergeable_state=BLOCKED                     |
+| phoenixvc/retort#551  | retort   | dev    | editor-theme oscillation fix (engine), 12/15 CI green + 3 queuing, mergeable_state=BLOCKED              |
+| phoenixvc/org-meta#14 | org-meta | master | Renovate adapter content + sample, 1/1 CI green, mergeable_state=CLEAN                                  |
+| phoenixvc/org-meta#15 | org-meta | master | Codecov adapter content + sample, 1/1 CI green, mergeable_state=CLEAN                                   |


### PR DESCRIPTION
## Summary

- Adds `docs/handoffs/2026-05-12.md` capturing this session's three completed actions and the next-session queue.

## Session highlights

- **Renovate adapter ground-truthed** against a 4-scenario fixture captured from `mystira-workspace`; 5 distinct drifts in `adapter-renovate.md` corrected. Pushed to existing org-meta#14 + retort#548.
- **Codecov adapter shipped** as the second body-posting bot (org-meta#15, retort#550 — both new). OSS-sourced fixture (Codecov not installed in phoenixvc).
- **Editor-theme oscillation fix** (retort#551 — new) resolving baton ticket `376cacd9`. Validated by 3 successive `retort:sync` runs.

## PRs in flight (this session)

| PR | Repo | Status |
|---|---|---|
| retort#548 (updated) | retort | Renovate adapter + drift fixes, 16/16 CI green, BLOCKED on review |
| retort#550 (new) | retort | Codecov adapter registration, 15/15 CI green, BLOCKED on review |
| retort#551 (new) | retort | Editor-theme fix, 12/15 CI green + 3 queuing, BLOCKED on review |
| org-meta#14 (updated) | org-meta | Renovate adapter content + sample, CLEAN |
| org-meta#15 (new) | org-meta | Codecov adapter content + sample, CLEAN |

## Test plan

- [x] Handoff document follows the established `docs/handoffs/<date>.md` pattern.
- [x] CI: branch-protection title check (Conventional Commits compliant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added session handoff documentation capturing completed work items, current blockers, planned actions, and PR status tracking information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phoenixvc/retort/pull/552)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->