### PR TITLE
test(agentkit): expand runtime coverage

### DIFF
--- a/.agentkit/engines/node/src/__tests__/backlog-store.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/backlog-store.test.mjs
@@ -215,5 +215,64 @@ describe('backlog-store', () => {
       expect(sorted[1].team).toBe('docs');
       expect(sorted[2].team).toBe('frontend');
     });
+
+    it('sorts by source', () => {
+      const items = [
+        { id: 'a', source: 'github', priority: 'P1' },
+        { id: 'b', source: 'manual', priority: 'P1' },
+        { id: 'c', source: 'discovery', priority: 'P1' },
+      ];
+      const sorted = sortItems(items, 'source');
+      expect(sorted.map((i) => i.source)).toEqual(['discovery', 'github', 'manual']);
+    });
+
+    it('sorts by updated (most recent first)', () => {
+      const items = [
+        { id: 'a', updatedAt: '2026-01-01T00:00:00Z' },
+        { id: 'b', updatedAt: '2026-03-01T00:00:00Z' },
+        { id: 'c', updatedAt: '2026-02-01T00:00:00Z' },
+      ];
+      const sorted = sortItems(items, 'updated');
+      expect(sorted.map((i) => i.id)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('sorts by score descending; missing scores rank last', () => {
+      const items = [
+        { id: 'a', score: 5 },
+        { id: 'b', score: 10 },
+        { id: 'c' }, // no score
+      ];
+      const sorted = sortItems(items, 'score');
+      expect(sorted.map((i) => i.id)).toEqual(['b', 'a', 'c']);
+    });
+
+    it('returns the original copy for an unknown sort key', () => {
+      const items = [{ id: 'a' }, { id: 'b' }];
+      const sorted = sortItems(items, 'totally-bogus-key');
+      expect(sorted.map((i) => i.id)).toEqual(['a', 'b']);
+      // Returns a copy, not the same array
+      expect(sorted).not.toBe(items);
+    });
+  });
+
+  describe('filterItems — additional branches', () => {
+    it('filters by status', () => {
+      const items = [
+        { id: 'a', status: 'open' },
+        { id: 'b', status: 'closed' },
+        { id: 'c', status: 'open' },
+      ];
+      const result = filterItems(items, { status: 'open' });
+      expect(result).toHaveLength(2);
+    });
+
+    it('filter is case-insensitive on status', () => {
+      const items = [
+        { id: 'a', status: 'Open' },
+        { id: 'b', status: 'CLOSED' },
+      ];
+      expect(filterItems(items, { status: 'open' })).toHaveLength(1);
+      expect(filterItems(items, { status: 'CLOSED' })).toHaveLength(1);
+    });
   });
 });

--- a/.agentkit/engines/node/src/__tests__/check.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/check.test.mjs
@@ -7,6 +7,7 @@ import {
   ALLOWED_FORMATTER_BASES,
   ALLOWED_LINTER_BASES,
   ALLOWED_NPX_PACKAGES,
+  auditUnresolvedPlaceholders,
   isAllowedFormatter,
   isAllowedLinter,
   resolveFormatter,
@@ -267,4 +268,226 @@ describe('isAllowedLinter()', () => {
     expect(ALLOWED_LINTER_BASES.has('eslint')).toBe(true);
     expect(ALLOWED_LINTER_BASES.has('pylint')).toBe(true);
   });
+});
+
+// ---------------------------------------------------------------------------
+// auditUnresolvedPlaceholders
+// ---------------------------------------------------------------------------
+
+describe('auditUnresolvedPlaceholders()', () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty array when no output dirs exist', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'audit-no-dirs-'));
+    const findings = await auditUnresolvedPlaceholders(tempDir, ['.claude', '.cursor']);
+    expect(findings).toEqual([]);
+  });
+
+  it('finds unresolved {{variable}} placeholders in markdown files', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'audit-find-'));
+    mkdirSync(resolve(tempDir, '.claude'), { recursive: true });
+    writeFileSync(
+      resolve(tempDir, '.claude', 'README.md'),
+      'Hello {{userName}} — welcome to {{projectName}}!'
+    );
+    const findings = await auditUnresolvedPlaceholders(tempDir, ['.claude']);
+    expect(findings.length).toBe(1);
+    expect(findings[0].variables).toEqual(expect.arrayContaining(['userName', 'projectName']));
+  });
+
+  it('skips block helpers and else markers', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'audit-helpers-'));
+    mkdirSync(resolve(tempDir, '.claude'), { recursive: true });
+    writeFileSync(
+      resolve(tempDir, '.claude', 'a.md'),
+      '{{#if foo}}yes{{else}}no{{/if}} — but {{realVar}} should be flagged'
+    );
+    const findings = await auditUnresolvedPlaceholders(tempDir, ['.claude']);
+    expect(findings.length).toBe(1);
+    expect(findings[0].variables).toEqual(['realVar']);
+  });
+
+  it('returns no findings when files have no placeholders', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'audit-clean-'));
+    mkdirSync(resolve(tempDir, '.claude'), { recursive: true });
+    writeFileSync(resolve(tempDir, '.claude', 'a.md'), 'plain text — no placeholders here');
+    const findings = await auditUnresolvedPlaceholders(tempDir, ['.claude']);
+    expect(findings).toEqual([]);
+  });
+
+  it('skips node_modules and .git directories', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'audit-skip-'));
+    mkdirSync(resolve(tempDir, '.claude', 'node_modules'), { recursive: true });
+    mkdirSync(resolve(tempDir, '.claude', '.git'), { recursive: true });
+    writeFileSync(
+      resolve(tempDir, '.claude', 'node_modules', 'leak.md'),
+      'Has {{shouldBeIgnored}} placeholder'
+    );
+    writeFileSync(
+      resolve(tempDir, '.claude', '.git', 'leak.md'),
+      'Has {{alsoIgnored}} placeholder'
+    );
+    const findings = await auditUnresolvedPlaceholders(tempDir, ['.claude']);
+    expect(findings).toEqual([]);
+  });
+
+  it('recurses into subdirectories', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'audit-recurse-'));
+    mkdirSync(resolve(tempDir, '.claude', 'sub', 'deep'), { recursive: true });
+    writeFileSync(resolve(tempDir, '.claude', 'sub', 'deep', 'a.md'), 'Has {{deepVar}} marker');
+    const findings = await auditUnresolvedPlaceholders(tempDir, ['.claude']);
+    expect(findings.length).toBe(1);
+    expect(findings[0].variables).toEqual(['deepVar']);
+  });
+
+  it('only scans markdown/yaml/json/mjs/js/ts files', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'audit-ext-'));
+    mkdirSync(resolve(tempDir, '.claude'), { recursive: true });
+    writeFileSync(resolve(tempDir, '.claude', 'a.md'), '{{mdVar}}');
+    writeFileSync(resolve(tempDir, '.claude', 'b.txt'), '{{txtVar}}'); // ignored
+    writeFileSync(resolve(tempDir, '.claude', 'c.json'), '{"k": "{{jsonVar}}"}');
+    const findings = await auditUnresolvedPlaceholders(tempDir, ['.claude']);
+    const allVars = findings.flatMap((f) => f.variables);
+    expect(allVars).toContain('mdVar');
+    expect(allVars).toContain('jsonVar');
+    expect(allVars).not.toContain('txtVar');
+  });
+
+  it('deduplicates the variables list per file', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'audit-dedup-'));
+    mkdirSync(resolve(tempDir, '.claude'), { recursive: true });
+    writeFileSync(
+      resolve(tempDir, '.claude', 'a.md'),
+      '{{repeated}} {{repeated}} {{unique}} {{repeated}}'
+    );
+    const findings = await auditUnresolvedPlaceholders(tempDir, ['.claude']);
+    expect(findings).toHaveLength(1);
+    // Each variable appears only once in the variables array
+    expect(findings[0].variables.sort()).toEqual(['repeated', 'unique']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runCheck — coverage results / unresolved placeholders / event logging error
+// ---------------------------------------------------------------------------
+
+describe('runCheck() — additional branches', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs unresolved placeholder findings without crashing', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const fixture = createCheckFixture();
+    try {
+      // Seed an output dir with an unresolved placeholder
+      mkdirSync(resolve(fixture.projectRoot, '.claude'), { recursive: true });
+      writeFileSync(resolve(fixture.projectRoot, '.claude', 'demo.md'), 'Hello {{unresolved_var}}');
+
+      const result = await runCheck({
+        agentkitRoot: fixture.agentkitRoot,
+        projectRoot: fixture.projectRoot,
+        flags: { fast: true },
+      });
+      expect(result).toBeDefined();
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('Unresolved Placeholders');
+      expect(out).toContain('unresolved_var');
+    } finally {
+      cleanupFixture(fixture.root);
+    }
+  }, 20_000);
+
+  it('runs the coverage step when --coverage is set', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const fixture = createCheckFixture();
+    try {
+      // project.yaml with coverage threshold
+      writeFileSync(
+        resolve(fixture.agentkitRoot, 'spec', 'project.yaml'),
+        'testing:\n  coverage: 50\n',
+        'utf-8'
+      );
+
+      const result = await runCheck({
+        agentkitRoot: fixture.agentkitRoot,
+        projectRoot: fixture.projectRoot,
+        flags: { fast: true, coverage: true },
+      });
+
+      expect(result).toBeDefined();
+      // The coverage attempt should at least be present in some form
+      expect(Array.isArray(result.coverage)).toBe(true);
+    } finally {
+      cleanupFixture(fixture.root);
+    }
+  }, 20_000);
+
+  it('skips invalid commands and reports SKIP / warning for invalid formatter', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const fixture = createCheckFixture({ withBuild: false, formatter: '   ' });
+    try {
+      const result = await runCheck({
+        agentkitRoot: fixture.agentkitRoot,
+        projectRoot: fixture.projectRoot,
+        flags: { fast: true },
+      });
+      expect(result).toBeDefined();
+      // Empty/whitespace formatter should trigger a warning
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      cleanupFixture(fixture.root);
+    }
+  }, 20_000);
+
+  it('skips disallowed formatter (not in ALLOWED list) with a warning', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const fixture = createCheckFixture({ withBuild: false, formatter: 'untrusted-formatter' });
+    try {
+      await runCheck({
+        agentkitRoot: fixture.agentkitRoot,
+        projectRoot: fixture.projectRoot,
+        flags: { fast: true },
+      });
+      const warnText = warnSpy.mock.calls.flat().join('\n');
+      expect(warnText).toContain('unrecognized formatter');
+    } finally {
+      cleanupFixture(fixture.root);
+    }
+  }, 20_000);
+
+  it('passes a userContext through when extra args are supplied', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const fixture = createCheckFixture();
+    try {
+      const result = await runCheck({
+        agentkitRoot: fixture.agentkitRoot,
+        projectRoot: fixture.projectRoot,
+        flags: { fast: true, _args: ['my', 'context'] },
+      });
+      expect(result.userContext).toBe('my context');
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('Context: my context');
+    } finally {
+      cleanupFixture(fixture.root);
+    }
+  }, 20_000);
 });

--- a/.agentkit/engines/node/src/__tests__/cost-tracker.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/cost-tracker.test.mjs
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
 import {
   endSession,
   generateReport,
@@ -10,6 +11,7 @@ import {
   initSession,
   logEvent,
   recordCommand,
+  runCost,
 } from '../cost-tracker.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -350,6 +352,176 @@ describe('cost-tracker', () => {
       expect(report.totalSessions).toBeDefined();
       expect(report.byUser).toBeDefined();
       expect(report.byCommand).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // runCost() — CLI handler
+  // -------------------------------------------------------------------------
+
+  describe('runCost()', () => {
+    let logSpy;
+
+    beforeEach(() => {
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+    });
+
+    it('default output (no flags) prints command list and 30-day summary', async () => {
+      await runCost({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        flags: {},
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('Usage tracking');
+      expect(out).toContain('Commands:');
+      expect(out).toContain('Sessions (last 30 days):');
+    });
+
+    it('default output reports total duration and files when sessions exist', async () => {
+      const session = initSession({ agentkitRoot: TEST_AGENTKIT, projectRoot: TEST_PROJECT });
+      // End the session so it has duration
+      endSession({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        sessionId: session.sessionId,
+      });
+
+      await runCost({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        flags: {},
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('Total duration:');
+      expect(out).toContain('Total files modified:');
+    });
+
+    it('--summary prints "no sessions" when none exist', async () => {
+      await runCost({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        flags: { summary: true },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('Recent session summary');
+      expect(out).toContain('No sessions found');
+    });
+
+    it('--summary lists sessions when they exist', async () => {
+      const session = initSession({ agentkitRoot: TEST_AGENTKIT, projectRoot: TEST_PROJECT });
+      endSession({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        sessionId: session.sessionId,
+      });
+
+      await runCost({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        flags: { summary: true, last: '7d' },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('Sessions (last 7d):');
+      expect(out).toContain(session.sessionId);
+    });
+
+    it('--sessions prints session list (table format)', async () => {
+      const session = initSession({ agentkitRoot: TEST_AGENTKIT, projectRoot: TEST_PROJECT });
+      endSession({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        sessionId: session.sessionId,
+      });
+
+      await runCost({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        flags: { sessions: true },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('session(s) found');
+      expect(out).toContain(session.sessionId);
+    });
+
+    it('--sessions --format json emits valid JSON', async () => {
+      initSession({ agentkitRoot: TEST_AGENTKIT, projectRoot: TEST_PROJECT });
+
+      await runCost({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        flags: { sessions: true, format: 'json' },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      // First call should be a JSON.stringify output
+      expect(() => JSON.parse(out.trim())).not.toThrow();
+      const parsed = JSON.parse(out.trim());
+      expect(Array.isArray(parsed)).toBe(true);
+    });
+
+    it('--report prints a table report', async () => {
+      const session = initSession({ agentkitRoot: TEST_AGENTKIT, projectRoot: TEST_PROJECT });
+      endSession({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        sessionId: session.sessionId,
+      });
+
+      await runCost({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        flags: { report: true },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('Cost & Usage Report');
+      expect(out).toContain('Sessions:');
+      expect(out).toContain('Files Modified:');
+    });
+
+    it('--report --format json emits valid JSON', async () => {
+      initSession({ agentkitRoot: TEST_AGENTKIT, projectRoot: TEST_PROJECT });
+
+      await runCost({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        flags: { report: true, format: 'json' },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      const parsed = JSON.parse(out.trim());
+      expect(parsed).toHaveProperty('month');
+      expect(parsed).toHaveProperty('totalSessions');
+    });
+
+    it('--report --format csv emits CSV header and rows', async () => {
+      const session = initSession({ agentkitRoot: TEST_AGENTKIT, projectRoot: TEST_PROJECT });
+      endSession({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        sessionId: session.sessionId,
+      });
+
+      await runCost({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        flags: { report: true, format: 'csv' },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('user,sessions,duration_ms,files_modified');
+    });
+
+    it('--report respects --month flag', async () => {
+      await runCost({
+        agentkitRoot: TEST_AGENTKIT,
+        projectRoot: TEST_PROJECT,
+        flags: { report: true, month: '2024-03', format: 'json' },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      const parsed = JSON.parse(out.trim());
+      expect(parsed.month).toBe('2024-03');
     });
   });
 });

--- a/.agentkit/engines/node/src/__tests__/discover.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/discover.test.mjs
@@ -79,6 +79,54 @@ describe('runDiscover()', () => {
     expect(Array.isArray(report.structure.topLevelDirs)).toBe(true);
   });
 
+  it('renders a markdown report when output=markdown', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runDiscover({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot: tmpDir,
+      flags: { output: 'markdown' },
+    });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('# Discovery Report');
+    expect(out).toContain('## Tech Stacks');
+    expect(out).toContain('## Project Structure');
+  });
+
+  it('renders a markdown report including recommendations and frameworks when present', async () => {
+    // Add some framework markers and an extra config to populate more sections
+    writeFile(join(tmpDir, 'next.config.js'), 'module.exports = {};\n');
+    writeFile(join(tmpDir, 'tailwind.config.js'), 'module.exports = {};\n');
+    writeFile(join(tmpDir, 'docs', 'README.md'), '# docs\n');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runDiscover({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot: tmpDir,
+      flags: { output: 'markdown' },
+    });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('# Discovery Report');
+    // Frameworks/Documentation/CI section headers should appear when populated
+    expect(out).toContain('## CI/CD');
+  });
+
+  it('passes a userContext through when extra args supplied', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const report = await runDiscover({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot: tmpDir,
+      flags: { output: 'json', _args: ['investigate', 'auth'] },
+    });
+
+    expect(report).toBeDefined();
+    expect(logSpy).toHaveBeenCalled();
+  });
+
   it('detects GitHub Actions CI', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
 

--- a/.agentkit/engines/node/src/__tests__/doctor.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/doctor.test.mjs
@@ -158,6 +158,51 @@ describe('runDoctor', () => {
     );
   });
 
+  it('prints suggested next actions when --verbose flag is set (PASS branch)', async () => {
+    const { validateSpec } = await import('../spec-validator.mjs');
+    validateSpec.mockReturnValue({ valid: true, errors: [], warnings: [] });
+
+    vi.spyOn(fs, 'readFileSync').mockImplementation((p) => {
+      if (typeof p === 'string' && p.includes('overlays') && p.includes('settings.yaml')) {
+        return 'renderTargets: ["claude"]';
+      }
+      return '';
+    });
+    vi.spyOn(fs, 'readdirSync').mockReturnValue([]);
+
+    const logSpy = vi.spyOn(console, 'log');
+
+    await runDoctor({
+      agentkitRoot: mockAgentkitRoot,
+      projectRoot: mockProjectRoot,
+      flags: { verbose: true },
+    });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('Suggested next actions');
+  });
+
+  it('prints "fix spec errors" suggestions when --verbose and validation fails', async () => {
+    const { validateSpec } = await import('../spec-validator.mjs');
+    validateSpec.mockReturnValue({
+      valid: false,
+      errors: ['Bad field'],
+      warnings: [],
+    });
+
+    const logSpy = vi.spyOn(console, 'log');
+
+    await runDoctor({
+      agentkitRoot: mockAgentkitRoot,
+      projectRoot: mockProjectRoot,
+      flags: { verbose: true },
+    });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('Fix spec errors');
+    expect(out).toContain('spec-validate');
+  });
+
   it('should report warning if no renderTargets are defined', async () => {
     const { validateSpec } = await import('../spec-validator.mjs');
     validateSpec.mockReturnValue({ valid: true, errors: [], warnings: [] });

--- a/.agentkit/engines/node/src/__tests__/expansion-analyzer.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/expansion-analyzer.test.mjs
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
 import {
   EFFORT_LEVELS,
   IMPACT_LEVELS,
@@ -7,7 +10,6 @@ import {
   formatReportAsYaml,
   runExpansionAnalysis,
 } from '../expansion-analyzer.mjs';
-import { resolve } from 'path';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -213,5 +215,101 @@ describe('formatReportAsYaml', () => {
     const yml = formatReportAsYaml(report);
     expect(typeof yml).toBe('string');
     expect(yml).toContain('generatedAt');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty-project analysis — exercises the "missing X" branches in each analyzer
+// ---------------------------------------------------------------------------
+
+describe('runExpansionAnalysis on a near-empty project', () => {
+  let tempDir;
+  let agentkitDir;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'expansion-empty-'));
+    agentkitDir = join(tempDir, '.agentkit');
+    mkdirSync(join(agentkitDir, 'spec'), { recursive: true });
+    // No README, no CHANGELOG, no CONTRIBUTING, no docs/, no tests/, no security policy
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('produces documentation suggestions for a project missing README/CHANGELOG/CONTRIBUTING', async () => {
+    const report = await runExpansionAnalysis({
+      projectRoot: tempDir,
+      agentkitRoot: agentkitDir,
+      flags: { category: 'documentation', maxSuggestions: 50 },
+    });
+
+    const titles = report.suggestions.map((s) => s.title);
+    expect(titles.some((t) => /README/i.test(t))).toBe(true);
+    expect(titles.some((t) => /CHANGELOG/i.test(t))).toBe(true);
+    expect(titles.some((t) => /CONTRIBUTING/i.test(t))).toBe(true);
+  });
+
+  it('produces security suggestions for a project missing standard security files', async () => {
+    const report = await runExpansionAnalysis({
+      projectRoot: tempDir,
+      agentkitRoot: agentkitDir,
+      flags: { category: 'security', maxSuggestions: 50 },
+    });
+
+    expect(report.categoriesAnalyzed).toEqual(['security']);
+    // Should produce at least one security suggestion for a bare repo
+    expect(Array.isArray(report.suggestions)).toBe(true);
+  });
+
+  it('survives missing AGENT_BACKLOG.md (loadBacklogItems returns empty)', async () => {
+    const report = await runExpansionAnalysis({
+      projectRoot: tempDir,
+      agentkitRoot: agentkitDir,
+      flags: { maxSuggestions: 5 },
+    });
+    expect(report).toBeDefined();
+    expect(Array.isArray(report.suggestions)).toBe(true);
+  });
+
+  it('survives malformed AGENT_BACKLOG.md (returns empty rather than crashing)', async () => {
+    // Create a "binary" backlog file that defeats parsing
+    writeFileSync(join(tempDir, 'AGENT_BACKLOG.md'), 'plain text without bullet items\n');
+    const report = await runExpansionAnalysis({
+      projectRoot: tempDir,
+      agentkitRoot: agentkitDir,
+      flags: { maxSuggestions: 5 },
+    });
+    expect(report).toBeDefined();
+  });
+
+  it('formats markdown for a report with missing optional fields', () => {
+    const md = formatReportAsMarkdown({
+      generatedAt: '2026-03-04T00:00:00.000Z',
+      categoriesAnalyzed: [],
+      totalRawSuggestions: 0,
+      totalAfterDedup: 0,
+      suggestions: [
+        {
+          id: 'SUG-001',
+          category: 'documentation',
+          title: 'Bare suggestion',
+          rationale: 'Without artifacts',
+          impact: 'low',
+          effort: 'XS',
+          riskIfSkipped: 'low',
+          alignment: 'low',
+          score: 1,
+          // No suggestedArtifacts
+        },
+      ],
+    });
+    expect(md).toContain('Bare suggestion');
+    // No "Suggested artifacts" section since the field is absent
+    expect(md).not.toContain('Suggested artifacts');
   });
 });

--- a/.agentkit/engines/node/src/__tests__/fs-utils.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/fs-utils.test.mjs
@@ -1,0 +1,121 @@
+/**
+ * Tests for fs-utils.mjs — small stateless I/O helpers.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { ensureDir, runConcurrent, walkDir, writeOutput } from '../fs-utils.mjs';
+
+describe('runConcurrent', () => {
+  it('processes all items in chunks', async () => {
+    const seen = [];
+    await runConcurrent(
+      [1, 2, 3, 4, 5],
+      async (n) => {
+        seen.push(n);
+      },
+      2
+    );
+    expect(seen.sort()).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('handles an empty list', async () => {
+    let called = 0;
+    await runConcurrent([], async () => {
+      called++;
+    });
+    expect(called).toBe(0);
+  });
+
+  it('respects the default concurrency when none is given', async () => {
+    const items = Array.from({ length: 10 }, (_, i) => i);
+    const seen = [];
+    await runConcurrent(items, async (n) => seen.push(n));
+    expect(seen).toHaveLength(10);
+  });
+});
+
+describe('ensureDir / writeOutput', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'fs-utils-test-'));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Windows file lock — ignore
+    }
+  });
+
+  it('ensureDir creates a directory recursively', async () => {
+    const target = join(tempDir, 'a', 'b', 'c');
+    await ensureDir(target);
+    // Subsequent call is a no-op
+    await ensureDir(target);
+    expect(() => readFileSync(target)).toThrow(); // it's a dir, not a file
+  });
+
+  it('writeOutput creates parent directories on the fly', async () => {
+    const target = join(tempDir, 'nested', 'deep', 'file.txt');
+    await writeOutput(target, 'hello world');
+    expect(readFileSync(target, 'utf-8')).toBe('hello world');
+  });
+
+  it('writeOutput overwrites existing file content', async () => {
+    const target = join(tempDir, 'file.txt');
+    await writeOutput(target, 'first');
+    await writeOutput(target, 'second');
+    expect(readFileSync(target, 'utf-8')).toBe('second');
+  });
+});
+
+describe('walkDir', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'fs-utils-walk-'));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Windows file lock — ignore
+    }
+  });
+
+  it('yields nothing for a non-existent directory', async () => {
+    const found = [];
+    for await (const f of walkDir(join(tempDir, 'does-not-exist'))) {
+      found.push(f);
+    }
+    expect(found).toEqual([]);
+  });
+
+  it('yields all files in a flat directory', async () => {
+    writeFileSync(join(tempDir, 'a.txt'), 'a');
+    writeFileSync(join(tempDir, 'b.txt'), 'b');
+    const found = [];
+    for await (const f of walkDir(tempDir)) {
+      found.push(f);
+    }
+    expect(found).toHaveLength(2);
+  });
+
+  it('recurses into subdirectories', async () => {
+    writeFileSync(join(tempDir, 'top.txt'), 'top');
+    await ensureDir(join(tempDir, 'sub'));
+    writeFileSync(join(tempDir, 'sub', 'inner.txt'), 'inner');
+    const found = [];
+    for await (const f of walkDir(tempDir)) {
+      found.push(f);
+    }
+    expect(found.some((f) => f.endsWith('top.txt'))).toBe(true);
+    expect(found.some((f) => f.endsWith('inner.txt'))).toBe(true);
+  });
+});

--- a/.agentkit/engines/node/src/__tests__/handoff.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/handoff.test.mjs
@@ -169,4 +169,87 @@ describe('runHandoff()', () => {
     const content = readFileSync(resolve(handoffDir, files[0]), 'utf-8');
     expect(content).toContain('# Session Handoff');
   });
+
+  it('renders uncommitted files section when there are uncommitted changes', async () => {
+    // Override git status mock to return many uncommitted files (>10 to exercise truncation)
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const fileLines = Array.from({ length: 13 }, (_, i) => ` M  src/file${i}.js`).join('\n');
+    vi.mocked(runner.execCommand).mockImplementation((cmd) => {
+      if (cmd.includes('rev-parse --abbrev-ref'))
+        return { exitCode: 0, stdout: 'feat/x\n', stderr: '', durationMs: 5 };
+      if (cmd.includes('git status --porcelain'))
+        return { exitCode: 0, stdout: fileLines + '\n', stderr: '', durationMs: 5 };
+      if (cmd.includes('git log -5'))
+        return {
+          exitCode: 0,
+          stdout: 'abc1 first\ndef2 second\n',
+          stderr: '',
+          durationMs: 5,
+        };
+      if (cmd.includes('git log'))
+        return { exitCode: 0, stdout: 'abc1234 Initial\n', stderr: '', durationMs: 5 };
+      if (cmd.includes('git diff')) return { exitCode: 0, stdout: '', stderr: '', durationMs: 5 };
+      return { exitCode: 1, stdout: '', stderr: '', durationMs: 0 };
+    });
+
+    const result = await runHandoff({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot: TEST_ROOT,
+      flags: {},
+    });
+
+    expect(result.uncommittedCount).toBe(13);
+    expect(result.document).toContain('### Uncommitted Files');
+    expect(result.document).toContain('### Recent Commits');
+    expect(result.document).toContain('and 3 more'); // truncation marker
+    // Next-steps should mention reviewing uncommitted changes
+    expect(result.document).toContain('Review and commit');
+  });
+
+  it('warns and falls back to "unknown" branch when git is not available', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    vi.mocked(runner.execCommand).mockReturnValue({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'not a git repo',
+      durationMs: 5,
+    });
+
+    const result = await runHandoff({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot: TEST_ROOT,
+      flags: {},
+    });
+    expect(result.branch).toBe('unknown');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('handles state with no team_progress and no todo_items gracefully', async () => {
+    setupTestProject({ team_progress: {}, todo_items: [] });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await runHandoff({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot: TEST_ROOT,
+      flags: {},
+    });
+
+    // Without active teams or todos, those sections should be omitted
+    expect(result.document).not.toContain('## Team Progress');
+    expect(result.document).not.toContain('## Open Items');
+  });
+
+  it('passes userContext through when extra args supplied', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runHandoff({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot: TEST_ROOT,
+      flags: { _args: ['extra', 'context'] },
+    });
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('Context: extra context');
+  });
 });

--- a/.agentkit/engines/node/src/__tests__/healthcheck.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/healthcheck.test.mjs
@@ -175,6 +175,223 @@ describe('runHealthcheck()', () => {
     }
   });
 
+  it('detects stacks via wildcard markers and runs build/test/lint checks', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    // Tooling: irrelevant for this test
+    vi.spyOn(runner, 'commandExists').mockReturnValue(false);
+    vi.spyOn(runner, 'execCommand').mockReturnValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      durationMs: 50,
+    });
+    vi.spyOn(runner, 'isValidCommand').mockReturnValue(true);
+
+    vi.spyOn(orchestrator, 'loadState').mockReturnValue({});
+    vi.spyOn(orchestrator, 'saveState').mockImplementation(() => {});
+    vi.spyOn(orchestrator, 'appendEvent').mockImplementation(() => {});
+
+    // Build a tiny project with a JS file so the wildcard '*.js' marker matches
+    mkdirSync(TEST_ROOT, { recursive: true });
+    writeFileSync(resolve(TEST_ROOT, 'main.js'), 'console.log(1)\n');
+
+    // Build an agentkitRoot with a teams.yaml that has wildcard detection
+    const tinyAgentkit = resolve(TEST_ROOT, '.agentkit-tiny');
+    mkdirSync(resolve(tinyAgentkit, 'spec'), { recursive: true });
+    writeFileSync(
+      resolve(tinyAgentkit, 'spec', 'teams.yaml'),
+      `techStacks:\n` +
+        `  - name: js-stack\n` +
+        `    detect: ['*.js']\n` +
+        `    buildCommand: 'echo build'\n` +
+        `    testCommand: 'echo test'\n` +
+        `    linter: 'eslint'\n`
+    );
+
+    const result = await runHealthcheck({
+      agentkitRoot: tinyAgentkit,
+      projectRoot: TEST_ROOT,
+      flags: {},
+    });
+
+    expect(result.stacks.length).toBe(1);
+    expect(result.stacks[0].name).toBe('js-stack');
+    // build, test, lint
+    expect(result.stacks[0].checks.length).toBe(3);
+    expect(result.stacks[0].checks.every((c) => c.status === 'PASS')).toBe(true);
+    expect(result.overallHealth).toBe('HEALTHY');
+  });
+
+  it('marks overallHealth UNHEALTHY when a stack check fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    vi.spyOn(runner, 'commandExists').mockReturnValue(false);
+    // Build returns failure, test/lint succeed
+    vi.spyOn(runner, 'execCommand').mockImplementation((cmd) => {
+      if (cmd.includes('build')) {
+        return { exitCode: 1, stdout: '', stderr: 'fail', durationMs: 10 };
+      }
+      return { exitCode: 0, stdout: '', stderr: '', durationMs: 10 };
+    });
+    vi.spyOn(runner, 'isValidCommand').mockReturnValue(true);
+
+    vi.spyOn(orchestrator, 'loadState').mockReturnValue({});
+    vi.spyOn(orchestrator, 'saveState').mockImplementation(() => {});
+    vi.spyOn(orchestrator, 'appendEvent').mockImplementation(() => {});
+
+    mkdirSync(TEST_ROOT, { recursive: true });
+    writeFileSync(resolve(TEST_ROOT, 'package.json'), '{}\n');
+
+    const tinyAgentkit = resolve(TEST_ROOT, '.agentkit-tiny2');
+    mkdirSync(resolve(tinyAgentkit, 'spec'), { recursive: true });
+    writeFileSync(
+      resolve(tinyAgentkit, 'spec', 'teams.yaml'),
+      `techStacks:\n` +
+        `  - name: pkg-stack\n` +
+        `    detect: ['package.json']\n` +
+        `    buildCommand: 'npm run build'\n` +
+        `    testCommand: 'npm test'\n`
+    );
+
+    const result = await runHealthcheck({
+      agentkitRoot: tinyAgentkit,
+      projectRoot: TEST_ROOT,
+      flags: {},
+    });
+
+    expect(result.overallHealth).toBe('UNHEALTHY');
+    const buildCheck = result.stacks[0].checks.find((c) => c.name === 'build');
+    expect(buildCheck.status).toBe('FAIL');
+  });
+
+  it('skips invalid commands and reports SKIP status', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    vi.spyOn(runner, 'commandExists').mockReturnValue(false);
+    vi.spyOn(runner, 'execCommand').mockReturnValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      durationMs: 5,
+    });
+    // Force isValidCommand to return false to exercise the SKIP branch
+    vi.spyOn(runner, 'isValidCommand').mockReturnValue(false);
+
+    vi.spyOn(orchestrator, 'loadState').mockReturnValue({});
+    vi.spyOn(orchestrator, 'saveState').mockImplementation(() => {});
+    vi.spyOn(orchestrator, 'appendEvent').mockImplementation(() => {});
+
+    mkdirSync(TEST_ROOT, { recursive: true });
+    writeFileSync(resolve(TEST_ROOT, 'package.json'), '{}\n');
+
+    const tinyAgentkit = resolve(TEST_ROOT, '.agentkit-tiny3');
+    mkdirSync(resolve(tinyAgentkit, 'spec'), { recursive: true });
+    writeFileSync(
+      resolve(tinyAgentkit, 'spec', 'teams.yaml'),
+      `techStacks:\n` +
+        `  - name: stack\n` +
+        `    detect: ['package.json']\n` +
+        `    buildCommand: 'malicious; rm -rf /'\n`
+    );
+
+    const result = await runHealthcheck({
+      agentkitRoot: tinyAgentkit,
+      projectRoot: TEST_ROOT,
+      flags: {},
+    });
+
+    expect(result.stacks[0].checks[0].status).toBe('SKIP');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('creates auto-tasks when auto-task flag set and a stack check fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    vi.spyOn(runner, 'commandExists').mockReturnValue(false);
+    vi.spyOn(runner, 'execCommand').mockReturnValue({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'broken',
+      durationMs: 10,
+    });
+    vi.spyOn(runner, 'isValidCommand').mockReturnValue(true);
+
+    vi.spyOn(orchestrator, 'loadState').mockReturnValue({});
+    vi.spyOn(orchestrator, 'saveState').mockImplementation(() => {});
+    vi.spyOn(orchestrator, 'appendEvent').mockImplementation(() => {});
+
+    const createTaskSpy = vi
+      .spyOn(taskProtocol, 'createTask')
+      .mockResolvedValue({ task: { id: 't-1' }, error: null });
+
+    mkdirSync(TEST_ROOT, { recursive: true });
+    writeFileSync(resolve(TEST_ROOT, 'package.json'), '{}\n');
+
+    const tinyAgentkit = resolve(TEST_ROOT, '.agentkit-auto-task');
+    mkdirSync(resolve(tinyAgentkit, 'spec'), { recursive: true });
+    writeFileSync(
+      resolve(tinyAgentkit, 'spec', 'teams.yaml'),
+      `techStacks:\n` +
+        `  - name: pkg-stack\n` +
+        `    detect: ['package.json']\n` +
+        `    buildCommand: 'npm run build'\n`
+    );
+
+    const result = await runHealthcheck({
+      agentkitRoot: tinyAgentkit,
+      projectRoot: TEST_ROOT,
+      flags: { 'auto-task': true },
+    });
+
+    expect(result.overallHealth).toBe('UNHEALTHY');
+    expect(createTaskSpy).toHaveBeenCalled();
+    const call = createTaskSpy.mock.calls[0];
+    expect(call[1].delegator).toBe('healthcheck');
+    expect(call[1].type).toBe('investigate');
+    expect(call[1].assignees).toEqual(['testing']);
+  });
+
+  it('warns when state update fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    vi.spyOn(runner, 'commandExists').mockReturnValue(false);
+    vi.spyOn(runner, 'execCommand').mockReturnValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      durationMs: 5,
+    });
+
+    // loadState rejects (simulates lock or filesystem error)
+    vi.spyOn(orchestrator, 'loadState').mockImplementation(() => {
+      throw new Error('state load failed');
+    });
+
+    mkdirSync(TEST_ROOT, { recursive: true });
+
+    const result = await runHealthcheck({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot: TEST_ROOT,
+      flags: {},
+    });
+
+    expect(result).toBeDefined();
+    // Warn should have been called for the state update failure
+    const warnCalls = warnSpy.mock.calls.flat().join('\n');
+    expect(warnCalls).toContain('State update failed');
+  });
+
   it('handles project root without agentkit setup', async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     mkdirSync(STATE_DIR, { recursive: true });

--- a/.agentkit/engines/node/src/__tests__/init.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/init.test.mjs
@@ -573,4 +573,107 @@ describe('runInit', () => {
       expect(settings.primaryStack).toBe('rust');
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Preset path
+  // ---------------------------------------------------------------------------
+  describe('preset path', () => {
+    it('runs init with --preset minimal', async () => {
+      const agentkitRoot = setupAgentkitRoot(resolve(tmpRoot, 'agentkit'));
+      vi.doMock('../discover.mjs', () => ({
+        runDiscover: vi.fn().mockResolvedValue(makeStubReport()),
+      }));
+      vi.doMock('../synchronize.mjs', () => ({
+        runSync: vi.fn().mockResolvedValue(undefined),
+      }));
+      vi.resetModules();
+      const { runInit: initFn } = await import('../init.mjs');
+      await initFn({
+        agentkitRoot,
+        projectRoot,
+        flags: { preset: 'minimal', repoName: 'preset-min' },
+      });
+
+      const settings = yaml.load(
+        readFileSync(resolve(agentkitRoot, 'overlays', 'preset-min', 'settings.yaml'), 'utf-8')
+      );
+      expect(Array.isArray(settings.renderTargets)).toBe(true);
+      // minimal preset has fewer targets than full
+      expect(settings.renderTargets.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('throws on unknown preset', async () => {
+      const agentkitRoot = setupAgentkitRoot(resolve(tmpRoot, 'agentkit'));
+      vi.resetModules();
+      const { runInit: initFn } = await import('../init.mjs');
+
+      await expect(
+        initFn({
+          agentkitRoot,
+          projectRoot,
+          flags: { preset: 'totally-bogus', repoName: 'p' },
+        })
+      ).rejects.toThrow(/Unknown preset/);
+    });
+
+    it('throws when overlay already exists without --force', async () => {
+      const agentkitRoot = setupAgentkitRoot(resolve(tmpRoot, 'agentkit'));
+      // Pre-create the overlay dir
+      mkdirSync(resolve(agentkitRoot, 'overlays', 'existing-name'), { recursive: true });
+
+      vi.doMock('../discover.mjs', () => ({
+        runDiscover: vi.fn().mockResolvedValue(makeStubReport()),
+      }));
+      vi.resetModules();
+      const { runInit: initFn } = await import('../init.mjs');
+
+      await expect(
+        initFn({
+          agentkitRoot,
+          projectRoot,
+          flags: { 'non-interactive': true, repoName: 'existing-name' },
+        })
+      ).rejects.toThrow(/already exists/);
+    });
+
+    it('throws on invalid repo name', async () => {
+      const agentkitRoot = setupAgentkitRoot(resolve(tmpRoot, 'agentkit'));
+      vi.resetModules();
+      const { runInit: initFn } = await import('../init.mjs');
+
+      await expect(
+        initFn({
+          agentkitRoot,
+          projectRoot,
+          flags: { 'non-interactive': true, repoName: '../escape-attempt' },
+        })
+      ).rejects.toThrow(/Invalid repo name/);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dry-run path
+  // ---------------------------------------------------------------------------
+  describe('dry-run', () => {
+    it('does not create overlay directory', async () => {
+      const agentkitRoot = setupAgentkitRoot(resolve(tmpRoot, 'agentkit'));
+      vi.doMock('../discover.mjs', () => ({
+        runDiscover: vi.fn().mockResolvedValue(makeStubReport()),
+      }));
+      vi.doMock('../synchronize.mjs', () => ({
+        runSync: vi.fn().mockResolvedValue(undefined),
+      }));
+      vi.resetModules();
+      const { runInit: initFn } = await import('../init.mjs');
+      await initFn({
+        agentkitRoot,
+        projectRoot,
+        flags: { 'non-interactive': true, 'dry-run': true, repoName: 'dry-run-test' },
+      });
+
+      // No overlay dir written
+      const overlayDir = resolve(agentkitRoot, 'overlays', 'dry-run-test');
+      expect(existsSync(overlayDir)).toBe(false);
+    });
+  });
 });

--- a/.agentkit/engines/node/src/__tests__/orchestrator.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/orchestrator.test.mjs
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   PHASES,
   VALID_TEAM_IDS,
@@ -11,12 +11,18 @@ import {
   checkLock,
   clearTeamsSpecCache,
   computeEscalation,
+  delegateTask,
   getStatus,
   getTasksSummary,
+  getTasksSummaryAsync,
   loadState,
+  orchestratorCheckDependencies,
+  orchestratorProcessHandoffs,
   readEvents,
   releaseLock,
   resolveTeamByArea,
+  routePhase4TestFailure,
+  runOrchestrate,
   saveState,
   setPhase,
   updateTeamStatus,
@@ -504,6 +510,286 @@ describe('orchestrator', () => {
       expect(result).toContain('devops');
       expect(result).toContain('infra');
       expect(result).toContain('engineering');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getTasksSummaryAsync — async equivalent of getTasksSummary
+  // -------------------------------------------------------------------------
+
+  describe('getTasksSummaryAsync()', () => {
+    it('returns empty-queue message when there are no tasks', async () => {
+      const result = await getTasksSummaryAsync(TEST_ROOT);
+      expect(result).toBe('No tasks in the task queue.');
+    });
+
+    it('returns active task counts for in-progress tasks', async () => {
+      mkdirSync(TASKS_DIR, { recursive: true });
+      writeFileSync(
+        resolve(TASKS_DIR, 't1.json'),
+        JSON.stringify({
+          id: 'task-001',
+          status: 'in_progress',
+          title: 'Active',
+          priority: 'P1',
+          assignees: ['team-backend'],
+          createdAt: new Date().toISOString(),
+        })
+      );
+      const result = await getTasksSummaryAsync(TEST_ROOT);
+      expect(result).toContain('Active tasks: 1');
+    });
+
+    it('counts terminal tasks separately', async () => {
+      mkdirSync(TASKS_DIR, { recursive: true });
+      writeFileSync(
+        resolve(TASKS_DIR, 't1.json'),
+        JSON.stringify({
+          id: 'task-001',
+          status: 'completed',
+          title: 'Done',
+          priority: 'P1',
+          assignees: ['team-backend'],
+          createdAt: new Date().toISOString(),
+        })
+      );
+      const result = await getTasksSummaryAsync(TEST_ROOT);
+      expect(result).toContain('Completed/closed tasks: 1');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // runOrchestrate — CLI handler
+  // -------------------------------------------------------------------------
+
+  describe('runOrchestrate()', () => {
+    let logSpy;
+    let errorSpy;
+    let exitSpy;
+
+    beforeEach(() => {
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+
+    it('--status prints orchestrator status and returns', async () => {
+      await runOrchestrate({
+        agentkitRoot: AGENTKIT_ROOT,
+        projectRoot: TEST_ROOT,
+        flags: { status: true },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('Orchestrator Status');
+    });
+
+    it('--force-unlock with no existing lock prints "no lock"', async () => {
+      await runOrchestrate({
+        agentkitRoot: AGENTKIT_ROOT,
+        projectRoot: TEST_ROOT,
+        flags: { 'force-unlock': true },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('No lock to release');
+    });
+
+    it('--force-unlock with existing lock releases it', async () => {
+      acquireLock(TEST_ROOT);
+      await runOrchestrate({
+        agentkitRoot: AGENTKIT_ROOT,
+        projectRoot: TEST_ROOT,
+        flags: { 'force-unlock': true },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('Lock released');
+    });
+
+    it('--phase N sets the orchestrator phase and persists state', async () => {
+      await runOrchestrate({
+        agentkitRoot: AGENTKIT_ROOT,
+        projectRoot: TEST_ROOT,
+        flags: { phase: '3' },
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('Phase set to 3');
+      const state = await loadState(TEST_ROOT);
+      expect(state.current_phase).toBe(3);
+    });
+
+    it('--phase with an invalid value reports an error', async () => {
+      await runOrchestrate({
+        agentkitRoot: AGENTKIT_ROOT,
+        projectRoot: TEST_ROOT,
+        flags: { phase: '99' },
+      });
+      const errOut = errorSpy.mock.calls.flat().join('\n');
+      expect(errOut.length).toBeGreaterThan(0);
+    });
+
+    it('default flow prints phase, next action, and event log entry', async () => {
+      await runOrchestrate({
+        agentkitRoot: AGENTKIT_ROOT,
+        projectRoot: TEST_ROOT,
+        flags: {},
+      });
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('Current phase:');
+      expect(out).toContain('Next action:');
+    });
+
+    it('exits with error when an existing lock blocks execution', async () => {
+      // Acquire a lock to force the locked-state branch
+      acquireLock(TEST_ROOT, { pid: 99999 });
+
+      await expect(
+        runOrchestrate({
+          agentkitRoot: AGENTKIT_ROOT,
+          projectRoot: TEST_ROOT,
+          flags: {},
+        })
+      ).rejects.toThrow('process.exit called');
+
+      const errOut = errorSpy.mock.calls.flat().join('\n');
+      expect(errOut).toContain('Session locked');
+    });
+
+    it('passes userContext through when extra args supplied', async () => {
+      await runOrchestrate({
+        agentkitRoot: AGENTKIT_ROOT,
+        projectRoot: TEST_ROOT,
+        flags: { _args: ['build', 'auth'] },
+      });
+      // The event log should have userContext embedded
+      const events = await readEvents(TEST_ROOT);
+      const orchEvent = events.find((e) => e.action === 'orchestrate_invoked');
+      expect(orchEvent).toBeDefined();
+      // userContext is part of the data payload
+      const userCtx = orchEvent?.userContext ?? orchEvent?.data?.userContext;
+      expect(userCtx).toBe('build auth');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // delegateTask
+  // -------------------------------------------------------------------------
+
+  describe('delegateTask()', () => {
+    it('creates a task and updates orchestrator state with active_tasks and team_progress', async () => {
+      const state = await loadState(TEST_ROOT);
+      const result = await delegateTask(TEST_ROOT, state, {
+        type: 'implement',
+        title: 'Add pagination',
+        assignees: ['team-backend'],
+        priority: 'P1',
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.task.id).toMatch(/^task-/);
+      expect(result.task.assignees).toEqual(['team-backend']);
+      expect(result.state.active_tasks['team-backend']).toContain(result.task.id);
+      expect(result.state.team_progress['team-backend'].status).toBe('in_progress');
+    });
+
+    it('preserves existing team_progress entries on subsequent delegations', async () => {
+      const state = await loadState(TEST_ROOT);
+      const r1 = await delegateTask(TEST_ROOT, state, {
+        type: 'implement',
+        title: 'First',
+        assignees: ['team-backend'],
+      });
+      const r2 = await delegateTask(TEST_ROOT, r1.state, {
+        type: 'implement',
+        title: 'Second',
+        assignees: ['team-backend'],
+      });
+
+      expect(r2.state.active_tasks['team-backend'].length).toBe(2);
+      expect(Object.keys(r2.state.team_progress['team-backend'].tasks).length).toBe(2);
+    });
+
+    it('handles tasks with multiple assignees', async () => {
+      const state = await loadState(TEST_ROOT);
+      const result = await delegateTask(TEST_ROOT, state, {
+        type: 'implement',
+        title: 'Cross-team task',
+        assignees: ['team-backend', 'team-frontend'],
+      });
+
+      expect(result.state.active_tasks['team-backend']).toContain(result.task.id);
+      expect(result.state.active_tasks['team-frontend']).toContain(result.task.id);
+    });
+
+    it('returns the original state and an error when createTask fails', async () => {
+      const state = await loadState(TEST_ROOT);
+      const result = await delegateTask(TEST_ROOT, state, {
+        // missing required fields — should fail validation
+        type: 'invalid-type-that-does-not-exist',
+        title: '',
+      });
+
+      expect(result.error).toBeDefined();
+      expect(result.task).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // orchestratorCheckDependencies
+  // -------------------------------------------------------------------------
+
+  describe('orchestratorCheckDependencies()', () => {
+    it('returns a state object even when there are no tasks', async () => {
+      const state = await loadState(TEST_ROOT);
+      const result = await orchestratorCheckDependencies(TEST_ROOT, state);
+      expect(result).toBeDefined();
+      expect(result.state).toBeDefined();
+      expect(Array.isArray(result.unblocked)).toBe(true);
+      expect(Array.isArray(result.errors)).toBe(true);
+    });
+
+    it('clones state defensively (does not mutate input)', async () => {
+      const state = await loadState(TEST_ROOT);
+      const beforeJson = JSON.stringify(state);
+      await orchestratorCheckDependencies(TEST_ROOT, state);
+      expect(JSON.stringify(state)).toBe(beforeJson);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // orchestratorProcessHandoffs
+  // -------------------------------------------------------------------------
+
+  describe('orchestratorProcessHandoffs()', () => {
+    it('returns the state unchanged when there are no handoffs to process', async () => {
+      const state = await loadState(TEST_ROOT);
+      const result = await orchestratorProcessHandoffs(TEST_ROOT, state);
+      expect(result.created).toEqual([]);
+      expect(result.errors).toEqual([]);
+      expect(result.state).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // routePhase4TestFailure
+  // -------------------------------------------------------------------------
+
+  describe('routePhase4TestFailure()', () => {
+    it('returns null task when no failed checks are present', async () => {
+      const state = await loadState(TEST_ROOT);
+      const checkResult = {
+        overallStatus: 'PASS',
+        stacks: [],
+      };
+      const result = await routePhase4TestFailure(TEST_ROOT, state, checkResult, ['team-backend']);
+      expect(result.task).toBeNull();
+      expect(result.state).toBe(state); // returns same state when nothing routed
     });
   });
 });

--- a/.agentkit/engines/node/src/__tests__/retort-config-wizard.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/retort-config-wizard.test.mjs
@@ -352,4 +352,211 @@ describe('runRetortConfigWizard', () => {
     const { readRetortConfig } = await import('../retort-config.mjs');
     expect(readRetortConfig(projectRoot)).toBeNull();
   });
+
+  // -------------------------------------------------------------------------
+  // Interactive wizard branches — mock @clack/prompts to drive each step
+  // -------------------------------------------------------------------------
+
+  describe('interactive wizard with mocked @clack/prompts', () => {
+    let clackMock;
+    let originalIsTTY;
+
+    beforeEach(() => {
+      // Force isTTY to true so the wizard takes the interactive path
+      originalIsTTY = process.stdout.isTTY;
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+
+      clackMock = {
+        intro: vi.fn(),
+        outro: vi.fn(),
+        cancel: vi.fn(),
+        text: vi.fn(),
+        select: vi.fn(),
+        multiselect: vi.fn(),
+        confirm: vi.fn(),
+        isCancel: vi.fn(() => false),
+        log: { success: vi.fn(), error: vi.fn() },
+        note: vi.fn(),
+      };
+      vi.doMock('@clack/prompts', () => clackMock);
+    });
+
+    afterEach(() => {
+      vi.doUnmock('@clack/prompts');
+      vi.resetModules();
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+    });
+
+    it('happy path — answers every prompt and writes a complete config', async () => {
+      // Phase A: project metadata
+      clackMock.text
+        .mockResolvedValueOnce('my-app') // projectName
+        .mockResolvedValueOnce('service'); // projectType
+
+      // Stacks, compliance, then phases B and C
+      clackMock.multiselect
+        .mockResolvedValueOnce(['typescript', 'node']) // stacks
+        .mockResolvedValueOnce(['gdpr']) // compliance
+        .mockResolvedValueOnce(['backend']) // disabled agents
+        .mockResolvedValueOnce(['frontend']) // remap candidates
+        .mockResolvedValueOnce(['cost-tracking']); // selected features (default)
+
+      // Confirm dialogs:
+      clackMock.confirm
+        .mockResolvedValueOnce(true) // configure agents?
+        .mockResolvedValueOnce(true) // remap agents?
+        .mockResolvedValueOnce(true); // override features?
+
+      // Remap text prompt for the frontend agent
+      clackMock.text.mockResolvedValueOnce('quality');
+
+      vi.resetModules();
+      const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+      await runRetortConfigWizard({
+        agentkitRoot,
+        projectRoot,
+        flags: { force: true },
+        prefill: { projectName: 'pre', stacks: [], enabledFeatures: null },
+      });
+
+      const configPath = resolve(projectRoot, '.retortconfig');
+      expect(existsSync(configPath)).toBe(true);
+
+      const raw = readFileSync(configPath, 'utf-8');
+      const parsed = yaml.load(raw.replace(/^#.*$/gm, '').trim());
+
+      expect(parsed.project.name).toBe('my-app');
+      expect(parsed.project.type).toBe('service');
+      expect(parsed.project.stacks).toEqual(['typescript', 'node']);
+      expect(parsed.project.compliance).toEqual(['gdpr']);
+      expect(parsed.agents.backend).toBeNull(); // disabled
+      expect(parsed.agents.frontend).toEqual({ team: 'quality' }); // remapped
+
+      expect(clackMock.intro).toHaveBeenCalled();
+      expect(clackMock.outro).toHaveBeenCalled();
+    });
+
+    it('cancels at the project name prompt and writes nothing', async () => {
+      const cancelSym = Symbol('cancel');
+      clackMock.text.mockResolvedValueOnce(cancelSym);
+      clackMock.isCancel.mockImplementation((v) => v === cancelSym);
+
+      vi.resetModules();
+      const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+      await runRetortConfigWizard({
+        agentkitRoot,
+        projectRoot,
+        flags: { force: true },
+        prefill: { projectName: 'pre', stacks: [], enabledFeatures: null },
+      });
+
+      const configPath = resolve(projectRoot, '.retortconfig');
+      expect(existsSync(configPath)).toBe(false);
+      expect(clackMock.cancel).toHaveBeenCalled();
+    });
+
+    it('skips agent and feature configuration when user declines confirms', async () => {
+      // Phase A
+      clackMock.text
+        .mockResolvedValueOnce('skip-app') // projectName
+        .mockResolvedValueOnce('library'); // projectType
+
+      clackMock.multiselect
+        .mockResolvedValueOnce([]) // stacks
+        .mockResolvedValueOnce(['none']); // compliance — none filtered out
+
+      // Decline both opt-ins
+      clackMock.confirm
+        .mockResolvedValueOnce(false) // configure agents?
+        .mockResolvedValueOnce(false); // override features?
+
+      vi.resetModules();
+      const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+      await runRetortConfigWizard({
+        agentkitRoot,
+        projectRoot,
+        flags: { force: true },
+        prefill: { projectName: 'pre', stacks: [], enabledFeatures: null },
+      });
+
+      const configPath = resolve(projectRoot, '.retortconfig');
+      const raw = readFileSync(configPath, 'utf-8');
+      const parsed = yaml.load(raw.replace(/^#.*$/gm, '').trim());
+
+      expect(parsed.project.name).toBe('skip-app');
+      expect(parsed.project.type).toBe('library');
+      expect(parsed.agents).toBeUndefined();
+      expect(parsed.features).toBeUndefined();
+      expect(parsed.project.compliance).toBeUndefined(); // none filtered out
+    });
+
+    it('falls back to non-interactive mode when @clack/prompts is unavailable', async () => {
+      vi.resetModules();
+      vi.doUnmock('@clack/prompts');
+      vi.doMock('@clack/prompts', () => {
+        throw new Error('module not installed');
+      });
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+      await runRetortConfigWizard({
+        agentkitRoot,
+        projectRoot,
+        flags: { force: true },
+        prefill: { projectName: 'fallback', stacks: ['typescript'], enabledFeatures: null },
+      });
+
+      const configPath = resolve(projectRoot, '.retortconfig');
+      expect(existsSync(configPath)).toBe(true);
+      const raw = readFileSync(configPath, 'utf-8');
+      const parsed = yaml.load(raw.replace(/^#.*$/gm, '').trim());
+      expect(parsed.project.name).toBe('fallback');
+
+      const warnCalls = warnSpy.mock.calls.flat().join('\n');
+      expect(warnCalls).toContain('@clack/prompts not available');
+
+      warnSpy.mockRestore();
+    });
+
+    it('records feature deviations from defaults only', async () => {
+      // Phase A
+      clackMock.text.mockResolvedValueOnce('feat-app').mockResolvedValueOnce('application');
+      clackMock.multiselect
+        .mockResolvedValueOnce([]) // stacks
+        .mockResolvedValueOnce([]) // compliance
+        .mockResolvedValueOnce([]); // selected features — all off, drift-check matches default (off), cost-tracking deviates from on
+
+      clackMock.confirm
+        .mockResolvedValueOnce(false) // skip agents
+        .mockResolvedValueOnce(true); // configure features
+
+      vi.resetModules();
+      const { runRetortConfigWizard } = await import('../retort-config-wizard.mjs');
+
+      await runRetortConfigWizard({
+        agentkitRoot,
+        projectRoot,
+        flags: { force: true },
+        prefill: { projectName: 'p', stacks: [], enabledFeatures: null },
+      });
+
+      const configPath = resolve(projectRoot, '.retortconfig');
+      const raw = readFileSync(configPath, 'utf-8');
+      const parsed = yaml.load(raw.replace(/^#.*$/gm, '').trim());
+
+      // cost-tracking defaults to true; selecting [] turns it off — that is a deviation
+      expect(parsed.features).toBeDefined();
+      expect(parsed.features['cost-tracking']).toBe(false);
+      // drift-check defaults to false and stays false — no deviation, omitted
+      expect(parsed.features['drift-check']).toBeUndefined();
+    });
+  });
 });

--- a/.agentkit/engines/node/src/__tests__/run-cli.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/run-cli.test.mjs
@@ -418,4 +418,118 @@ describe('runRun', () => {
     const result = JSON.parse(output[0]);
     expect(result.taskId).toBe(frontendTask.id);
   });
+
+  // -------------------------------------------------------------------------
+  // Non-JSON output paths
+  // -------------------------------------------------------------------------
+
+  it('non-JSON output prints "dispatched" message and prompt', async () => {
+    await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['BACKEND'],
+      title: 'Pretty print task',
+    });
+
+    const logs = [];
+    vi.spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+
+    await runRun({ projectRoot: tmpRoot, flags: {} });
+
+    const out = logs.join('\n');
+    expect(out).toContain('Dispatched');
+    expect(out).toContain('working');
+    expect(out).toContain('/team-backend');
+  });
+
+  it('non-JSON output prints "DRY RUN" message in dry-run mode', async () => {
+    await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['BACKEND'],
+      title: 'Dry run task',
+    });
+
+    const logs = [];
+    vi.spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+
+    await runRun({ projectRoot: tmpRoot, flags: { 'dry-run': true } });
+
+    const out = logs.join('\n');
+    expect(out).toContain('DRY RUN');
+  });
+
+  it('non-JSON: prints empty-queue message when no tasks', async () => {
+    const logs = [];
+    vi.spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+
+    await runRun({ projectRoot: tmpRoot, flags: {} });
+
+    const out = logs.join('\n');
+    expect(out).toContain('No submitted tasks in queue');
+  });
+
+  it('non-JSON: prints empty-queue message with assignee suffix when filter set', async () => {
+    const logs = [];
+    vi.spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+
+    await runRun({ projectRoot: tmpRoot, flags: { assignee: 'BACKEND' } });
+
+    const out = logs.join('\n');
+    expect(out).toContain('No submitted tasks');
+    expect(out).toContain('BACKEND');
+  });
+
+  it('non-JSON: prints error to stderr for non-existent --id', async () => {
+    const errLogs = [];
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      errLogs.push(args.join(' '));
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('EXIT');
+    });
+
+    await expect(runRun({ projectRoot: tmpRoot, flags: { id: 'task-bogus' } })).rejects.toThrow(
+      'EXIT'
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errLogs.join('\n')).toContain('Task not found');
+  });
+
+  it('non-JSON: prints "not dispatchable" error for terminal-state tasks', async () => {
+    const { task: created } = await createTask(tmpRoot, {
+      type: 'implement',
+      delegator: 'orchestrator',
+      assignees: ['BACKEND'],
+      title: 'Terminal',
+    });
+    const { updateTaskStatus } = await import('../task-protocol.mjs');
+    await updateTaskStatus(tmpRoot, created.id, 'accepted');
+    await updateTaskStatus(tmpRoot, created.id, 'working');
+    await updateTaskStatus(tmpRoot, created.id, 'completed');
+
+    const errLogs = [];
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      errLogs.push(args.join(' '));
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('EXIT');
+    });
+
+    await expect(runRun({ projectRoot: tmpRoot, flags: { id: created.id } })).rejects.toThrow(
+      'EXIT'
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errLogs.join('\n')).toContain('not dispatchable');
+  });
 });

--- a/.agentkit/engines/node/src/__tests__/runner.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/runner.test.mjs
@@ -6,6 +6,8 @@ import {
   formatDuration,
   isValidCommand,
   formatTimestamp,
+  runWithConcurrency,
+  runInPool,
 } from '../runner.mjs';
 
 describe('execCommand()', () => {
@@ -143,5 +145,68 @@ describe('formatTimestamp()', () => {
 
   it('handles timestamps without milliseconds', () => {
     expect(formatTimestamp('2026-02-23T17:30:00Z')).toBe('2026-02-23 17:30:00');
+  });
+});
+
+describe('runWithConcurrency', () => {
+  it('runs all tasks and returns results in original order', async () => {
+    const tasks = [1, 2, 3, 4, 5].map((n) => () => Promise.resolve(n * 2));
+    const results = await runWithConcurrency(tasks, 2);
+    expect(results).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it('respects the concurrency limit', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const tasks = Array.from({ length: 10 }, () => async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active--;
+      return 'ok';
+    });
+    await runWithConcurrency(tasks, 3);
+    expect(maxActive).toBeLessThanOrEqual(3);
+  });
+
+  it('handles an empty task list', async () => {
+    const results = await runWithConcurrency([], 5);
+    expect(results).toEqual([]);
+  });
+
+  it('handles concurrency higher than the task count', async () => {
+    const tasks = [() => Promise.resolve(1), () => Promise.resolve(2)];
+    const results = await runWithConcurrency(tasks, 10);
+    expect(results).toEqual([1, 2]);
+  });
+});
+
+describe('runInPool', () => {
+  it('runs all tasks and returns results in order', async () => {
+    const tasks = [1, 2, 3, 4].map((n) => () => Promise.resolve(`r${n}`));
+    const results = await runInPool(tasks, 2);
+    expect(results).toEqual(['r1', 'r2', 'r3', 'r4']);
+  });
+
+  it('throws TypeError when tasks is not an array', async () => {
+    await expect(runInPool('not an array', 2)).rejects.toThrow(TypeError);
+  });
+
+  it('returns empty array for empty input', async () => {
+    expect(await runInPool([], 5)).toEqual([]);
+  });
+
+  it('throws RangeError for non-finite or non-positive concurrency', async () => {
+    const tasks = [() => Promise.resolve(1)];
+    await expect(runInPool(tasks, 0)).rejects.toThrow(RangeError);
+    await expect(runInPool(tasks, -1)).rejects.toThrow(RangeError);
+    await expect(runInPool(tasks, Infinity)).rejects.toThrow(RangeError);
+    await expect(runInPool(tasks, NaN)).rejects.toThrow(RangeError);
+  });
+
+  it('caps concurrency to the number of tasks', async () => {
+    const tasks = [() => Promise.resolve('a'), () => Promise.resolve('b')];
+    const results = await runInPool(tasks, 100);
+    expect(results).toEqual(['a', 'b']);
   });
 });

--- a/.agentkit/engines/node/src/__tests__/task-protocol.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/task-protocol.test.mjs
@@ -762,6 +762,33 @@ describe('formatTaskSummary', () => {
     expect(summary).toContain('team-backend');
     expect(summary).toContain('team-testing');
   });
+
+  it('renders dependsOn / blockedBy / artifacts sections when populated', async () => {
+    const { task: parent } = await createTask(tmpRoot, {
+      title: 'Parent',
+      delegator: 'orch',
+      assignees: ['team-backend'],
+    });
+    const { task } = await createTask(tmpRoot, {
+      title: 'Child task',
+      delegator: 'orch',
+      assignees: ['team-frontend'],
+      dependsOn: [parent.id],
+      blockedBy: [parent.id],
+    });
+    // Synthesise a task object with artifacts since createTask discards them
+    const taskWithArtifacts = { ...task, artifacts: [{ type: 'file', path: 'src/foo.ts' }] };
+    const summary = formatTaskSummary(taskWithArtifacts);
+    expect(summary).toContain('Depends on:');
+    expect(summary).toContain(parent.id);
+    expect(summary).toContain('Blocked by:');
+    expect(summary).toContain('Artifacts: 1');
+  });
+
+  it('handles a malformed task object without throwing', () => {
+    expect(() => formatTaskSummary({})).not.toThrow();
+    expect(() => formatTaskSummary(null)).not.toThrow();
+  });
 });
 
 describe('formatTaskList', () => {

--- a/.agentkit/engines/node/src/__tests__/template-utils.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/template-utils.test.mjs
@@ -24,6 +24,8 @@ import {
   collapseBlankLines,
   escapeYamlString,
   resolveHelpers,
+  simpleDiff,
+  categorizeFile,
 } from '../template-utils.mjs';
 import { transform } from '../project-mapping.mjs';
 
@@ -1743,5 +1745,52 @@ describe('sync report collector', () => {
     expect(getSyncReportData()).not.toBeNull();
     resetSyncReport();
     expect(getSyncReportData()).toBeNull();
+  });
+});
+
+describe('simpleDiff', () => {
+  it('returns empty string when both inputs are equal', () => {
+    expect(simpleDiff('hello', 'hello')).toBe('');
+  });
+
+  it('marks added lines with +', () => {
+    const out = simpleDiff('a', 'a\nb');
+    expect(out).toContain('+ b');
+  });
+
+  it('marks removed lines with -', () => {
+    const out = simpleDiff('a\nb', 'a');
+    expect(out).toContain('- b');
+  });
+
+  it('marks changed lines with both - and +', () => {
+    const out = simpleDiff('a\nold', 'a\nnew');
+    expect(out).toContain('- old');
+    expect(out).toContain('+ new');
+  });
+
+  it('truncates output after 20 lines and appends "..."', () => {
+    const a = '';
+    const b = Array.from({ length: 25 }, (_, i) => `line${i}`).join('\n');
+    const out = simpleDiff(a, b);
+    expect(out).toContain('...');
+    // Each added line is one entry; output is truncated to 20 entries
+    expect(out.split('\n').filter((l) => l.startsWith('+ ')).length).toBeLessThanOrEqual(20);
+  });
+
+  it('handles CRLF line endings consistently with LF', () => {
+    expect(simpleDiff('a\r\nb', 'a\nb')).toBe('');
+  });
+});
+
+describe('categorizeFile', () => {
+  it('returns a string label', () => {
+    const cat = categorizeFile('docs/README.md');
+    expect(typeof cat).toBe('string');
+    expect(cat.length).toBeGreaterThan(0);
+  });
+
+  it('handles deeply nested paths', () => {
+    expect(typeof categorizeFile('apps/api/src/index.ts')).toBe('string');
   });
 });

--- a/.agentkit/engines/node/src/__tests__/var-builders.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/var-builders.test.mjs
@@ -1,0 +1,573 @@
+/**
+ * Tests for var-builders.mjs helpers that aren't directly covered by the
+ * higher-level synchronize-agents/teams-list/build-command-vars/rule-vars/
+ * branch-protection-json suites. Focuses on small inferring helpers, command
+ * path resolution, feature gating, and the area-routing builder.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAgentVars,
+  buildAreaRoutingTable,
+  buildBrowserTestingVars,
+  buildTeamVars,
+  formatConventionLine,
+  getTeamCommandStem,
+  inferMaxHandoffChainDepth,
+  inferMaxStagnationTurns,
+  inferMaxTaskTurns,
+  inferTestingCoverage,
+  isFeatureEnabled,
+  isItemFeatureEnabled,
+  resolveCommandPath,
+} from '../var-builders.mjs';
+
+// ---------------------------------------------------------------------------
+// inferMaxTaskTurns
+// ---------------------------------------------------------------------------
+
+describe('inferMaxTaskTurns', () => {
+  it('returns 15 for solo team', () => {
+    expect(inferMaxTaskTurns('solo')).toBe(15);
+  });
+  it('returns 25 for small team', () => {
+    expect(inferMaxTaskTurns('small')).toBe(25);
+  });
+  it('returns 35 for medium team', () => {
+    expect(inferMaxTaskTurns('medium')).toBe(35);
+  });
+  it('returns 35 for large team', () => {
+    expect(inferMaxTaskTurns('large')).toBe(35);
+  });
+  it('returns 25 for unknown / undefined team size', () => {
+    expect(inferMaxTaskTurns(undefined)).toBe(25);
+    expect(inferMaxTaskTurns('totally-bogus')).toBe(25);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferMaxHandoffChainDepth
+// ---------------------------------------------------------------------------
+
+describe('inferMaxHandoffChainDepth', () => {
+  it('returns 3 for tiny team counts', () => {
+    expect(inferMaxHandoffChainDepth(1)).toBe(3);
+    expect(inferMaxHandoffChainDepth(3)).toBe(3);
+  });
+  it('returns 5 for medium team counts', () => {
+    expect(inferMaxHandoffChainDepth(4)).toBe(5);
+    expect(inferMaxHandoffChainDepth(6)).toBe(5);
+  });
+  it('returns 7 for large team counts', () => {
+    expect(inferMaxHandoffChainDepth(7)).toBe(7);
+    expect(inferMaxHandoffChainDepth(20)).toBe(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferMaxStagnationTurns
+// ---------------------------------------------------------------------------
+
+describe('inferMaxStagnationTurns', () => {
+  it('returns 15 for greenfield', () => {
+    expect(inferMaxStagnationTurns('greenfield')).toBe(15);
+  });
+  it('returns 10 for active', () => {
+    expect(inferMaxStagnationTurns('active')).toBe(10);
+  });
+  it('returns 5 for maintenance and legacy', () => {
+    expect(inferMaxStagnationTurns('maintenance')).toBe(5);
+    expect(inferMaxStagnationTurns('legacy')).toBe(5);
+  });
+  it('returns 10 by default for unknown phase', () => {
+    expect(inferMaxStagnationTurns(undefined)).toBe(10);
+    expect(inferMaxStagnationTurns('mystery')).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferTestingCoverage
+// ---------------------------------------------------------------------------
+
+describe('inferTestingCoverage', () => {
+  it('returns "60" for greenfield', () => {
+    expect(inferTestingCoverage('greenfield')).toBe('60');
+  });
+  it('returns "80" for active', () => {
+    expect(inferTestingCoverage('active')).toBe('80');
+  });
+  it('returns "90" for maintenance and legacy', () => {
+    expect(inferTestingCoverage('maintenance')).toBe('90');
+    expect(inferTestingCoverage('legacy')).toBe('90');
+  });
+  it('returns "80" by default for unknown phase', () => {
+    expect(inferTestingCoverage(undefined)).toBe('80');
+    expect(inferTestingCoverage('xyz')).toBe('80');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBrowserTestingVars
+// ---------------------------------------------------------------------------
+
+describe('buildBrowserTestingVars', () => {
+  it('returns false flags for an empty/missing spec', () => {
+    expect(buildBrowserTestingVars(undefined)).toEqual({
+      usesPlaywright: false,
+      usesBrowser: false,
+    });
+    expect(buildBrowserTestingVars({})).toEqual({
+      usesPlaywright: false,
+      usesBrowser: false,
+    });
+  });
+
+  it('returns false flags when testing.e2e is not an array', () => {
+    expect(buildBrowserTestingVars({ testing: { e2e: 'playwright' } })).toEqual({
+      usesPlaywright: false,
+      usesBrowser: false,
+    });
+  });
+
+  it('detects playwright', () => {
+    const vars = buildBrowserTestingVars({ testing: { e2e: ['playwright'] } });
+    expect(vars.usesPlaywright).toBe(true);
+    expect(vars.usesBrowser).toBe(false);
+  });
+
+  it('is case-insensitive for tool names', () => {
+    const vars = buildBrowserTestingVars({ testing: { e2e: ['Playwright'] } });
+    expect(vars.usesPlaywright).toBe(true);
+  });
+
+  it('detects browser tools (cypress) without playwright', () => {
+    const vars = buildBrowserTestingVars({ testing: { e2e: ['cypress'] } });
+    expect(vars.usesBrowser).toBe(true);
+    expect(vars.usesPlaywright).toBe(false);
+  });
+
+  it('detects puppeteer and webdriverio as browser tools', () => {
+    expect(buildBrowserTestingVars({ testing: { e2e: ['puppeteer'] } }).usesBrowser).toBe(true);
+    expect(buildBrowserTestingVars({ testing: { e2e: ['webdriverio'] } }).usesBrowser).toBe(true);
+  });
+
+  it('prefers playwright when both playwright and browser tools are listed', () => {
+    const vars = buildBrowserTestingVars({
+      testing: { e2e: ['playwright', 'cypress'] },
+    });
+    expect(vars.usesPlaywright).toBe(true);
+    expect(vars.usesBrowser).toBe(false);
+  });
+
+  it('skips non-string entries gracefully', () => {
+    const vars = buildBrowserTestingVars({
+      testing: { e2e: [null, 123, 'cypress'] },
+    });
+    expect(vars.usesBrowser).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTeamCommandStem
+// ---------------------------------------------------------------------------
+
+describe('getTeamCommandStem', () => {
+  it('prefixes raw team IDs with team-', () => {
+    expect(getTeamCommandStem('backend')).toBe('team-backend');
+    expect(getTeamCommandStem('quality')).toBe('team-quality');
+  });
+  it('keeps already-prefixed team IDs unchanged', () => {
+    expect(getTeamCommandStem('team-backend')).toBe('team-backend');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveCommandPath
+// ---------------------------------------------------------------------------
+
+describe('resolveCommandPath', () => {
+  it('returns the bare name when no prefix is supplied', () => {
+    expect(resolveCommandPath('check', null)).toEqual({ dir: '', stem: 'check' });
+    expect(resolveCommandPath('check', undefined)).toEqual({ dir: '', stem: 'check' });
+    expect(resolveCommandPath('check', '')).toEqual({ dir: '', stem: 'check' });
+  });
+
+  it('uses subdirectory strategy', () => {
+    expect(resolveCommandPath('check', 'kits', 'subdirectory')).toEqual({
+      dir: 'kits',
+      stem: 'check',
+    });
+  });
+
+  it('uses filename strategy by default', () => {
+    expect(resolveCommandPath('check', 'kits')).toEqual({ dir: '', stem: 'kits-check' });
+    expect(resolveCommandPath('check', 'kits', 'filename')).toEqual({
+      dir: '',
+      stem: 'kits-check',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isFeatureEnabled / isItemFeatureEnabled
+// ---------------------------------------------------------------------------
+
+describe('isFeatureEnabled', () => {
+  it('returns true when feature var is true', () => {
+    expect(isFeatureEnabled('cost-tracking', { feature_cost_tracking: true })).toBe(true);
+  });
+
+  it('returns false when feature var is explicitly false', () => {
+    expect(isFeatureEnabled('cost-tracking', { feature_cost_tracking: false })).toBe(false);
+  });
+
+  it('defaults to enabled when var is absent (graceful degradation)', () => {
+    expect(isFeatureEnabled('cost-tracking', {})).toBe(true);
+  });
+
+  it('translates hyphens to underscores in the var name', () => {
+    expect(isFeatureEnabled('multi-word-feature', { feature_multi_word_feature: false })).toBe(
+      false
+    );
+  });
+
+  it('treats truthy non-true values (e.g. "yes") as enabled', () => {
+    expect(isFeatureEnabled('foo', { feature_foo: 'yes' })).toBe(true);
+  });
+});
+
+describe('isItemFeatureEnabled', () => {
+  it('returns true for items without a requiredFeature', () => {
+    expect(isItemFeatureEnabled({}, {})).toBe(true);
+    expect(isItemFeatureEnabled({ id: 'foo' }, {})).toBe(true);
+  });
+
+  it('delegates to isFeatureEnabled when requiredFeature is set', () => {
+    expect(
+      isItemFeatureEnabled({ requiredFeature: 'cost-tracking' }, { feature_cost_tracking: false })
+    ).toBe(false);
+    expect(
+      isItemFeatureEnabled({ requiredFeature: 'cost-tracking' }, { feature_cost_tracking: true })
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAreaRoutingTable
+// ---------------------------------------------------------------------------
+
+describe('buildAreaRoutingTable', () => {
+  it('builds a default routing table when no overrides are supplied', () => {
+    const table = buildAreaRoutingTable(undefined);
+    // Defaults include backend, frontend, etc.
+    expect(table).toContain('`backend`→backend');
+    expect(table).toContain('`frontend`→frontend');
+    expect(table).toContain('`cli`→backend');
+    expect(table).toContain('`sync-engine`→devops');
+  });
+
+  it('merges custom routing on top of defaults', () => {
+    const table = buildAreaRoutingTable({
+      routing: { backend: 'platform', custom: 'quality' },
+    });
+    expect(table).toContain('`backend`→platform');
+    expect(table).toContain('`custom`→quality');
+    // Defaults still present for areas not overridden
+    expect(table).toContain('`frontend`→frontend');
+  });
+
+  it('handles an empty routing object', () => {
+    const table = buildAreaRoutingTable({ routing: {} });
+    expect(table).toContain('`backend`→backend');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatConventionLine
+// ---------------------------------------------------------------------------
+
+describe('formatConventionLine', () => {
+  it('renders a string convention as a bullet', () => {
+    expect(formatConventionLine('Always validate input')).toBe('- Always validate input');
+  });
+
+  it('renders an object convention with id and rule', () => {
+    expect(formatConventionLine({ id: 'no-eval', rule: 'Disallow eval' })).toContain(
+      '**[no-eval]** Disallow eval'
+    );
+  });
+
+  it('appends type and phase badges', () => {
+    const line = formatConventionLine({
+      id: 'r1',
+      rule: 'Do thing',
+      type: 'enforcement',
+      phase: 'planning',
+    });
+    expect(line).toContain('enforcement');
+    expect(line).toContain('phase: planning');
+  });
+
+  it('joins multiple phases', () => {
+    const line = formatConventionLine({
+      id: 'r1',
+      rule: 'Do thing',
+      phase: ['planning', 'review'],
+    });
+    expect(line).toContain('phase: planning, review');
+  });
+
+  it('omits the badge suffix when type and phase are missing', () => {
+    expect(formatConventionLine({ id: 'r1', rule: 'Do thing' })).toBe('- **[r1]** Do thing');
+  });
+
+  it('handles missing id and rule gracefully', () => {
+    expect(formatConventionLine({})).toBe('- **[]** ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTeamVars — exercises agent persona resolution + inferred limits
+// ---------------------------------------------------------------------------
+
+describe('buildTeamVars', () => {
+  it('uses team values when provided and infers when absent', () => {
+    const team = {
+      id: 'backend',
+      name: 'Backend',
+      focus: 'API',
+      scope: ['apps/api/**'],
+      accepts: ['implement'],
+      'handoff-chain': ['testing'],
+    };
+    const teamsSpec = { teams: [team] };
+    const agentsSpec = { agents: { backend: [{ id: 'be1', name: 'Backend One', role: 'API' }] } };
+    const vars = { teamSize: 'small', projectPhase: 'active' };
+
+    const result = buildTeamVars(team, vars, teamsSpec, agentsSpec);
+    expect(result.teamId).toBe('backend');
+    expect(result.teamName).toBe('Backend');
+    expect(result.teamFocus).toBe('API');
+    expect(result.teamScope).toBe('apps/api/**');
+    expect(result.teamAccepts).toBe('implement');
+    expect(result.teamHandoffChain).toBe('testing');
+    expect(result.maxTaskTurns).toBe(25); // small
+    expect(result.maxHandoffChainDepth).toBe(3); // 1 team
+    expect(result.maxStagnationTurns).toBe(10); // active
+    expect(result.teamHasAgents).toBe(true);
+    expect(result.teamAgentSummaries).toContain('Backend One');
+  });
+
+  it('uses team-supplied overrides for max-task-turns / max-handoff-chain-depth / max-stagnation-turns', () => {
+    const team = {
+      id: 'q',
+      name: 'Quality',
+      'max-task-turns': 99,
+      'max-handoff-chain-depth': 8,
+      'max-stagnation-turns': 4,
+    };
+    const teamsSpec = { teams: [team] };
+    const agentsSpec = { agents: {} };
+    const vars = { teamSize: 'large', projectPhase: 'greenfield' };
+
+    const result = buildTeamVars(team, vars, teamsSpec, agentsSpec);
+    expect(result.maxTaskTurns).toBe(99);
+    expect(result.maxHandoffChainDepth).toBe(8);
+    expect(result.maxStagnationTurns).toBe(4);
+    expect(result.teamHasAgents).toBe(false);
+    expect(result.teamAgentSummaries).toBe('');
+  });
+
+  it('handles non-array scope/accepts/handoff-chain values', () => {
+    const team = {
+      id: 't',
+      name: 'T',
+      scope: 'src/**',
+      accepts: 'implement',
+      'handoff-chain': 'docs',
+    };
+    const result = buildTeamVars(team, {}, { teams: [] }, { agents: {} });
+    expect(result.teamScope).toBe('src/**');
+    expect(result.teamAccepts).toBe('implement');
+    expect(result.teamHandoffChain).toBe('docs');
+  });
+
+  it('falls back to id when name is missing', () => {
+    const team = { id: 'no-name' };
+    const result = buildTeamVars(team, {}, { teams: [] }, { agents: {} });
+    expect(result.teamName).toBe('no-name');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAgentVars — exercises the small section helpers (negotiation, lookahead, etc.)
+// ---------------------------------------------------------------------------
+
+describe('buildAgentVars', () => {
+  it('renders all agent fields including decision model, retry, beliefs, confidence, negotiation, lookahead', () => {
+    const agent = {
+      id: 'a1',
+      name: 'Agent One',
+      role: ' API engineer ',
+      focus: ['api', 'auth'],
+      responsibilities: ['design endpoints'],
+      'preferred-tools': ['rest'],
+      conventions: ['use TLS'],
+      examples: [{ title: 'Hello', code: 'console.log()' }],
+      'anti-patterns': ['no-eval'],
+      'domain-rules': ['validate-input'],
+      'decision-model': {
+        type: 'hybrid',
+        'hybrid-of': ['heuristic', 'llm'],
+        description: ' Trades off speed and accuracy. ',
+      },
+      'retry-policy': {
+        'max-retries': 3,
+        'failure-classification': { transient: 'retry', logic: 'fix', permanent: 'escalate' },
+        backoff: 'exponential',
+        'escalate-to': 'human',
+      },
+      'belief-system': {
+        'state-reads': ['orchestrator'],
+        'task-reads': true,
+        'update-on': ['task-complete'],
+        'revision-strategy': 'overwrite',
+      },
+      confidence: {
+        'output-threshold': 0.8,
+        'requires-validation': true,
+        'validation-agent': 'reviewer',
+        'low-confidence-action': 'escalate',
+      },
+      negotiation: {
+        'conflict-scope': 'team',
+        'resolution-strategy': 'majority',
+        'can-negotiate-with': ['a2', 'a3'],
+      },
+      lookahead: { enabled: true, depth: 3, 'simulation-budget': 10 },
+    };
+
+    const result = buildAgentVars(agent, 'engineering', { foo: 'bar' });
+
+    expect(result.foo).toBe('bar'); // vars passthrough
+    expect(result.agentId).toBe('a1');
+    expect(result.agentName).toBe('Agent One');
+    expect(result.agentRole).toBe('API engineer'); // trimmed
+    expect(result.agentCategory).toBe('engineering');
+    expect(result.agentFocusList).toContain('- api');
+    expect(result.agentResponsibilitiesList).toContain('- design endpoints');
+    expect(result.agentToolsList).toContain('- rest');
+    expect(result.agentConventions).toContain('- use TLS');
+    expect(result.agentExamples).toContain('Hello');
+    expect(result.agentExamples).toContain('console.log()');
+    expect(result.agentAntiPatterns).toContain('- no-eval');
+    expect(result.agentDomainRules).toContain('- validate-input');
+
+    // Decision model
+    expect(result.agentDecisionModel).toContain('hybrid');
+    expect(result.agentDecisionModel).toContain('Hybrid of:');
+    expect(result.agentDecisionModel).toContain('Trades off speed and accuracy.');
+
+    // Retry policy
+    expect(result.agentRetryPolicy).toContain('Max retries:');
+    expect(result.agentRetryPolicy).toContain('transient→retry');
+    expect(result.agentRetryPolicy).toContain('**Backoff:** exponential');
+    expect(result.agentRetryPolicy).toContain('**Escalate to:** human');
+
+    // Belief system
+    expect(result.agentBeliefSystem).toContain('**State reads:**');
+    expect(result.agentBeliefSystem).toContain('**Task reads:** true');
+    expect(result.agentBeliefSystem).toContain('**Update on:**');
+    expect(result.agentBeliefSystem).toContain('**Revision strategy:** overwrite');
+
+    // Confidence
+    expect(result.agentConfidence).toContain('**Output threshold:** 0.8');
+    expect(result.agentConfidence).toContain('**Requires validation:** true');
+    expect(result.agentConfidence).toContain('**Validation agent:** reviewer');
+    expect(result.agentConfidence).toContain('**Low confidence action:** escalate');
+
+    // Negotiation
+    expect(result.agentNegotiation).toContain('**Conflict scope:** team');
+    expect(result.agentNegotiation).toContain('**Resolution strategy:** majority');
+    expect(result.agentNegotiation).toContain('**Can negotiate with:** a2, a3');
+
+    // Lookahead
+    expect(result.agentLookahead).toContain('**Enabled:** true');
+    expect(result.agentLookahead).toContain('**Depth:** 3');
+    expect(result.agentLookahead).toContain('**Simulation budget:** 10');
+  });
+
+  it('returns empty section strings when subsections are absent', () => {
+    const agent = { id: 'bare', name: 'Bare', role: 'Minimal' };
+    const result = buildAgentVars(agent, 'engineering', {});
+    expect(result.agentDecisionModel).toBe('');
+    expect(result.agentRetryPolicy).toBe('');
+    expect(result.agentBeliefSystem).toBe('');
+    expect(result.agentConfidence).toBe('');
+    expect(result.agentNegotiation).toBe('');
+    expect(result.agentLookahead).toBe('');
+    expect(result.agentConventions).toBe('');
+    expect(result.agentExamples).toBe('');
+    expect(result.agentAntiPatterns).toBe('');
+    expect(result.agentDomainRules).toBe('');
+  });
+
+  it('omits backoff entry when set to "none"', () => {
+    const result = buildAgentVars(
+      { id: 'r', name: 'R', 'retry-policy': { backoff: 'none', 'max-retries': 1 } },
+      'engineering',
+      {}
+    );
+    expect(result.agentRetryPolicy).toContain('**Max retries:** 1');
+    expect(result.agentRetryPolicy).not.toContain('Backoff:');
+  });
+
+  it('omits failure-classification when none of its keys are present', () => {
+    const result = buildAgentVars(
+      { id: 'r', name: 'R', 'retry-policy': { 'failure-classification': {}, 'max-retries': 2 } },
+      'engineering',
+      {}
+    );
+    expect(result.agentRetryPolicy).toContain('**Max retries:** 2');
+    expect(result.agentRetryPolicy).not.toContain('Failure handling:');
+  });
+
+  it('omits lookahead entirely when not enabled', () => {
+    const result = buildAgentVars(
+      { id: 'r', name: 'R', lookahead: { enabled: false, depth: 5 } },
+      'engineering',
+      {}
+    );
+    expect(result.agentLookahead).toBe('');
+  });
+
+  it('omits depth and simulation-budget when zero or undefined', () => {
+    const result = buildAgentVars(
+      { id: 'r', name: 'R', lookahead: { enabled: true, depth: 0, 'simulation-budget': 0 } },
+      'engineering',
+      {}
+    );
+    expect(result.agentLookahead).toContain('**Enabled:** true');
+    expect(result.agentLookahead).not.toContain('Depth:');
+    expect(result.agentLookahead).not.toContain('Simulation budget:');
+  });
+
+  it('omits negotiation peers when can-negotiate-with is empty', () => {
+    const result = buildAgentVars(
+      {
+        id: 'r',
+        name: 'R',
+        negotiation: { 'conflict-scope': 'self', 'can-negotiate-with': [] },
+      },
+      'engineering',
+      {}
+    );
+    expect(result.agentNegotiation).toContain('**Conflict scope:** self');
+    expect(result.agentNegotiation).not.toContain('Can negotiate with:');
+  });
+
+  it('handles role as a non-string value gracefully', () => {
+    const result = buildAgentVars({ id: 'r', name: 'R', role: null }, 'engineering', {});
+    expect(result.agentRole).toBe('');
+  });
+});


### PR DESCRIPTION
Summary: completes preserved stash coverage WIP by adding and extending AgentKit runtime unit coverage across command runners, config flows, utilities, and template helpers. Conflict resolution: kept current dev sync-guard tests and excluded local .claude scheduled task state. Verification: pnpm --dir .agentkit exec prettier --check on changed tests; pnpm --dir .agentkit exec vitest run on the 17 changed test files (691 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for backlog sorting and filtering, placeholder detection, CLI commands, health checks, initialization, orchestration, task dispatch, and reporting.
  * Added validation for error handling, dry-run behavior, concurrency limits, malformed inputs, interactive configuration flows, and filesystem operations.
  * Added coverage for markdown output, task summaries, template utilities, variable generation, and analyzer edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->