### PR TITLE
test(sync): widen sync-integration timeouts for known-slow tests

### DIFF
--- a/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
@@ -391,7 +391,7 @@ describe('syncClaudeSkills (via runSync --only claude)', () => {
   beforeAll(async () => {
     projectRoot = makeTmpProject();
     await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'claude' } });
-  });
+  }, 60000);
   afterAll(() => {
     rmSync(projectRoot, { recursive: true, force: true });
   });
@@ -633,7 +633,7 @@ describe('--overwrite flag', () => {
     rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  it('skips project-owned files by default', { timeout: 45000 }, async () => {
+  it('skips project-owned files by default', { timeout: 60000 }, async () => {
     const contribPath = join(projectRoot, 'CONTRIBUTING.md');
     expect(existsSync(contribPath)).toBe(true);
 
@@ -644,7 +644,7 @@ describe('--overwrite flag', () => {
     expect(readFileSync(contribPath, 'utf-8')).toBe(customContent);
   });
 
-  it('overwrites project-owned files with --overwrite', { timeout: 45000 }, async () => {
+  it('overwrites project-owned files with --overwrite', { timeout: 60000 }, async () => {
     const contribPath = join(projectRoot, 'CONTRIBUTING.md');
     const customContent = 'CUSTOM_OVERWRITE_MARKER_67890';
     writeFileSync(contribPath, customContent, 'utf-8');
@@ -653,7 +653,7 @@ describe('--overwrite flag', () => {
     expect(readFileSync(contribPath, 'utf-8')).not.toContain(customContent);
   });
 
-  it('--force is alias for --overwrite', { timeout: 45000 }, async () => {
+  it('--force is alias for --overwrite', { timeout: 60000 }, async () => {
     const contribPath = join(projectRoot, 'CONTRIBUTING.md');
     writeFileSync(contribPath, 'CUSTOM', 'utf-8');
     await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { force: true } });

--- a/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
@@ -757,7 +757,7 @@ describe('render-target output isolation (--only flag)', () => {
     expect(existsSync(resolve(projectRoot, '.github', 'prompts'))).toBe(false);
   });
 
-  it('--only windsurf produces no cursor command files', { timeout: 15000 }, async () => {
+  it('--only windsurf produces no cursor command files', { timeout: 30000 }, async () => {
     await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'windsurf' } });
     expect(existsSync(resolve(projectRoot, '.cursor', 'commands'))).toBe(false);
   });


### PR DESCRIPTION
## Summary

Bumps four timeouts in `sync-integration.test.mjs` that all share the same root cause: a full `--only` (or `--overwrite`) sync runs ~10–20s on Windows under parallel load, and the existing ceilings leave too little headroom. The first commit covers the windsurf flake called out in `docs/handoffs/2026-05-12.md`; the second commit picks up two more failures observed in the same run.

| Test (line) | Old | New |
|---|---|---|
| `--only windsurf produces no cursor command files` (760) | 15s | 30s |
| `syncClaudeSkills > beforeAll` (391) | default 30s hook | 60s |
| `--overwrite flag > skips project-owned files by default` (636) | 45s | 60s |
| `--overwrite flag > overwrites project-owned files with --overwrite` (647) | 45s | 60s |
| `--overwrite flag > --force is alias for --overwrite` (656) | 45s | 60s |

No behavior change — just slack in the ceilings. The `--overwrite` suite's `beforeAll` already uses 60s; the three tests now match it.

## Why these and not others

Confirmed by re-running `pnpm exec vitest run engines/node/src/__tests__/sync-integration.test.mjs` locally against `dev` tip: 1 failed suite + 1 failed test, both timeouts at the exact lines bumped here. The `--only windsurf` test passes in 10.5s in isolation — same family of bug, just sitting closer to its ceiling.

## Test plan

- [x] `pnpm --dir .agentkit exec vitest run engines/node/src/__tests__/sync-integration.test.mjs -t "only windsurf produces no cursor"` passes in isolation
- [ ] CI green on PR
- [ ] No regression to test suite duration (tests still complete in <13min wall-clock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)