### PR TITLE
feat(claude-hooks): validate the hooks spec and make windowsFirst an emit filter

### DIFF
--- a/.agentkit/docs/getting-started/ONBOARDING.md
+++ b/.agentkit/docs/getting-started/ONBOARDING.md
@@ -147,11 +147,19 @@ Edit `overlays/<your-repo>/settings.yaml` to adjust global behavior:
 repoName: my-project
 defaultBranch: main
 primaryStack: typescript
-windowsFirst: false
+windowsFirst: false # POSIX-only repo: skip the .ps1 hook variants
 renderTargets:
   - claude
   - cursor
 ```
+
+`windowsFirst` controls whether the PowerShell variant of each hook is emitted
+and wired. It defaults to `true`, which ships `<hook>.ps1` alongside `<hook>.sh`
+and invokes the `.ps1` in preference, falling back to the `.sh` on machines
+without `pwsh` — the right setting for Windows or mixed-platform teams. Set it to
+`false` only when the repo never runs hooks on Windows; sync then emits no `.ps1`
+files and wires the `.sh` directly. Hooks that ship only a `.sh` are unaffected
+either way, so the setting never removes a hook — only a variant of one.
 
 ### Adding Custom Commands
 

--- a/.agentkit/docs/getting-started/QUICK_START.md
+++ b/.agentkit/docs/getting-started/QUICK_START.md
@@ -76,7 +76,7 @@ After initialization, review and customize `.agentkit/overlays/my-project/settin
 repoName: my-project
 defaultBranch: main
 primaryStack: auto # auto | node | dotnet | rust | python
-windowsFirst: false
+windowsFirst: true # false skips the .ps1 hook variants (POSIX-only repos)
 renderTargets:
   - claude # Remove any tools your team does not use
   - cursor

--- a/.agentkit/engines/node/src/__tests__/claude-hook-wiring.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/claude-hook-wiring.test.mjs
@@ -17,7 +17,7 @@
  * retort's own generated output was always clean and this defect survived
  * unnoticed — the synthetic scenarios are the only thing that exercises it.
  */
-import { readFileSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -25,10 +25,12 @@ import { load as loadYaml } from 'js-yaml';
 import {
   buildHooksFromSpec,
   collectHookExtensions,
+  isWindowsFirst,
   extractHookFiles,
   extractHookStems,
   filterHooksToEmitted,
   isHookEmitted,
+  syncClaudeHooks,
 } from '../platform-syncer.mjs';
 import { buildHookFeatureMap, loadFeatureSpec } from '../feature-manager.mjs';
 import { runValidate } from '../validate.mjs';
@@ -352,6 +354,95 @@ describe('collectHookExtensions()', () => {
 
     rmSync(dir, { recursive: true, force: true });
   });
+
+  it('should index both variants when windowsFirst is unset', async () => {
+    const byStem = await collectHookExtensions(HOOK_TEMPLATE_DIR, {});
+
+    expect([...byStem.get('session-start')].sort()).toEqual(['ps1', 'sh']);
+  });
+
+  it('should drop the .ps1 variant when windowsFirst is false', async () => {
+    const byStem = await collectHookExtensions(HOOK_TEMPLATE_DIR, { windowsFirst: false });
+
+    expect([...byStem.get('session-start')]).toEqual(['sh']);
+  });
+
+  it('should keep every hook when windowsFirst is false, since .sh always ships', async () => {
+    // Arrange — dropping .ps1 must never remove a hook outright
+    const withPs1 = await collectHookExtensions(HOOK_TEMPLATE_DIR);
+
+    // Act
+    const shOnly = await collectHookExtensions(HOOK_TEMPLATE_DIR, { windowsFirst: false });
+
+    // Assert
+    expect([...shOnly.keys()].sort()).toEqual([...withPs1.keys()].sort());
+    for (const exts of shOnly.values()) {
+      expect([...exts]).toEqual(['sh']);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isWindowsFirst — the emit filter for the PowerShell variant
+// ---------------------------------------------------------------------------
+
+describe('isWindowsFirst()', () => {
+  it('should default to true so an overlay that never set the key is unaffected', () => {
+    expect(isWindowsFirst(undefined)).toBe(true);
+    expect(isWindowsFirst({})).toBe(true);
+    expect(isWindowsFirst({ windowsFirst: true })).toBe(true);
+  });
+
+  it('should be false only for an explicit false', () => {
+    expect(isWindowsFirst({ windowsFirst: false })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncClaudeHooks — the emission half of the windowsFirst filter
+//
+// collectHookExtensions() decides what settings.json invokes; this decides what
+// lands on disk. They read the same flag, and a test on only one of them would
+// let the pair drift back apart.
+// ---------------------------------------------------------------------------
+
+describe('syncClaudeHooks() windowsFirst emission', () => {
+  const root = resolve(TEST_TMP, 'windows-first-emission');
+  const templatesDir = resolve(root, 'templates');
+  const hooksDir = resolve(templatesDir, 'claude', 'hooks');
+
+  beforeEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(resolve(hooksDir, 'alpha.sh'), '#!/usr/bin/env bash\nexit 0\n', 'utf-8');
+    writeFileSync(resolve(hooksDir, 'alpha.ps1'), 'exit 0\n', 'utf-8');
+    writeFileSync(resolve(hooksDir, 'beta.sh'), '#!/usr/bin/env bash\nexit 0\n', 'utf-8');
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  async function emitWith(vars) {
+    const out = resolve(root, 'out');
+    await syncClaudeHooks(templatesDir, out, vars, '1.0.0', 'test-repo', null);
+    const dir = resolve(out, '.claude', 'hooks');
+    return existsSync(dir) ? readdirSync(dir).sort() : [];
+  }
+
+  it('should emit both variants by default', async () => {
+    expect(await emitWith({})).toEqual(['alpha.ps1', 'alpha.sh', 'beta.sh']);
+  });
+
+  it('should skip .ps1 files when windowsFirst is false', async () => {
+    expect(await emitWith({ windowsFirst: false })).toEqual(['alpha.sh', 'beta.sh']);
+  });
+
+  it('should still emit a hook that ships no .ps1 when windowsFirst is false', async () => {
+    // The filter drops a variant, never a hook — budget-guard-check and
+    // pre-push-validate ship only a .sh and must survive either setting
+    expect(await emitWith({ windowsFirst: false })).toContain('beta.sh');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -435,6 +526,40 @@ describe('hook wiring leaves no orphaned template', () => {
           `hook template "${stem}.${ext}" ships but nothing wires it`
         ).toBe(true);
       }
+    }
+  });
+
+  it('should hold in both directions when windowsFirst drops the .ps1 variant', async () => {
+    // Arrange — the emit filter has to move wiring and files together. Wiring a
+    // .ps1 this repo no longer writes is the dangling reference #185 was about;
+    // emitting one nothing invokes is the orphan the test above covers.
+    const spec = loadYaml(readFileSync(SETTINGS_SPEC, 'utf-8'));
+    const exts = await collectHookExtensions(HOOK_TEMPLATE_DIR, { windowsFirst: false });
+
+    // Act
+    const wired = new Set();
+    for (const matchers of Object.values(buildHooksFromSpec(spec.hooks, exts))) {
+      for (const matcher of matchers) {
+        for (const hook of matcher.hooks) {
+          for (const file of extractHookFiles(hook.command)) wired.add(file);
+        }
+      }
+    }
+
+    // Assert — nothing wired that is not emitted...
+    for (const file of wired) {
+      expect(file.endsWith('.sh'), `"${file}" is wired but windowsFirst:false emits no .ps1`).toBe(
+        true
+      );
+      const stem = file.replace(/\.sh$/, '');
+      expect(exts.has(stem), `"${file}" is wired but ships no template`).toBe(true);
+    }
+
+    // ...and nothing emitted that is not wired
+    for (const stem of exts.keys()) {
+      expect(wired.has(`${stem}.sh`), `hook template "${stem}.sh" ships but nothing wires it`).toBe(
+        true
+      );
     }
   });
 });

--- a/.agentkit/engines/node/src/__tests__/spec-validator.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/spec-validator.test.mjs
@@ -1138,3 +1138,176 @@ describe('convention type and phase validation', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// validate() — pattern and additionalProperties
+// ---------------------------------------------------------------------------
+describe('validate() pattern', () => {
+  const schema = { type: 'string', pattern: /^[a-z-]+$/ };
+
+  it('should accept a string matching the pattern', () => {
+    expect(validate('session-start', schema, 'x')).toEqual([]);
+  });
+
+  it('should reject a string that does not match, naming the offending value', () => {
+    const errors = validate('bad name;rm', schema, 'x');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('bad name;rm');
+  });
+
+  it('should ignore the pattern for a non-string value', () => {
+    // Type errors are reported by the type check; pattern must not double-report
+    expect(validate(42, { type: 'string', pattern: /^[a-z]+$/ }, 'x')).toHaveLength(1);
+  });
+
+  it('should skip the pattern for an omitted optional field', () => {
+    expect(validate(undefined, schema, 'x')).toEqual([]);
+  });
+});
+
+describe('validate() additionalProperties', () => {
+  const base = {
+    type: 'object',
+    properties: { known: { type: 'string' } },
+  };
+
+  it('should allow undeclared keys by default, so existing schemas are unaffected', () => {
+    expect(validate({ known: 'a', extra: 'b' }, base, 'x')).toEqual([]);
+  });
+
+  it('should reject an undeclared key when additionalProperties is false', () => {
+    const schema = { ...base, additionalProperties: false };
+    const errors = validate({ known: 'a', extra: 'b' }, schema, 'x');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('extra');
+    expect(errors[0]).toContain('unknown key');
+  });
+
+  it('should accept an object using only declared keys', () => {
+    const schema = { ...base, additionalProperties: false };
+    expect(validate({ known: 'a' }, schema, 'x')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// settings.yaml — hooks block shape
+//
+// The block was previously `{ type: 'object' }`, so every case below passed
+// validation and produced a settings.json missing the affected hook in silence.
+// ---------------------------------------------------------------------------
+describe('validateSpec() settings.yaml hooks', () => {
+  function makeSettingsRoot(hooks) {
+    const root = mkdtempSync(resolve(tmpdir(), 'agentkit-spec-hooks-'));
+    const specDir = resolve(root, 'spec');
+    mkdirSync(specDir, { recursive: true });
+
+    const files = {
+      'teams.yaml': {
+        teams: [{ id: 'backend', name: 'BACKEND', focus: 'API', scope: ['src/**'] }],
+        techStacks: [
+          {
+            name: 'node',
+            buildCommand: 'pnpm build',
+            testCommand: 'pnpm test',
+            detect: ['package.json'],
+          },
+        ],
+      },
+      'agents.yaml': {
+        agents: {
+          engineering: [
+            {
+              id: 'backend',
+              name: 'Backend Engineer',
+              role: 'backend role',
+              focus: ['src/**'],
+              responsibilities: ['build api'],
+            },
+          ],
+        },
+      },
+      'commands.yaml': { commands: [] },
+      'rules.yaml': {
+        rules: [
+          {
+            domain: 'typescript',
+            description: 'ts conventions',
+            'applies-to': ['**/*.ts'],
+            conventions: [{ id: 'ts-1', rule: 'Use strict mode', severity: 'warning' }],
+          },
+        ],
+      },
+      'settings.yaml': { permissions: { allow: [], deny: [] }, hooks },
+      'aliases.yaml': { aliases: {} },
+      'docs.yaml': { categories: [] },
+    };
+
+    for (const [name, body] of Object.entries(files)) {
+      writeFileSync(resolve(specDir, name), JSON.stringify(body, null, 2));
+    }
+    return root;
+  }
+
+  function errorsFor(hooks) {
+    const root = makeSettingsRoot(hooks);
+    try {
+      return validateSpec(root).errors.filter((e) => e.includes('settings.yaml'));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  it('should accept the shape the real spec uses', () => {
+    expect(
+      errorsFor({
+        sessionStart: 'session-start',
+        preToolUse: [{ matcher: 'Bash|Write|Edit', hook: 'budget-guard-check' }],
+        postToolUse: [{ matcher: 'Write|Edit', hook: 'warn-uncommitted' }],
+        stop: 'stop-build-check',
+      })
+    ).toEqual([]);
+  });
+
+  it('should accept an empty hooks block', () => {
+    expect(errorsFor({})).toEqual([]);
+  });
+
+  it('should accept an entry with no matcher, which is optional', () => {
+    expect(errorsFor({ preToolUse: [{ hook: 'guard-destructive-commands' }] })).toEqual([]);
+  });
+
+  it('should reject a mis-keyed lifecycle event', () => {
+    const errors = errorsFor({ preToolUsage: [{ hook: 'budget-guard-check' }] });
+    expect(errors.some((e) => e.includes('preToolUsage') && e.includes('unknown key'))).toBe(true);
+  });
+
+  it('should reject an entry whose hook key is misspelled', () => {
+    const errors = errorsFor({ preToolUse: [{ matcher: 'Bash', hoook: 'budget-guard-check' }] });
+    // Both the missing required `hook` and the stray `hoook` are reported
+    expect(errors.some((e) => e.includes('hook') && e.includes('required'))).toBe(true);
+    expect(errors.some((e) => e.includes('hoook') && e.includes('unknown key'))).toBe(true);
+  });
+
+  it('should reject a hook stem that is unsafe to interpolate into a command', () => {
+    // Semicolon and space both end the command the stem is spliced into
+    const errors = errorsFor({ preToolUse: [{ hook: 'guard;whoami' }] });
+    expect(errors.some((e) => e.includes('guard;whoami'))).toBe(true);
+  });
+
+  it('should reject a hook stem containing shell expansion characters', () => {
+    const errors = errorsFor({ sessionStart: 'start$(whoami)' });
+    expect(errors.some((e) => e.includes('start$(whoami)'))).toBe(true);
+  });
+
+  it('should reject a non-string sessionStart', () => {
+    const errors = errorsFor({ sessionStart: 42 });
+    expect(errors.some((e) => e.includes('sessionStart') && e.includes('expected string'))).toBe(
+      true
+    );
+  });
+
+  it('should reject a lifecycle list that is not an array', () => {
+    const errors = errorsFor({ preToolUse: { hook: 'budget-guard-check' } });
+    expect(errors.some((e) => e.includes('preToolUse') && e.includes('expected array'))).toBe(true);
+  });
+});

--- a/.agentkit/engines/node/src/fs-utils.mjs
+++ b/.agentkit/engines/node/src/fs-utils.mjs
@@ -58,6 +58,21 @@ export function isUnsafePathSegment(value) {
   return false;
 }
 
+/**
+ * Characters permitted in a hook stem (the file name minus its `.sh`/`.ps1`
+ * extension). A stem is interpolated into a command whose path is only partly
+ * quoted — `"$CLAUDE_PROJECT_DIR"/.claude/hooks/<stem>.sh` — so whitespace,
+ * quotes, `$`, backticks or `;` in a name would change how that command parses.
+ * Real hook names are simple, so require exactly that.
+ *
+ * Lives in fs-utils (not platform-syncer) for the same reason as
+ * isUnsafePathSegment: spec-validator.mjs rejects an unsafe stem at validation
+ * time, and must do so against the *same* pattern the syncer filters on without
+ * importing the entire syncer. Two copies of this regex drifting apart is the
+ * exact failure this pattern exists to prevent.
+ */
+export const SAFE_HOOK_STEM = /^[A-Za-z0-9._-]+$/;
+
 export async function* walkDir(dir) {
   if (!existsSync(dir)) return;
   let entries = [];

--- a/.agentkit/engines/node/src/platform-syncer.mjs
+++ b/.agentkit/engines/node/src/platform-syncer.mjs
@@ -16,7 +16,7 @@ import {
   validateThemeSpec,
 } from './brand-resolver.mjs';
 
-import { isUnsafePathSegment } from './fs-utils.mjs';
+import { isUnsafePathSegment, SAFE_HOOK_STEM } from './fs-utils.mjs';
 import { normalizeForComparison, threeWayMerge } from './scaffold-merge.mjs';
 import { readYaml } from './spec-loader.mjs';
 import { insertHeader, parseTemplateFrontmatter, renderTemplate } from './template-utils.mjs';
@@ -646,12 +646,24 @@ export function filterHooksToEmitted(hooks, hookFeatureMap, vars) {
 }
 
 /**
- * A hook stem is interpolated into a shell command whose path is only partly
- * quoted (`"$CLAUDE_PROJECT_DIR"/.claude/hooks/<stem>.sh`), so anything beyond
- * a plain file name — whitespace, quotes, `$`, backticks, `;` — would alter how
- * that command parses. Real hook names are simple, so require exactly that.
+ * Whether this repo emits the PowerShell variant of a hook.
+ *
+ * `.sh` is the universal baseline and always ships; `.ps1` is additive — the
+ * native variant on Windows, invoked in preference to the `.sh` when both are
+ * present, with the `.sh` as the fallback for machines without pwsh. A repo
+ * that never runs on Windows sets `windowsFirst: false` to stop emitting
+ * PowerShell files it would never execute.
+ *
+ * The filter is deliberately one-directional. Dropping the `.sh` instead would
+ * strip the fallback that lets a Windows-authored repo still run its hooks on a
+ * Linux CI runner, and would delete outright the hooks that ship no `.ps1` at
+ * all (budget-guard-check, pre-push-validate) — silently removing a guard.
+ *
+ * Defaults to true, so an overlay that never sets the key is unaffected.
  */
-const SAFE_HOOK_STEM = /^[A-Za-z0-9._-]+$/;
+export function isWindowsFirst(vars) {
+  return vars?.windowsFirst !== false;
+}
 
 /**
  * Indexes the hook templates by stem, recording which extensions ship for each
@@ -665,15 +677,23 @@ const SAFE_HOOK_STEM = /^[A-Za-z0-9._-]+$/;
  * wired, so it can never reach a command string. Sync still writes the file, so
  * it surfaces as an orphan and fails the wiring test instead of silently
  * generating a command that does not parse.
+ *
+ * `vars` is optional and only supplies `windowsFirst`. It must be the same
+ * `vars` syncClaudeHooks() gates emission on: the index decides what settings.json
+ * *invokes*, so indexing a variant this repo does not emit would wire a command
+ * pointing at a file that was never written.
  */
-export async function collectHookExtensions(hooksDir) {
+export async function collectHookExtensions(hooksDir, vars) {
   const byStem = new Map();
   if (!existsSync(hooksDir)) return byStem;
+  const withPowerShell = isWindowsFirst(vars);
   for (const fname of await readdir(hooksDir)) {
     const m = fname.match(/^(.+)\.(sh|ps1)$/i);
     if (!m || !SAFE_HOOK_STEM.test(m[1])) continue;
+    const ext = m[2].toLowerCase();
+    if (ext === 'ps1' && !withPowerShell) continue;
     if (!byStem.has(m[1])) byStem.set(m[1], new Set());
-    byStem.get(m[1]).add(m[2].toLowerCase());
+    byStem.get(m[1]).add(ext);
   }
   return byStem;
 }
@@ -790,7 +810,7 @@ export async function syncClaudeSettings(
   // which variant each entry invokes.
   const specHooks = buildHooksFromSpec(
     settingsSpec?.hooks,
-    await collectHookExtensions(join(templatesDir, 'claude', 'hooks'))
+    await collectHookExtensions(join(templatesDir, 'claude', 'hooks'), vars)
   );
   if (specHooks) settings.hooks = specHooks;
   // Keep hook wiring in step with the hooks sync actually emits
@@ -826,6 +846,9 @@ export async function syncClaudeHooks(
     if (!isHookEmitted(stem, hookFeatureMap, vars)) continue;
 
     const ext = extname(srcFile).toLowerCase();
+    // Mirrors collectHookExtensions(), which gates what settings.json invokes.
+    // Both read the same `vars`, so a variant is never wired without being written.
+    if (ext === '.ps1' && !isWindowsFirst(vars)) continue;
     const content = await readTemplateText(srcFile);
     const rendered = renderTemplate(content, vars, srcFile);
     const withHeader = insertHeader(rendered, ext, version, repoName);

--- a/.agentkit/engines/node/src/spec-validator.mjs
+++ b/.agentkit/engines/node/src/spec-validator.mjs
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, readdirSync } from 'fs';
 import yaml from 'js-yaml';
 import { resolve } from 'path';
 import { validateAffectsTemplates, validateFeatureSpec } from './feature-manager.mjs';
+import { SAFE_HOOK_STEM } from './fs-utils.mjs';
 import { VALID_TASK_TYPES } from './task-types.mjs';
 
 // ---------------------------------------------------------------------------
@@ -61,6 +62,18 @@ function validate(value, schema, path = '') {
       for (const [key, propSchema] of Object.entries(schema.properties)) {
         errors.push(...validate(value[key], propSchema, `${path}.${key}`));
       }
+      // Opt-in, so every existing schema keeps accepting keys it does not
+      // declare. Set it only where an unrecognised key means a typo rather
+      // than an extension point: silently ignoring one is how a mis-keyed
+      // hook event vanishes from generated wiring without a word.
+      if (schema.additionalProperties === false) {
+        const declared = Object.keys(schema.properties);
+        for (const key of Object.keys(value)) {
+          if (!declared.includes(key)) {
+            errors.push(`${path}.${key}: unknown key (expected one of [${declared.join(', ')}])`);
+          }
+        }
+      }
     }
   }
 
@@ -70,6 +83,10 @@ function validate(value, schema, path = '') {
 
   if (schema.minLength && typeof value === 'string' && value.length < schema.minLength) {
     errors.push(`${path}: must be at least ${schema.minLength} characters`);
+  }
+
+  if (schema.pattern && typeof value === 'string' && !schema.pattern.test(value)) {
+    errors.push(`${path}: "${value}" must match ${schema.pattern}`);
   }
 
   return errors;
@@ -262,6 +279,30 @@ const ruleDomainSchema = {
 // ---------------------------------------------------------------------------
 // Schema: settings.yaml
 // ---------------------------------------------------------------------------
+/**
+ * One entry in `preToolUse` / `postToolUse`. `hook` names a script by stem;
+ * `matcher` is the regex tested against the tool name and is optional.
+ *
+ * buildHooksFromSpec() skips an entry whose `hook` is missing or unnamed rather
+ * than throwing, so without this schema a `hoook:` typo produced a settings.json
+ * quietly missing that guard. additionalProperties catches exactly that.
+ */
+const hookEntrySchema = {
+  type: 'object',
+  properties: {
+    matcher: { type: 'string', minLength: 1 },
+    hook: { type: 'string', required: true, minLength: 1, pattern: SAFE_HOOK_STEM },
+  },
+  additionalProperties: false,
+};
+
+/**
+ * The `hooks:` block was `{ type: 'object' }` — validated as "is an object" and
+ * nothing more, which is how the spec and the hook templates drifted apart
+ * unnoticed. Each lifecycle event is now checked for shape, and an unknown key
+ * is an error: a mis-keyed event (`preToolUsage:`) would otherwise be dropped in
+ * silence, emitting settings.json with that guard simply absent.
+ */
 const settingsSchema = {
   type: 'object',
   properties: {
@@ -273,7 +314,17 @@ const settingsSchema = {
         deny: { type: 'array', required: true, items: { type: 'string' } },
       },
     },
-    hooks: { type: 'object', required: true },
+    hooks: {
+      type: 'object',
+      required: true,
+      properties: {
+        sessionStart: { type: 'string', minLength: 1, pattern: SAFE_HOOK_STEM },
+        stop: { type: 'string', minLength: 1, pattern: SAFE_HOOK_STEM },
+        preToolUse: { type: 'array', items: hookEntrySchema },
+        postToolUse: { type: 'array', items: hookEntrySchema },
+      },
+      additionalProperties: false,
+    },
   },
 };
 

--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -464,6 +464,13 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
     // autoSyncOnPush controls whether the pre-push hook runs agentkit sync
     // before every push (issue #410). Defaults to false; opt-in per repo.
     autoSyncOnPush: overlaySettings.autoSyncOnPush ?? settingsSpec.sync?.autoSyncOnPush ?? false,
+    // windowsFirst controls whether the PowerShell variant of each hook is
+    // emitted and wired. Defaults to true: `.ps1` ships alongside the `.sh`
+    // and is invoked in preference to it, with the `.sh` as the fallback for
+    // machines without pwsh. Set false in a repo that never runs on Windows to
+    // stop emitting PowerShell files it would never execute. See
+    // isWindowsFirst() in platform-syncer.mjs for why the filter is one-directional.
+    windowsFirst: overlaySettings.windowsFirst ?? settingsSpec.sync?.windowsFirst ?? true,
     // skillsCategorised opts the repo into the layered skills layout:
     //   .claude/skills/<category>/<name>/SKILL.md
     //   .agents/skills/<category>/<name>/SKILL.md

--- a/.agentkit/overlays/__TEMPLATE__/settings.yaml
+++ b/.agentkit/overlays/__TEMPLATE__/settings.yaml
@@ -4,6 +4,11 @@ repoName: __TEMPLATE__
 defaultBranch: main # Repository default branch (usually main or master)
 integrationBranch: main # Branch PRs should target (often dev or main; defaults to defaultBranch)
 primaryStack: auto
+# Emit the PowerShell (.ps1) variant of each hook alongside the .sh.
+# true  — .ps1 ships and is invoked in preference to the .sh, which stays as the
+#         fallback for machines without pwsh. Correct for Windows or mixed teams.
+# false — .ps1 files are not emitted or wired. Set this only if the repo never
+#         runs hooks on Windows. Hooks that ship no .ps1 are unaffected.
 windowsFirst: true
 
 # After template + overlay are combined, run an LLM synthesis pass that produces

--- a/.agentkit/overlays/retort/settings.yaml
+++ b/.agentkit/overlays/retort/settings.yaml
@@ -4,6 +4,9 @@ repoName: retort
 defaultBranch: main # Production branch — never commit directly
 integrationBranch: dev # PRs must target dev, not main
 primaryStack: auto
+# Emit the .ps1 variant of each hook alongside the .sh. Retort is developed on
+# Windows and tested on Linux CI, so both must ship: the .ps1 runs natively for
+# contributors, the .sh is the fallback on runners without pwsh.
 windowsFirst: true
 
 aiSynthesisLayer: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Activate the commit template: `git config commit.template .gitmessage`
 - Hook-based safety guardrails
 - Automated quality gates and validation
 - Hook wiring generated from spec ([#575](../../pull/575), [history](docs/history/implementations/0010-2026-08-07-hook-wiring-generated-from-spec-implementation.md))
+- Hook spec validation and windowsFirst emit filter ([history](docs/history/features/0001-2026-08-08-hook-spec-validation-and-windowsfirst-emit-filter-feature.md))
 
 ### Changed
 

--- a/docs/history/.index.json
+++ b/docs/history/.index.json
@@ -2,7 +2,7 @@
   "sequences": {
     "implementation": 11,
     "bugfix": 6,
-    "feature": 1,
+    "feature": 2,
     "migration": 1,
     "issue": 1,
     "lesson": 1
@@ -55,6 +55,14 @@
       "date": "2026-08-07",
       "pr": "579",
       "file": "bug-fixes/0005-2026-08-07-silently-broken-ci-config-defects-bugfix.md"
+    },
+    {
+      "number": 1,
+      "type": "feature",
+      "title": "Hook spec validation and windowsFirst emit filter",
+      "date": "2026-08-08",
+      "pr": "",
+      "file": "features/0001-2026-08-08-hook-spec-validation-and-windowsfirst-emit-filter-feature.md"
     }
   ]
 }

--- a/docs/history/features/0001-2026-08-08-hook-spec-validation-and-windowsfirst-emit-filter-feature.md
+++ b/docs/history/features/0001-2026-08-08-hook-spec-validation-and-windowsfirst-emit-filter-feature.md
@@ -1,0 +1,174 @@
+# Hook spec validation and windowsFirst emit filter - Historical Summary
+
+**Launched**: 2026-08-08
+**PR**: [#PR-Number]
+**Feature Type**: Enhancement (validation hardening + one new setting)
+
+## Feature Overview
+
+Closes the two follow-ups recorded at the end of #577.
+
+1. The `hooks:` block in `.agentkit/spec/settings.yaml` is now schema-validated
+   for shape. It was previously declared `{ type: 'object', required: true }` —
+   "is an object" and nothing more.
+2. `windowsFirst` — present in three overlays and documented for adopters, but
+   read by no code or template — now controls whether the PowerShell variant of
+   each hook is emitted and wired.
+
+## User Problem Solved
+
+**Unvalidated hook spec.** `buildHooksFromSpec()` skips malformed entries rather
+than throwing, which is correct for robustness but means a spec mistake produces
+a `settings.json` with the affected guard silently absent. Nothing failed; the
+hook simply never ran. This is the same class of defect as the five orphaned
+`.ps1` hooks in #577, and the missing schema is why it went unnoticed.
+
+Verified against the old schema before changing it — this block produced **zero**
+errors:
+
+```yaml
+hooks:
+  preToolUsage: # mis-keyed event: dropped in silence
+    - hoook: budget-guard-check # misspelled key: entry skipped
+  sessionStart: 42 # not a string: hook unnamed, skipped
+  preToolUse:
+    - hook: 'guard;whoami' # unsafe stem: dropped by the syncer's own filter
+```
+
+**Dead config.** `windowsFirst` was inert. QUICK_START and ONBOARDING presented
+it to adopters as a real knob, so setting it did nothing and the docs misled.
+
+## Implementation Details
+
+### Architecture
+
+Both changes serve one principle: a mismatch between the spec and what ships
+should fail loudly at sync time rather than degrade silently at runtime.
+
+The `windowsFirst` filter is applied at two points that must agree — what sync
+writes to disk, and what `settings.json` invokes. Both read the same `vars`, and
+the bidirectional invariant test from #577 is asserted under both settings, so
+they cannot drift apart the way the original defect did.
+
+### Components
+
+- **`spec-validator.mjs`**: `settingsSchema.hooks` now declares each lifecycle
+  event. `hookEntrySchema` validates `{ matcher?, hook }`. Two primitives added
+  to `validate()`: `pattern` (regex on strings) and `additionalProperties`
+  (reject undeclared keys). Both are opt-in — every existing schema keeps
+  accepting keys it does not declare, so nothing else changes behaviour.
+- **`fs-utils.mjs`**: `SAFE_HOOK_STEM` moved here from `platform-syncer.mjs` so
+  the validator and the syncer test the same regex. Duplicating it would have
+  recreated the exact drift being closed. `fs-utils` already exists for this
+  purpose — see the note on `isUnsafePathSegment`.
+- **`platform-syncer.mjs`**: new `isWindowsFirst(vars)`. `collectHookExtensions()`
+  takes optional `vars` and omits `.ps1` when the flag is false;
+  `syncClaudeHooks()` skips writing `.ps1` under the same condition.
+- **`synchronize.mjs`**: `windowsFirst` resolved into `vars` from the overlay,
+  defaulting to `true`.
+
+### The filter is one-directional — deliberately
+
+`windowsFirst: false` drops `.ps1`. **Nothing drops `.sh`.** A symmetric filter
+was considered and rejected: under `windowsFirst: true` it would have made
+`session-start` pwsh-only, breaking this repo's own Linux CI, and would have
+deleted `budget-guard-check` and `pre-push-validate` outright — they ship no
+`.ps1` at all — removing a budget guard and a pre-push check in silence.
+
+`.sh` is the universal baseline; `.ps1` is additive. Every `.ps1` template that
+ships has a `.sh` sibling, so dropping the variant never removes a hook.
+
+### API Changes
+
+- `collectHookExtensions(hooksDir)` → `collectHookExtensions(hooksDir, vars?)`.
+  Second argument optional; omitting it indexes both variants, so existing
+  callers are unaffected.
+- New export: `isWindowsFirst(vars)`.
+- New overlay setting: `windowsFirst` (boolean, defaults `true`).
+
+### Database Changes
+
+None — this repository has no database.
+
+## User Experience
+
+A repo that never runs hooks on Windows sets `windowsFirst: false` in its overlay
+and stops receiving `.ps1` files it would never execute. Wiring follows
+automatically. Everyone else is unaffected: `true` is byte-for-byte the previous
+behaviour, confirmed by a zero-drift sync.
+
+A malformed `hooks:` block now fails `spec-validate` with a message naming the
+offending key, instead of producing a `settings.json` missing that hook.
+
+### UI Changes
+
+None — no user interface in this project.
+
+### Documentation
+
+- `.agentkit/docs/getting-started/ONBOARDING.md` — describes what the setting
+  does, the default, and that it never removes a hook (only a variant).
+- `.agentkit/docs/getting-started/QUICK_START.md` — sample corrected to `true`
+  (the default) with an inline note; it previously showed `false`, which would
+  now silently opt a new adopter out of PowerShell hooks.
+- Inline comments in `overlays/__TEMPLATE__/settings.yaml` and
+  `overlays/retort/settings.yaml`.
+
+## Rollout Plan
+
+Single change, no phasing. `windowsFirst` defaults to `true`, so the feature is
+inert until a repo opts in — there is no migration step for existing adopters.
+
+### Monitoring
+
+No runtime telemetry. The guarantees are enforced at build time by the
+bidirectional wiring invariant and the CI drift check.
+
+## Results
+
+Not applicable in the product sense — this is framework-internal. Verification:
+
+| Check                         | Result                            |
+| ----------------------------- | --------------------------------- |
+| `spec-validate`               | PASSED                            |
+| `validate`                    | PASSED (16 pre-existing warnings) |
+| Sync drift                    | Zero — generated output unchanged |
+| `spec-validator.test.mjs`     | 96 passed (+16 new)               |
+| `claude-hook-wiring.test.mjs` | 69 passed (+9 new)                |
+| Prettier                      | Clean on all changed files        |
+
+Local full-suite runs on this Windows machine remain untrustworthy: three tests
+fail on 15s/30s/90s timeouts (`discover`, `sync-integration`, `prettier`) under
+disk contention, and the failing set differs between runs. None report an
+assertion failure. The Linux CI Test job is the real verification.
+
+### Usage Statistics
+
+Not tracked.
+
+### User Feedback
+
+None yet.
+
+## Future Enhancements
+
+- The `sync:` block in `spec/settings.yaml` is still unvalidated; only `hooks:`
+  and `permissions:` have schemas. `additionalProperties` is now available if
+  that is worth tightening.
+- `.agentkit/.manifest.json` is gitignored, so a fresh clone has no prior
+  manifest and orphan-pruning never fires. Unrelated to this change, but it is
+  why stale generated output survives across clones.
+
+## Related Work
+
+- #577 — wired every shipped hook variant, pruned stale output; recorded both
+  follow-ups closed here.
+- #575 — introduced `buildHooksFromSpec()` and made the spec the single source
+  of hook wiring.
+- #185 — the original dangling-hook-reference defect.
+
+---
+
+**Product Manager**: n/a (framework-internal)
+**Tech Lead**: Jurie Smit
+**Status**: Live


### PR DESCRIPTION
## Summary

Closes the two follow-ups recorded at the end of #577.

1. **The `hooks:` block was unvalidated.** It was declared `{ type: 'object', required: true }` — "is an object" and nothing further. That is how the spec and the hook templates drifted apart unnoticed.
2. **`windowsFirst` was dead config.** Set in three overlays and documented in QUICK_START and ONBOARDING as a real knob, but read by no code or template. It now controls whether the PowerShell variant of each hook is emitted and wired.

## Why it mattered

`buildHooksFromSpec()` skips malformed entries rather than throwing — correct for robustness, but it means a spec mistake yields a `settings.json` with the guard silently absent. Verified against the old schema before changing it, this block produced **zero** errors:

```yaml
hooks:
  preToolUsage: # mis-keyed event: dropped in silence
    - hoook: budget-guard-check # misspelled key: entry skipped
  sessionStart: 42 # not a string: hook unnamed, skipped
  preToolUse:
    - hook: 'guard;whoami' # unsafe stem: dropped by the syncer's own filter
```

## The windowsFirst filter is one-directional — deliberately

`false` drops `.ps1`. **Nothing drops `.sh`.** A symmetric filter was considered and rejected: under `windowsFirst: true` it would have made `session-start` pwsh-only, breaking this repo's own Linux CI, and would have deleted `budget-guard-check` and `pre-push-validate` outright — they ship no `.ps1` — removing a budget guard and a pre-push check in silence.

`.sh` is the universal baseline; `.ps1` is additive. Emission (`syncClaudeHooks`) and wiring (`collectHookExtensions`) read the same flag, and the bidirectional invariant from #577 is asserted under **both** settings, so the pair cannot drift back apart.

`windowsFirst: true` is byte-for-byte the previous behaviour — sync reports zero drift.

## Notable

`SAFE_HOOK_STEM` moves to `fs-utils.mjs` so the validator and the syncer test the same regex. Duplicating it would have recreated the exact drift being closed; `fs-utils` already exists for this reason (see `isUnsafePathSegment`).

`pattern` and `additionalProperties` were added to `validate()` to express the schema. Both are **opt-in**, so every existing schema keeps accepting keys it does not declare — no other spec changes behaviour.

## Test plan

| Check | Result |
| --- | --- |
| `spec-validate` | PASSED |
| `validate` | PASSED (16 pre-existing warnings) |
| Sync drift | Zero — generated output unchanged |
| `spec-validator.test.mjs` | 96 passed (+16 new) |
| `claude-hook-wiring.test.mjs` | 69 passed (+9 new) |
| Prettier | Clean on all changed files |

Rebased onto `3621e10f` (#579) and re-verified: 165 passed across both suites, drift still zero.

Local full-suite runs on this Windows machine remain untrustworthy — three tests fail on 15s/30s/90s timeouts (`discover`, `sync-integration`, `prettier`) under disk contention, and the failing set differs between runs. None report an assertion failure. The Linux CI Test job is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
