### PR TITLE
docs(handoffs): add session handoff for the sync churn work

### DIFF
--- a/docs/handoffs/2026-08-07-03.md
+++ b/docs/handoffs/2026-08-07-03.md
@@ -1,0 +1,117 @@
+# Session Handoff
+
+**Date:** 2026-08-07
+**Branch:** `claude/retort-marketingskills-compare-bb12bb` (worktree `.claude/worktrees/retort-marketingskills-compare-bb12bb`)
+**Last Commit:** b1ed98a6 — fix(sync): address bot review findings on the formatting reorder
+**Merged as:** 4ff8bd3f — [PR #571](https://github.com/phoenixvc/retort/pull/571) (squash, 18:34Z)
+**Session Scope:** Started as a repo comparison; became a sync-engine churn investigation
+**Overall Status:** MERGED — `dev` green at `d7635cd9`
+
+## Read This First — Scope Drift Was Intentional
+
+The session began as "compare retort to `coreyhaines31/marketingskills`". That comparison
+surfaced that retort already had marketing _agents_ defined but no team owning them, and
+fixing that exposed four latent sync-engine defects. The shipped PR is therefore mostly
+engine work, not the comparison that started it.
+
+The marketingskills integration itself was **not** done, and one finding should be recorded
+before anyone retries it: `skills.yaml` documents `source: upstream` for vendoring external
+skill libraries, but [platform-syncer.mjs](../../.agentkit/engines/node/src/platform-syncer.mjs)
+filters to `source === 'org-meta'` only. Skills registered as `upstream` pass validation and
+are **silently dropped at sync** — no files, no warning. Vendoring marketingskills that way
+would look like it worked and do nothing. The real ingestion path is
+`~/repos/org-meta/skills/<name>/`.
+
+## What Was Done
+
+Four defects fixed, each verified before and after:
+
+- **ADR index was a hardcoded list.** The template shipped a literal list of eight filenames
+  with no loop, so every adopter repo received an index linking to _retort's own_ ADRs 01–08,
+  and new records never appeared. ADRs 09/10/11 were all missing here. Added `buildAdrList()`
+  (scans the project's decisions dir, reads each H1 for a title, sorts by filename).
+- **`sync --overwrite` destroyed uncommitted work.** It bypasses the entire scaffold
+  protection block — both the `once` skip shielding user-authored files and the `managed`
+  three-way merge. Observed rewriting 24 tracked files including `AGENT_BACKLOG.md` and the
+  body of an existing decision record. Now aborts on a dirty tree; `--force` is the escape hatch.
+- **Sync rewrote every file on every run.** Not the copy — the copy already had a working
+  content-hash guard. Prettier ran _after_ the copy, so temp held unformatted bytes and the
+  project held formatted ones; the hashes could never match, and the skip branches explicitly
+  re-queued unchanged files for formatting. Moved formatting ahead of the compare and
+  in-process (Prettier's Node API, replacing 13 subprocess spawns per sync).
+- **Version stamp in 660 file headers.** Every release rewrote all of them, which also defeats
+  the write-if-changed guard. Moved to `.agentkit/GENERATED.json` (version, overlay, spec hash;
+  deliberately **no timestamp**, and its own write is skipped when unchanged).
+
+Plus the MARKETING team itself: `content-strategist` and `growth-analyst` were defined and
+rendered but no team owned them, so they were reachable only by direct invocation.
+
+Two ADRs record the reasoning: [ADR-11](../architecture/decisions/11-eliminate-sync-churn.md)
+(churn) and [ADR-12](../architecture/decisions/12-test-suite-reliability.md) (suite reliability).
+
+## Current Blockers
+
+None. PR merged, `dev` head `d7635cd9` green across Test, Validate, quality-check, Markdown
+Lint, YAML Lint, detect-conflicts, validate-retrospective.
+
+## Next 3 Actions
+
+1. **ADR-11 decision 3 — resolve-or-abort on overlay selection.** The only unimplemented churn
+   fix, and the one that produces _incorrect_ output rather than noise. A missing
+   `.agentkit-repo` marker silently falls back to `__TEMPLATE__` and emits mass wrong-content
+   output; this is the documented root cause of PRs #478/#479 and it reproduced this session
+   (the marker was absent from both the worktree and the repo root). Replace the silent
+   fallback with: use the marker if present → else derive from the primary worktree via
+   `git rev-parse --git-common-dir` → else abort naming the available overlays.
+2. **ADR-12 decision 4 — fixture repo for the git-log heuristic tests.**
+   `detectCommitConvention()` reads ambient repository history, so it breaks on a shallow
+   clone or any repo with different commit conventions. A correctness bug, not just a flake.
+3. **Decide the ADR naming convention.** Four records currently share the `ADR-08` identifier
+   (see the index). Recommendation on the PR: date-prefixed filenames with a stable `id` in
+   frontmatter — collision-free without cross-branch coordination. Do **not** renumber; that
+   breaks every inbound cross-reference, which is why the duplicates calcified. `buildAdrList()`
+   sorts by filename, so both conventions coexist and migration can be lazy or never. The
+   convention lives in `.agentkit/spec/docs.yaml` (`adrRanges`, `adrTemplate`).
+
+## How to Validate
+
+```bash
+# The core invariant this session established: a second sync changes nothing.
+pnpm --dir .agentkit retort:sync
+git status --porcelain          # must be empty
+pnpm --dir .agentkit retort:sync
+git status --porcelain          # must still be empty
+
+# Formatting parity between the in-process formatter and the CLI.
+node .agentkit/node_modules/prettier/bin/prettier.cjs --check .
+
+pnpm --dir .agentkit test
+```
+
+## Open Risks
+
+- **The test suite is red on Windows only.** 4–8 failures, varying run to run on identical
+  code, all timeouts. CI on Linux passes every time — four independent confirmations this
+  session. `hookTimeout` has since been raised to 240s in `vitest.config.mjs`, which should
+  clear the worst of it. Do not treat local red as a regression signal without checking CI.
+- **Wall-time measurements on this machine are unreliable.** The suite ran 386s, 726s, 756s,
+  857s and 1294s across essentially equivalent code. ADR-12 withdraws an earlier "47% faster"
+  claim for exactly this reason. Sync-level numbers (repeated, single deterministic operation)
+  are trustworthy; suite-level ones are not.
+- **`sync --overwrite` still regenerates user-authored content** when the tree is clean. The
+  guard makes it recoverable via git, but the open question — whether `--overwrite` should
+  touch decision records at all, or only the editor-theme and config files it was introduced
+  for — is deliberately undecided. See ADR-12 "Out of scope".
+- **Orphaned generated files are never pruned.** 148 tracked files still carry the old version
+  stamp: `scaffold: once` user content plus stale rule domains that `filterDomainsByStack`
+  stopped generating. Inert for release churn, but `dev` deleted four of them (#572/#573/#575)
+  which is what caused this PR's merge conflict. Expect that class of conflict again.
+- **`dev` moved three times during this session** (#575, #576, #577). Long-lived branches here
+  should expect `BEHIND`/`CONFLICTING` and re-merge rather than rebase.
+
+## State Files
+
+- Orchestrator: `.claude/state/orchestrator.json` — absent (not initialised in this worktree)
+- Events: `.claude/state/events.log` — absent
+- Backlog: `AGENT_BACKLOG.md` — 0 open checklist items
+- Teams: `AGENT_TEAMS.md` — 15 teams defined (MARKETING added this session)


### PR DESCRIPTION
## Summary

Session handoff for the [PR #571](https://github.com/phoenixvc/retort/pull/571) work (merged as `4ff8bd3f`). Documentation only — no code changes.

## Why this is worth reading

Three things it records that aren't visible from #571's diff:

- **`source: upstream` in `skills.yaml` is dead spec.** `platform-syncer.mjs` filters to `source === 'org-meta'` only, so skills registered as `upstream` pass validation and are silently dropped at sync — no files, no warning. Anyone vendoring an external skill library that way would see it appear to work and do nothing.
- **The test suite is red on Windows only.** 4–8 failures varying run to run on identical code, all timeouts; CI on Linux passed every time across four checks. Local red is not a regression signal here without checking CI.
- **Wall-time measurements on this machine are unreliable** — 386s to 1294s for equivalent code. ADR-12 withdraws an earlier "47% faster" claim for that reason.

It also names the next three actions, with ADR-11 decision 3 (resolve-or-abort on overlay selection) first, since that is the remaining churn class that produces *incorrect* output rather than noise, and it reproduced during the session.

## Test plan

Documentation only. `markdownlint-cli2` and `prettier --check` both pass on the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)