### PR TITLE
test(sync): share golden sync roots and right-size timeouts

### DIFF
--- a/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
@@ -646,40 +646,35 @@ describe('syncRooRules (via runSync --only roo)', () => {
 // Tests: Render target gating — new tools excluded when not in targets
 // ---------------------------------------------------------------------------
 describe('render target gating for new tools', () => {
-  let projectRoot;
+  let claudeFiles;
+  let warpFiles;
 
-  beforeEach(() => {
-    projectRoot = makeTmpProject();
+  beforeAll(async () => {
+    const [claudeRoot, warpRoot] = await Promise.all([
+      goldenSync({ only: 'claude' }),
+      goldenSync({ only: 'warp' }),
+    ]);
+    claudeFiles = collectFiles(claudeRoot);
+    warpFiles = collectFiles(warpRoot);
   });
-  afterEach(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+
+  it('--only claude does NOT generate gemini, warp, cline, roo, codex files', () => {
+    expect(claudeFiles.some((f) => f === 'GEMINI.md')).toBe(false);
+    expect(claudeFiles.some((f) => f === 'WARP.md')).toBe(false);
+    expect(claudeFiles.some((f) => f.startsWith('.gemini/'))).toBe(false);
+    expect(claudeFiles.some((f) => f.startsWith('.agents/'))).toBe(false);
+    expect(claudeFiles.some((f) => f.startsWith('.clinerules/'))).toBe(false);
+    expect(claudeFiles.some((f) => f.startsWith('.roo/'))).toBe(false);
   });
 
-  it(
-    '--only claude does NOT generate gemini, warp, cline, roo, codex files',
-    { timeout: 30_000 },
-    async () => {
-      await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'claude' } });
-      const files = collectFiles(projectRoot);
-      expect(files.some((f) => f === 'GEMINI.md')).toBe(false);
-      expect(files.some((f) => f === 'WARP.md')).toBe(false);
-      expect(files.some((f) => f.startsWith('.gemini/'))).toBe(false);
-      expect(files.some((f) => f.startsWith('.agents/'))).toBe(false);
-      expect(files.some((f) => f.startsWith('.clinerules/'))).toBe(false);
-      expect(files.some((f) => f.startsWith('.roo/'))).toBe(false);
-    }
-  );
-
-  it('always-on outputs generated regardless of --only flag', async () => {
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'warp' } });
-    const files = collectFiles(projectRoot);
+  it('always-on outputs generated regardless of --only flag', () => {
     // AGENTS.md is always-on
-    expect(files.some((f) => f === 'AGENTS.md')).toBe(true);
+    expect(warpFiles.some((f) => f === 'AGENTS.md')).toBe(true);
     // WARP.md is the only gated output
-    expect(files.some((f) => f === 'WARP.md')).toBe(true);
+    expect(warpFiles.some((f) => f === 'WARP.md')).toBe(true);
     // Claude-specific outputs should NOT be present
-    expect(files.some((f) => f === 'CLAUDE.md')).toBe(false);
-    expect(files.some((f) => f.startsWith('.claude/'))).toBe(false);
+    expect(warpFiles.some((f) => f === 'CLAUDE.md')).toBe(false);
+    expect(warpFiles.some((f) => f.startsWith('.claude/'))).toBe(false);
   });
 });
 

--- a/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
@@ -807,7 +807,13 @@ describe('--quiet, --verbose, --no-clean, --diff flags', () => {
 // invalidate the negative assertions, because sync only prunes orphaned files
 // when a previous .manifest.json is present.
 const ISOLATION_CASES = [
-  { only: 'mcp', absent: [['.github', 'prompts'], ['.roo', 'rules']] },
+  {
+    only: 'mcp',
+    absent: [
+      ['.github', 'prompts'],
+      ['.roo', 'rules'],
+    ],
+  },
   { only: 'windsurf', absent: [['.cursor', 'commands']] },
   { only: 'cline', absent: [['.agents', 'skills']] },
   { only: 'ai', absent: [['.cursor', 'rules', 'team-backend.mdc']] },
@@ -1264,23 +1270,27 @@ describe('syncGitattributes (merge driver sync)', () => {
     expect(content).toContain('pnpm-lock.yaml');
   });
 
-  it('preserves user content outside managed section on re-sync', { timeout: 120_000 }, async () => {
-    const gitattrsPath = resolve(projectRoot, '.gitattributes');
-    // Prepend custom user content
-    const existing = readFileSync(gitattrsPath, 'utf-8');
-    writeFileSync(gitattrsPath, '# My custom rules\n*.pdf binary\n\n' + existing, 'utf-8');
+  it(
+    'preserves user content outside managed section on re-sync',
+    { timeout: 120_000 },
+    async () => {
+      const gitattrsPath = resolve(projectRoot, '.gitattributes');
+      // Prepend custom user content
+      const existing = readFileSync(gitattrsPath, 'utf-8');
+      writeFileSync(gitattrsPath, '# My custom rules\n*.pdf binary\n\n' + existing, 'utf-8');
 
-    // Re-sync
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { quiet: true } });
+      // Re-sync
+      await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { quiet: true } });
 
-    const updated = readFileSync(gitattrsPath, 'utf-8');
-    expect(updated).toContain('# My custom rules');
-    expect(updated).toContain('*.pdf binary');
-    expect(updated).toContain('merge=agentkit-generated');
-    // Should have exactly one managed section (not duplicated)
-    const startCount = (updated.match(/# >>> Retort merge drivers/g) || []).length;
-    expect(startCount).toBe(1);
-  });
+      const updated = readFileSync(gitattrsPath, 'utf-8');
+      expect(updated).toContain('# My custom rules');
+      expect(updated).toContain('*.pdf binary');
+      expect(updated).toContain('merge=agentkit-generated');
+      // Should have exactly one managed section (not duplicated)
+      const startCount = (updated.match(/# >>> Retort merge drivers/g) || []).length;
+      expect(startCount).toBe(1);
+    }
+  );
 
   it('replaces stale managed section without duplication', { timeout: 120_000 }, async () => {
     const gitattrsPath = resolve(projectRoot, '.gitattributes');

--- a/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join, resolve } from 'path';
 import yaml from 'js-yaml';
@@ -27,6 +35,70 @@ function makeNamedTmpProject(repoName) {
   mkdirSync(dir, { recursive: true });
   return dir;
 }
+
+// ---------------------------------------------------------------------------
+// Shared sync roots
+// ---------------------------------------------------------------------------
+// Full syncs dominate this suite's runtime — a single one renders 600+ files.
+// Many describe blocks previously ran their own sync with identical flags
+// (`--only copilot` alone ran five times), which is what pushed beforeAll
+// hooks past the 30s hook timeout.
+//
+// Each distinct flag-set is now synced at most once into a pristine "golden"
+// root. Blocks that only read the output share that root via goldenSync();
+// blocks that mutate it take a cheap recursive copy via cloneSync(), since
+// copying an already-rendered tree costs far less than re-rendering it.
+
+/** @type {Map<string, Promise<string>>} flag-set key -> pristine synced root */
+const goldenRoots = new Map();
+
+/**
+ * Returns a pristine project root synced with the given flags, reusing an
+ * existing one when the same flag-set has already been synced.
+ *
+ * The promise (not the resolved path) is cached so concurrent callers share a
+ * single in-flight sync rather than racing to build duplicates.
+ *
+ * Callers MUST NOT modify the returned tree — use cloneSync() for that.
+ */
+function goldenSync(flags = {}) {
+  // quiet/verbose only gate console output (see synchronize.mjs), so they are
+  // excluded from the key — {} and { quiet: true } render identical trees.
+  const significant = Object.fromEntries(
+    Object.entries(flags).filter(([name]) => name !== 'quiet' && name !== 'verbose')
+  );
+  const key = JSON.stringify(significant, Object.keys(significant).sort());
+  if (!goldenRoots.has(key)) {
+    goldenRoots.set(
+      key,
+      (async () => {
+        const projectRoot = makeTmpProject();
+        await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags });
+        return projectRoot;
+      })()
+    );
+  }
+  return goldenRoots.get(key);
+}
+
+/** Returns a writable copy of the golden root for the given flags. */
+async function cloneSync(flags = {}) {
+  const golden = await goldenSync(flags);
+  const dest = makeTmpProject();
+  cpSync(golden, dest, { recursive: true });
+  return dest;
+}
+
+afterAll(() => {
+  for (const pending of goldenRoots.values()) {
+    Promise.resolve(pending)
+      .then((root) => rmSync(root, { recursive: true, force: true }))
+      .catch(() => {
+        /* sync failed; nothing to clean up */
+      });
+  }
+  goldenRoots.clear();
+});
 
 function writeTestFile(filePath, content) {
   mkdirSync(dirname(filePath), { recursive: true });
@@ -200,11 +272,7 @@ describe('syncCopilotPrompts (via runSync --only copilot)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'copilot' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'copilot' });
   });
 
   it(
@@ -255,11 +323,7 @@ describe('syncCopilotAgents (via runSync --only copilot)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'copilot' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'copilot' });
   });
 
   it('generates .github/agents/*.agent.md from agents.yaml', async () => {
@@ -286,11 +350,7 @@ describe('syncCopilotChatModes (via runSync --only copilot)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'copilot' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'copilot' });
   });
 
   it('generates .github/chatmodes/team-*.chatmode.md from teams.yaml', async () => {
@@ -317,11 +377,7 @@ describe('syncGemini (via runSync --only gemini)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'gemini' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'gemini' });
   });
 
   it('generates GEMINI.md at project root', async () => {
@@ -354,11 +410,7 @@ describe('syncCodexSkills (via runSync --only codex)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'codex' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'codex' });
   });
 
   it('generates .agents/skills/*/SKILL.md for non-team commands', { timeout: 15000 }, async () => {
@@ -409,11 +461,7 @@ describe('syncClaudeSkills (via runSync --only claude)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'claude' } });
-  }, 60000);
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'claude' });
   });
 
   it('generates .claude/skills/*/SKILL.md for non-team commands', { timeout: 15000 }, async () => {
@@ -472,11 +520,7 @@ describe('syncCursorCommands (via runSync --only cursor)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'cursor' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'cursor' });
   });
 
   it('generates .cursor/commands/*.md for non-team commands', async () => {
@@ -511,11 +555,7 @@ describe('syncWindsurfCommands (via runSync --only windsurf)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'windsurf' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'windsurf' });
   });
 
   it('windsurf commands resolve {{stateDir}} to .windsurf/state', { timeout: 15000 }, async () => {
@@ -535,11 +575,7 @@ describe('syncWarp (via runSync --only warp)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'warp' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'warp' });
   });
 
   it('generates WARP.md at project root', async () => {
@@ -564,11 +600,7 @@ describe('syncClineRules (via runSync --only cline)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'cline' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'cline' });
   });
 
   it('generates .clinerules/*.md from rules.yaml domains', { timeout: 15000 }, async () => {
@@ -593,11 +625,7 @@ describe('syncRooRules (via runSync --only roo)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'roo' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'roo' });
   });
 
   it('generates .roo/rules/*.md from rules.yaml domains', { timeout: 15000 }, async () => {
@@ -659,14 +687,15 @@ describe('--overwrite flag', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: {} });
-  }, 60000);
+    // These tests re-sync and edit files, so take a writable copy rather than
+    // sharing the golden root.
+    projectRoot = await cloneSync({});
+  });
   afterAll(() => {
     rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  it('skips project-owned files by default', { timeout: 60000 }, async () => {
+  it('skips project-owned files by default', { timeout: 120_000 }, async () => {
     const contribPath = join(projectRoot, 'CONTRIBUTING.md');
     expect(existsSync(contribPath)).toBe(true);
 
@@ -677,7 +706,7 @@ describe('--overwrite flag', () => {
     expect(readFileSync(contribPath, 'utf-8')).toBe(customContent);
   });
 
-  it('overwrites project-owned files with --overwrite', { timeout: 60000 }, async () => {
+  it('overwrites project-owned files with --overwrite', { timeout: 120_000 }, async () => {
     const contribPath = join(projectRoot, 'CONTRIBUTING.md');
     const customContent = 'CUSTOM_OVERWRITE_MARKER_67890';
     writeFileSync(contribPath, customContent, 'utf-8');
@@ -686,7 +715,7 @@ describe('--overwrite flag', () => {
     expect(readFileSync(contribPath, 'utf-8')).not.toContain(customContent);
   });
 
-  it('--force is alias for --overwrite', { timeout: 60000 }, async () => {
+  it('--force is alias for --overwrite', { timeout: 120_000 }, async () => {
     const contribPath = join(projectRoot, 'CONTRIBUTING.md');
     writeFileSync(contribPath, 'CUSTOM', 'utf-8');
     await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { force: true } });
@@ -775,65 +804,45 @@ describe('--quiet, --verbose, --no-clean, --diff flags', () => {
 // ---------------------------------------------------------------------------
 // Tests: Render-target output isolation (--only flag)
 // ---------------------------------------------------------------------------
+// Each case syncs a single render target and asserts that no OTHER target's
+// output appears. Previously every assertion ran its own full sync (10 syncs,
+// sequential); the targets are now synced once each, in parallel, and the
+// assertions read the resulting trees. Each target keeps its own project root —
+// sharing one root across targets would let earlier output linger and
+// invalidate the negative assertions, because sync only prunes orphaned files
+// when a previous .manifest.json is present.
+const ISOLATION_CASES = [
+  { only: 'mcp', absent: [['.github', 'prompts'], ['.roo', 'rules']] },
+  { only: 'windsurf', absent: [['.cursor', 'commands']] },
+  { only: 'cline', absent: [['.agents', 'skills']] },
+  { only: 'ai', absent: [['.cursor', 'rules', 'team-backend.mdc']] },
+  { only: 'codex', absent: [['.windsurf', 'rules', 'team-backend.md']] },
+  { only: 'gemini', absent: [['.github', 'chatmodes']] },
+  { only: 'warp', absent: [['.github', 'agents'], ['.clinerules']] },
+  { only: 'roo', absent: [['.claude', 'agents']] },
+];
+
 describe('render-target output isolation (--only flag)', () => {
-  let projectRoot;
+  /** @type {Map<string, string>} render target -> synced project root */
+  const rootsByTarget = new Map();
 
-  beforeEach(() => {
-    projectRoot = makeTmpProject();
-  });
-  afterEach(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
-  });
-
-  it('--only mcp produces no copilot prompts', async () => {
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'mcp' } });
-    expect(existsSync(resolve(projectRoot, '.github', 'prompts'))).toBe(false);
-  });
-
-  it('--only windsurf produces no cursor command files', { timeout: 30000 }, async () => {
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'windsurf' } });
-    expect(existsSync(resolve(projectRoot, '.cursor', 'commands'))).toBe(false);
+  beforeAll(async () => {
+    // goldenSync dedupes against the per-target describe blocks above, so each
+    // render target is synced once for the whole file rather than twice.
+    await Promise.all(
+      ISOLATION_CASES.map(async ({ only }) => {
+        rootsByTarget.set(only, await goldenSync({ only }));
+      })
+    );
   });
 
-  it('--only cline produces no codex skills', async () => {
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'cline' } });
-    expect(existsSync(resolve(projectRoot, '.agents', 'skills'))).toBe(false);
-  });
-
-  it('--only ai produces no cursor team rules', async () => {
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'ai' } });
-    expect(existsSync(resolve(projectRoot, '.cursor', 'rules', 'team-backend.mdc'))).toBe(false);
-  });
-
-  it('--only codex produces no windsurf team rules', async () => {
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'codex' } });
-    expect(existsSync(resolve(projectRoot, '.windsurf', 'rules', 'team-backend.md'))).toBe(false);
-  });
-
-  it('--only gemini produces no copilot chatmodes', async () => {
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'gemini' } });
-    expect(existsSync(resolve(projectRoot, '.github', 'chatmodes'))).toBe(false);
-  });
-
-  it('--only warp produces no copilot agent files', async () => {
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'warp' } });
-    expect(existsSync(resolve(projectRoot, '.github', 'agents'))).toBe(false);
-  });
-
-  it('--only roo produces no claude agent files', async () => {
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'roo' } });
-    expect(existsSync(resolve(projectRoot, '.claude', 'agents'))).toBe(false);
-  });
-
-  it('--only warp produces no cline rules', async () => {
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'warp' } });
-    expect(existsSync(resolve(projectRoot, '.clinerules'))).toBe(false);
-  });
-
-  it('--only mcp produces no roo rules', async () => {
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'mcp' } });
-    expect(existsSync(resolve(projectRoot, '.roo', 'rules'))).toBe(false);
-  });
+  for (const { only, absent } of ISOLATION_CASES) {
+    for (const segments of absent) {
+      it(`--only ${only} produces no ${segments.join('/')}`, () => {
+        expect(existsSync(resolve(rootsByTarget.get(only), ...segments))).toBe(false);
+      });
+    }
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -843,11 +852,7 @@ describe('syncCopilotInstructions — testing & QA templates (via runSync --only
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'copilot' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'copilot' });
   });
 
   it('generates .github/instructions/testing.md', { timeout: 15000 }, () => {
@@ -938,11 +943,7 @@ describe('syncClaudeRules — testing template (via runSync --only claude)', () 
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'claude' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'claude' });
   });
 
   it('generates .claude/rules/testing.md', { timeout: 15000 }, () => {
@@ -978,11 +979,7 @@ describe('syncLanguageInstructions — generic, multi-platform dynamic generatio
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'copilot' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'copilot' });
   });
 
   // --- Copilot output (.github/instructions/languages/) ---
@@ -1077,11 +1074,7 @@ describe('syncLanguageInstructions — claude target output (.claude/rules/langu
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { only: 'claude' } });
-  });
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ only: 'claude' });
   });
 
   it('generates .claude/rules/languages/ for claude target', { timeout: 15000 }, () => {
@@ -1121,12 +1114,8 @@ describe('syncEditorTheme (brand-driven editor theme)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
     // Full sync — brand.yaml and editor-theme.yaml exist in spec, editorTheme.enabled is true
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { quiet: true } });
-  }, 60_000);
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
+    projectRoot = await goldenSync({ quiet: true });
   });
 
   it(
@@ -1255,9 +1244,9 @@ describe('syncGitattributes (merge driver sync)', () => {
   let projectRoot;
 
   beforeAll(async () => {
-    projectRoot = makeTmpProject();
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { quiet: true } });
-  }, 120_000);
+    // These tests edit .gitattributes and re-sync, so they need a writable copy.
+    projectRoot = await cloneSync({ quiet: true });
+  });
   afterAll(() => {
     rmSync(projectRoot, { recursive: true, force: true });
   });
@@ -1280,7 +1269,7 @@ describe('syncGitattributes (merge driver sync)', () => {
     expect(content).toContain('pnpm-lock.yaml');
   });
 
-  it('preserves user content outside managed section on re-sync', { timeout: 60_000 }, async () => {
+  it('preserves user content outside managed section on re-sync', { timeout: 120_000 }, async () => {
     const gitattrsPath = resolve(projectRoot, '.gitattributes');
     // Prepend custom user content
     const existing = readFileSync(gitattrsPath, 'utf-8');
@@ -1298,7 +1287,7 @@ describe('syncGitattributes (merge driver sync)', () => {
     expect(startCount).toBe(1);
   });
 
-  it('replaces stale managed section without duplication', { timeout: 60_000 }, async () => {
+  it('replaces stale managed section without duplication', { timeout: 120_000 }, async () => {
     const gitattrsPath = resolve(projectRoot, '.gitattributes');
     // Re-sync a second time to verify no duplication
     await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { quiet: true } });

--- a/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
@@ -53,11 +53,24 @@ function makeNamedTmpProject(repoName) {
 const goldenRoots = new Map();
 
 /**
+ * Every temp directory handed to a sync, tracked separately from the promises
+ * above so cleanup does not depend on those promises resolving. A failed sync
+ * still leaves files on disk, and its promise rejects without ever yielding the
+ * path, so recording the directory up front is what makes it removable.
+ *
+ * @type {Set<string>}
+ */
+const createdRoots = new Set();
+
+/**
  * Returns a pristine project root synced with the given flags, reusing an
  * existing one when the same flag-set has already been synced.
  *
  * The promise (not the resolved path) is cached so concurrent callers share a
- * single in-flight sync rather than racing to build duplicates.
+ * single in-flight sync rather than racing to build duplicates. A rejected
+ * sync stays cached deliberately: the failure is a real problem with the spec
+ * or engine, and re-running it for each of the dozen waiting blocks would bury
+ * the original error under a pile of identical ones.
  *
  * Callers MUST NOT modify the returned tree — use cloneSync() for that.
  */
@@ -69,13 +82,13 @@ function goldenSync(flags = {}) {
   );
   const key = JSON.stringify(significant, Object.keys(significant).sort());
   if (!goldenRoots.has(key)) {
+    // Created outside the async body so the path is recorded for cleanup even
+    // if runSync rejects.
+    const projectRoot = makeTmpProject();
+    createdRoots.add(projectRoot);
     goldenRoots.set(
       key,
-      (async () => {
-        const projectRoot = makeTmpProject();
-        await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags });
-        return projectRoot;
-      })()
+      runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags }).then(() => projectRoot)
     );
   }
   return goldenRoots.get(key);
@@ -85,18 +98,16 @@ function goldenSync(flags = {}) {
 async function cloneSync(flags = {}) {
   const golden = await goldenSync(flags);
   const dest = makeTmpProject();
+  createdRoots.add(dest);
   cpSync(golden, dest, { recursive: true });
   return dest;
 }
 
 afterAll(() => {
-  for (const pending of goldenRoots.values()) {
-    Promise.resolve(pending)
-      .then((root) => rmSync(root, { recursive: true, force: true }))
-      .catch(() => {
-        /* sync failed; nothing to clean up */
-      });
+  for (const root of createdRoots) {
+    rmSync(root, { recursive: true, force: true });
   }
+  createdRoots.clear();
   goldenRoots.clear();
 });
 

--- a/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
@@ -63,6 +63,31 @@ const goldenRoots = new Map();
 const createdRoots = new Set();
 
 /**
+ * Resolves the given flag-sets to golden roots one at a time.
+ *
+ * runSync calls clearTemplateMeta() and clearTemplateTextCache() on entry
+ * (synchronize.mjs), and both operate on module-level singletons shared by all
+ * callers, so two overlapping runSync calls clear each other's in-flight state.
+ * templateMetaMap drives scaffold-mode decisions, so that corruption would be
+ * silent rather than a crash.
+ *
+ * Vitest already runs describe blocks sequentially, so the only place syncs
+ * could overlap is a Promise.all over goldenSync — this helper replaces those.
+ * Cached flag-sets resolve immediately, so the sequential walk only pays for
+ * targets no earlier block has synced.
+ *
+ * @param {object[]} flagSets
+ * @returns {Promise<string[]>} golden root per flag-set, in order
+ */
+async function goldenSyncAll(flagSets) {
+  const roots = [];
+  for (const flags of flagSets) {
+    roots.push(await goldenSync(flags));
+  }
+  return roots;
+}
+
+/**
  * Returns a pristine project root synced with the given flags, reusing an
  * existing one when the same flag-set has already been synced.
  *
@@ -661,10 +686,7 @@ describe('render target gating for new tools', () => {
   let warpFiles;
 
   beforeAll(async () => {
-    const [claudeRoot, warpRoot] = await Promise.all([
-      goldenSync({ only: 'claude' }),
-      goldenSync({ only: 'warp' }),
-    ]);
+    const [claudeRoot, warpRoot] = await goldenSyncAll([{ only: 'claude' }, { only: 'warp' }]);
     claudeFiles = collectFiles(claudeRoot);
     warpFiles = collectFiles(warpRoot);
   });
@@ -841,11 +863,8 @@ describe('render-target output isolation (--only flag)', () => {
   beforeAll(async () => {
     // goldenSync dedupes against the per-target describe blocks above, so each
     // render target is synced once for the whole file rather than twice.
-    await Promise.all(
-      ISOLATION_CASES.map(async ({ only }) => {
-        rootsByTarget.set(only, await goldenSync({ only }));
-      })
-    );
+    const roots = await goldenSyncAll(ISOLATION_CASES.map(({ only }) => ({ only })));
+    ISOLATION_CASES.forEach(({ only }, i) => rootsByTarget.set(only, roots[i]));
   });
 
   for (const { only, absent } of ISOLATION_CASES) {

--- a/.agentkit/vitest.config.mjs
+++ b/.agentkit/vitest.config.mjs
@@ -3,7 +3,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     testTimeout: 30_000,
-    hookTimeout: 30_000,
+    // A single full sync renders 600+ files and measures ~25s on Windows, so a
+    // 30s hook budget left almost no headroom and made any sync-in-beforeAll
+    // intermittently fail. Sync-heavy hooks may also do a cold sync plus a
+    // recursive copy, so allow room for two while still catching real hangs.
+    hookTimeout: 120_000,
     env: {
       GIT_CONFIG_COUNT: '1',
       GIT_CONFIG_KEY_0: 'commit.gpgsign',

--- a/.agentkit/vitest.config.mjs
+++ b/.agentkit/vitest.config.mjs
@@ -3,11 +3,13 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     testTimeout: 30_000,
-    // A single full sync renders 600+ files and measures ~25s on Windows, so a
-    // 30s hook budget left almost no headroom and made any sync-in-beforeAll
-    // intermittently fail. Sync-heavy hooks may also do a cold sync plus a
-    // recursive copy, so allow room for two while still catching real hangs.
-    hookTimeout: 120_000,
+    // Setup hooks in sync-integration.test.mjs render a full output tree: a
+    // single sync writes 600+ files and measures ~25s on Windows (more for an
+    // all-targets sync), and the first hook to request a writable tree pays a
+    // cold sync plus a recursive copy. The old 30s budget left no headroom and
+    // made those hooks fail intermittently. This is sized for that worst case
+    // while still catching a genuinely hung hook.
+    hookTimeout: 240_000,
     env: {
       GIT_CONFIG_COUNT: '1',
       GIT_CONFIG_KEY_0: 'commit.gpgsign',


### PR DESCRIPTION
## Summary

`sync-integration.test.mjs` ran a full sync in almost every setup hook — **27 syncs across the file**, many with identical flags (`--only copilot` five times, `--only claude` three). A single full sync renders 600+ files and **measures ~25s on Windows**, so the 30s `hookTimeout` left roughly 5s of headroom and hooks failed intermittently.

Every failure was a timeout; **none were assertion failures**. They also cascaded — 6 tests were being skipped as collateral.

## Approach

Each distinct flag-set is now synced at most once into a pristine "golden" root:

- **`goldenSync(flags)`** caches the *in-flight promise* per flag-set, so concurrent callers share one sync rather than racing. Blocks that only read output share the root directly.
- **`cloneSync(flags)`** returns a recursive copy for the two blocks that mutate their tree (`--overwrite`, `syncGitattributes`). Copying a rendered tree is far cheaper than re-rendering it.
- `quiet`/`verbose` are excluded from the cache key — they only gate `console.log` ([synchronize.mjs:236](.agentkit/engines/node/src/synchronize.mjs:236)), so `{}` and `{ quiet: true }` render identical trees and share a root.
- The `--only` isolation block is now table-driven and resolves roots through `goldenSync`, so each render target is synced once for the whole file instead of once per block *plus* once per assertion.

**Setup syncs: 27 → 12 golden roots + 2 copies.**

## Safety

Sharing a root is only safe for read-only blocks. I audited every block programmatically:

- **17** blocks share a read-only golden root
- **2** blocks take a writable clone
- **0** unsafe combinations

The audit caught a real bug mid-refactor: `syncGitattributes` does `writeFileSync` + re-`runSync`, so it needs `cloneSync`, not a shared root.

## Timeouts — derived, not guessed

Measured a single full sync at **24.3s**, then sized from that:

| Setting | Before | After | Why |
|---|---|---|---|
| `hookTimeout` | 30s | 240s | A hook may do a cold all-targets sync **plus** a 600-file copy |
| in-test re-sync timeouts (5 tests) | 60s | 120s | Each does a full sync inline |

240s is deliberately generous — these hooks legitimately render a full output tree — while still catching a genuinely hung hook.

## Test plan

- **95/95 passing, 0 skipped** (previously failing with 6 skipped)
- Verified **against the `dev` baseline without the spec cleanup applied**, where the larger spec makes syncs slower still — this branch stands on its own and does not depend on #569
- Programmatic audit confirms no shared golden root is ever mutated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved synchronization test reliability by reusing validated results and isolating test environments.
  * Added broader cleanup coverage to prevent temporary test data from affecting subsequent runs.
  * Enabled parallel validation of multiple rendering targets.
  * Increased test time limits for longer-running synchronization and configuration scenarios.
  * These improvements provide more consistent and dependable validation without changing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->