### PR TITLE
fix(sync): resolve or abort on overlay selection, never fall back silently

### DIFF
--- a/.agentkit/engines/node/src/__tests__/fresh-install.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/fresh-install.test.mjs
@@ -96,11 +96,19 @@ describe('fresh install (no node_modules)', () => {
     { skip: process.platform === 'win32', timeout: 130_000 },
     () => {
       const cliPath = join(projectRoot, '.agentkit', 'engines', 'node', 'src', 'cli.mjs');
-      const result = execFileSync('node', [cliPath, 'sync', '--dry-run', '--diff'], {
-        encoding: 'utf-8',
-        cwd: projectRoot,
-        timeout: 120_000,
-      });
+      // The subject here is the dependency auto-install, not overlay
+      // resolution. A fresh checkout genuinely has no `.agentkit-repo` — that
+      // is what `retort init` writes — so sync would correctly abort and never
+      // reach the assertions. Naming the overlay keeps the test on its subject.
+      const result = execFileSync(
+        'node',
+        [cliPath, 'sync', '--overlay', '__TEMPLATE__', '--dry-run', '--diff'],
+        {
+          encoding: 'utf-8',
+          cwd: projectRoot,
+          timeout: 120_000,
+        }
+      );
       expect(result).toContain('[retort:sync]');
       expect(result).toContain('Dry-run');
       expect(

--- a/.agentkit/engines/node/src/__tests__/overlay-resolver.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/overlay-resolver.test.mjs
@@ -103,6 +103,16 @@ describe('resolveOverlaySelection — resolution order', () => {
     expect(selection.reason).toContain('--overlay flag');
   });
 
+  it('rejects an explicit blank --overlay instead of falling through to a valid marker', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const projectRoot = makeProjectRoot('demo-repo');
+    writeMarker(projectRoot, 'demo-repo');
+
+    expect(() => resolveOverlaySelection(agentkitRoot, projectRoot, { overlay: '' })).toThrow(
+      'Invalid overlay name "" (from --overlay flag)'
+    );
+  });
+
   it('reads the .agentkit-repo marker at the project root', () => {
     const agentkitRoot = makeAgentkitRoot();
     const projectRoot = makeProjectRoot('unrelated-name');

--- a/.agentkit/engines/node/src/__tests__/overlay-resolver.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/overlay-resolver.test.mjs
@@ -1,0 +1,292 @@
+/**
+ * Overlay resolution — resolve-or-abort (ADR-11 decision 3).
+ *
+ * The behaviour under test is the absence of a fallback: when nothing names an
+ * overlay, sync must fail loudly instead of rendering `__TEMPLATE__` content
+ * into a repo that wanted something else. That silent fallback is the root
+ * cause recorded for PRs #478 and #479.
+ */
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, resolve } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveOverlaySelection } from '../overlay-resolver.mjs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Temp directories created by a test, removed in afterEach. */
+const created = new Set();
+
+function makeTmpDir(label) {
+  const dir = resolve(
+    tmpdir(),
+    `agentkit-overlay-resolver-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  created.add(dir);
+  return dir;
+}
+
+function writeTestFile(filePath, content) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, 'utf-8');
+}
+
+/** An agentkit root whose `overlays/` contains one settings.yaml per name. */
+function makeAgentkitRoot(overlayNames = ['__TEMPLATE__', 'demo-repo']) {
+  const root = makeTmpDir('root');
+  for (const name of overlayNames) {
+    writeTestFile(resolve(root, 'overlays', name, 'settings.yaml'), `repoName: ${name}\n`);
+  }
+  return root;
+}
+
+/** A project root named `name`, created under a fresh temp parent. */
+function makeProjectRoot(name = 'project') {
+  const dir = resolve(makeTmpDir('project'), name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeMarker(dir, repoName) {
+  writeFileSync(resolve(dir, '.agentkit-repo'), repoName + '\n', 'utf-8');
+}
+
+function git(args, cwd) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+    windowsHide: true,
+  }).trim();
+}
+
+/**
+ * Initialise a git repo at `dir` with one commit, so linked worktrees can be
+ * added to it. Identity is set locally to keep the test independent of the
+ * ambient git config.
+ */
+function initGitRepo(dir) {
+  git(['init', '--initial-branch=main'], dir);
+  git(['config', 'user.email', 'test@example.com'], dir);
+  git(['config', 'user.name', 'Test'], dir);
+  writeTestFile(resolve(dir, 'README.md'), '# test\n');
+  git(['add', '.'], dir);
+  git(['commit', '-m', 'chore: initial'], dir);
+}
+
+afterEach(() => {
+  for (const dir of created) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  created.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Resolution sources, most explicit first
+// ---------------------------------------------------------------------------
+
+describe('resolveOverlaySelection — resolution order', () => {
+  it('prefers the --overlay flag over every other source', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const projectRoot = makeProjectRoot('demo-repo');
+    writeMarker(projectRoot, 'demo-repo');
+
+    const selection = resolveOverlaySelection(agentkitRoot, projectRoot, {
+      overlay: '__TEMPLATE__',
+    });
+
+    expect(selection.repoName).toBe('__TEMPLATE__');
+    expect(selection.reason).toContain('--overlay flag');
+  });
+
+  it('reads the .agentkit-repo marker at the project root', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const projectRoot = makeProjectRoot('unrelated-name');
+    writeMarker(projectRoot, 'demo-repo');
+
+    const selection = resolveOverlaySelection(agentkitRoot, projectRoot, {});
+
+    expect(selection.repoName).toBe('demo-repo');
+    expect(selection.reason).toContain('.agentkit-repo marker');
+  });
+
+  it('ignores a blank marker and falls through to the next source', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const projectRoot = makeProjectRoot('demo-repo');
+    writeMarker(projectRoot, '   ');
+
+    const selection = resolveOverlaySelection(agentkitRoot, projectRoot, {});
+
+    expect(selection.repoName).toBe('demo-repo');
+    expect(selection.reason).toContain('inferred from project root name');
+  });
+
+  it('infers the overlay from the project root directory name', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const projectRoot = makeProjectRoot('demo-repo');
+
+    const selection = resolveOverlaySelection(agentkitRoot, projectRoot, {});
+
+    expect(selection.repoName).toBe('demo-repo');
+    expect(selection.reason).toContain('inferred from project root name "demo-repo"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Linked git worktrees
+// ---------------------------------------------------------------------------
+
+describe('resolveOverlaySelection — linked git worktrees', () => {
+  it('resolves the marker from the primary worktree when the worktree has none', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const primaryRoot = makeProjectRoot('primary');
+    initGitRepo(primaryRoot);
+    writeMarker(primaryRoot, 'demo-repo');
+
+    // A worktree directory name that matches no overlay, so a pass would have
+    // to have come from the primary marker rather than from inference.
+    const worktreeRoot = resolve(primaryRoot, '..', 'wt-feature-branch');
+    git(['worktree', 'add', worktreeRoot, '-b', 'feature'], primaryRoot);
+    expect(existsSync(resolve(worktreeRoot, '.agentkit-repo'))).toBe(false);
+
+    const selection = resolveOverlaySelection(agentkitRoot, worktreeRoot, {});
+
+    expect(selection.repoName).toBe('demo-repo');
+    expect(selection.reason).toContain('primary worktree');
+  });
+
+  it('prefers the worktree own marker over the primary worktree marker', () => {
+    const agentkitRoot = makeAgentkitRoot(['__TEMPLATE__', 'demo-repo', 'other-repo']);
+    const primaryRoot = makeProjectRoot('primary');
+    initGitRepo(primaryRoot);
+    writeMarker(primaryRoot, 'demo-repo');
+
+    const worktreeRoot = resolve(primaryRoot, '..', 'wt-feature-branch');
+    git(['worktree', 'add', worktreeRoot, '-b', 'feature'], primaryRoot);
+    writeMarker(worktreeRoot, 'other-repo');
+
+    const selection = resolveOverlaySelection(agentkitRoot, worktreeRoot, {});
+
+    expect(selection.repoName).toBe('other-repo');
+    expect(selection.reason).toBe('.agentkit-repo marker');
+  });
+
+  it('aborts when neither the worktree nor the primary worktree has a marker', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const primaryRoot = makeProjectRoot('primary');
+    initGitRepo(primaryRoot);
+
+    const worktreeRoot = resolve(primaryRoot, '..', 'wt-feature-branch');
+    git(['worktree', 'add', worktreeRoot, '-b', 'feature'], primaryRoot);
+
+    expect(() => resolveOverlaySelection(agentkitRoot, worktreeRoot, {})).toThrow(
+      /No .agentkit-repo marker in the primary worktree either/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Abort behaviour — the point of the change
+// ---------------------------------------------------------------------------
+
+describe('resolveOverlaySelection — abort instead of falling back', () => {
+  it('throws rather than defaulting to __TEMPLATE__ when nothing resolves', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const projectRoot = makeProjectRoot('matches-no-overlay');
+
+    expect(() => resolveOverlaySelection(agentkitRoot, projectRoot, {})).toThrow(
+      /Cannot determine which overlay to render/
+    );
+  });
+
+  it('names the available overlays in the abort message', () => {
+    const agentkitRoot = makeAgentkitRoot(['__TEMPLATE__', 'alpha', 'beta']);
+    const projectRoot = makeProjectRoot('matches-no-overlay');
+
+    expect(() => resolveOverlaySelection(agentkitRoot, projectRoot, {})).toThrow(
+      /Available overlays: __TEMPLATE__, alpha, beta/
+    );
+  });
+
+  it('lists only directories that actually carry a settings.yaml', () => {
+    const agentkitRoot = makeAgentkitRoot(['__TEMPLATE__', 'alpha']);
+    mkdirSync(resolve(agentkitRoot, 'overlays', 'no-settings'), { recursive: true });
+    const projectRoot = makeProjectRoot('matches-no-overlay');
+
+    let message = '';
+    try {
+      resolveOverlaySelection(agentkitRoot, projectRoot, {});
+    } catch (err) {
+      message = err.message;
+    }
+
+    expect(message).toContain('Available overlays: __TEMPLATE__, alpha');
+    expect(message).not.toContain('no-settings');
+  });
+
+  it('offers actionable remedies in the abort message', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const projectRoot = makeProjectRoot('matches-no-overlay');
+
+    let message = '';
+    try {
+      resolveOverlaySelection(agentkitRoot, projectRoot, {});
+    } catch (err) {
+      message = err.message;
+    }
+
+    expect(message).toContain('retort init');
+    expect(message).toContain('retort sync --overlay <name>');
+    expect(message).toContain('retort worktree create');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation of a resolved name
+// ---------------------------------------------------------------------------
+
+describe('resolveOverlaySelection — validates the resolved overlay', () => {
+  it('throws when the marker names an overlay that does not exist', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const projectRoot = makeProjectRoot('project');
+    writeMarker(projectRoot, 'typo-repo');
+
+    expect(() => resolveOverlaySelection(agentkitRoot, projectRoot, {})).toThrow(
+      /Overlay "typo-repo" \(from \.agentkit-repo marker\) does not exist/
+    );
+  });
+
+  it('throws when --overlay names an overlay that does not exist', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const projectRoot = makeProjectRoot('project');
+
+    expect(() => resolveOverlaySelection(agentkitRoot, projectRoot, { overlay: 'nope' })).toThrow(
+      /Overlay "nope" \(from --overlay flag\) does not exist/
+    );
+  });
+
+  it('rejects a marker that tries to escape the overlays directory', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const projectRoot = makeProjectRoot('project');
+    writeMarker(projectRoot, '../../etc');
+
+    expect(() => resolveOverlaySelection(agentkitRoot, projectRoot, {})).toThrow(
+      /Invalid overlay name/
+    );
+  });
+
+  it('accepts __TEMPLATE__ when it is named explicitly', () => {
+    const agentkitRoot = makeAgentkitRoot();
+    const projectRoot = makeProjectRoot('project');
+
+    const selection = resolveOverlaySelection(agentkitRoot, projectRoot, {
+      overlay: '__TEMPLATE__',
+    });
+
+    expect(selection.repoName).toBe('__TEMPLATE__');
+  });
+});

--- a/.agentkit/engines/node/src/__tests__/sync-agent-features.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-agent-features.test.mjs
@@ -13,6 +13,15 @@ import { renderTemplate, replacePlaceholders } from '../template-utils.mjs';
 
 const AGENTKIT_ROOT = resolve(import.meta.dirname, '..', '..', '..', '..');
 
+/**
+ * Overlay these syncs render from. The project directory is named
+ * `agentkit-forge`, which stopped matching an overlay when the repo was renamed
+ * to retort, so nothing here is resolvable by name. Since ADR-11 decision 3 that
+ * aborts rather than silently defaulting to `__TEMPLATE__` — naming it keeps the
+ * rendered output identical to what these assertions were written against.
+ */
+const TEMPLATE_OVERLAY = '__TEMPLATE__';
+
 function makeTmpDir() {
   const dir = resolve(
     tmpdir(),
@@ -231,7 +240,7 @@ describe('P0 + P2 Integration: sync generates agent personas and shared sections
       await runSync({
         agentkitRoot: AGENTKIT_ROOT,
         projectRoot,
-        flags: { quiet: false },
+        flags: { overlay: TEMPLATE_OVERLAY, quiet: false },
       });
     } finally {
       console.log = originalLog;
@@ -296,7 +305,7 @@ describe('P7: Concurrency protocol simplification', () => {
       await runSync({
         agentkitRoot: AGENTKIT_ROOT,
         projectRoot,
-        flags: { quiet: false },
+        flags: { overlay: TEMPLATE_OVERLAY, quiet: false },
       });
     } finally {
       console.log = originalLog;

--- a/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/sync-integration.test.mjs
@@ -53,6 +53,21 @@ function removeTree(path) {
   }
 }
 
+/**
+ * Overlay these tests render from.
+ *
+ * Temp project roots carry no `.agentkit-repo` marker and have a random
+ * directory name, so overlay resolution has nothing to resolve from. Since
+ * ADR-11 decision 3 that aborts instead of silently defaulting to
+ * `__TEMPLATE__`, so the tests name the overlay explicitly — which renders
+ * exactly what the old implicit fallback rendered.
+ *
+ * Only syncs against a temp project root need this. Blocks that build their own
+ * agentkit root and a matching project directory (`makeNamedTmpProject`) resolve
+ * by name and deliberately do not pass it.
+ */
+const TEMPLATE_OVERLAY = '__TEMPLATE__';
+
 /** Creates a temp project root for testing sync output. */
 function makeTmpProject() {
   const dir = resolve(
@@ -147,7 +162,11 @@ function goldenSync(flags = {}) {
     createdRoots.add(projectRoot);
     goldenRoots.set(
       key,
-      runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags }).then(() => projectRoot)
+      runSync({
+        agentkitRoot: AGENTKIT_ROOT,
+        projectRoot,
+        flags: { overlay: TEMPLATE_OVERLAY, ...flags },
+      }).then(() => projectRoot)
     );
   }
   return goldenRoots.get(key);
@@ -786,7 +805,11 @@ describe('--overwrite flag', () => {
     const customContent = 'CUSTOM_CONTENT_MARKER_12345';
     writeFileSync(contribPath, customContent, 'utf-8');
 
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: {} });
+    await runSync({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot,
+      flags: { overlay: TEMPLATE_OVERLAY },
+    });
     expect(readFileSync(contribPath, 'utf-8')).toBe(customContent);
   });
 
@@ -795,14 +818,22 @@ describe('--overwrite flag', () => {
     const customContent = 'CUSTOM_OVERWRITE_MARKER_67890';
     writeFileSync(contribPath, customContent, 'utf-8');
 
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { overwrite: true } });
+    await runSync({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot,
+      flags: { overlay: TEMPLATE_OVERLAY, overwrite: true },
+    });
     expect(readFileSync(contribPath, 'utf-8')).not.toContain(customContent);
   });
 
   it('--force is alias for --overwrite', { timeout: 120_000 }, async () => {
     const contribPath = join(projectRoot, 'CONTRIBUTING.md');
     writeFileSync(contribPath, 'CUSTOM', 'utf-8');
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { force: true } });
+    await runSync({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot,
+      flags: { overlay: TEMPLATE_OVERLAY, force: true },
+    });
     expect(readFileSync(contribPath, 'utf-8')).not.toContain('CUSTOM');
   });
 });
@@ -828,7 +859,11 @@ describe('--quiet, --verbose, --no-clean, --diff flags', () => {
       origLog.apply(console, args);
     };
     try {
-      await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { diff: true } });
+      await runSync({
+        agentkitRoot: AGENTKIT_ROOT,
+        projectRoot,
+        flags: { overlay: TEMPLATE_OVERLAY, diff: true },
+      });
       const out = log.join('\n');
       expect(out).toContain('Diff mode');
       expect(out).toContain('create ');
@@ -850,7 +885,9 @@ describe('--quiet, --verbose, --no-clean, --diff flags', () => {
       mkdirSync(tempAgentkitRoot, { recursive: true });
 
       // Copy essential files from AGENTKIT_ROOT to temp
-      const essentialFiles = ['.manifest.json', 'spec', 'templates', 'engines'];
+      // `overlays` is needed as well: overlay resolution now verifies the
+      // selected overlay actually exists, so a root without it cannot sync.
+      const essentialFiles = ['.manifest.json', 'spec', 'templates', 'engines', 'overlays'];
       for (const file of essentialFiles) {
         const src = join(AGENTKIT_ROOT, file);
         const dest = join(tempAgentkitRoot, file);
@@ -868,7 +905,11 @@ describe('--quiet, --verbose, --no-clean, --diff flags', () => {
       }
 
       try {
-        await runSync({ agentkitRoot: tempAgentkitRoot, projectRoot, flags: {} });
+        await runSync({
+          agentkitRoot: tempAgentkitRoot,
+          projectRoot,
+          flags: { overlay: TEMPLATE_OVERLAY },
+        });
         const manifestPath = join(tempAgentkitRoot, '.manifest.json');
         const originalManifest = existsSync(manifestPath)
           ? readFileSync(manifestPath, 'utf-8')
@@ -878,7 +919,11 @@ describe('--quiet, --verbose, --no-clean, --diff flags', () => {
         writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8');
         const orphanPath = join(projectRoot, '__TEST_ORPHAN__.md');
         writeFileSync(orphanPath, 'orphan', 'utf-8');
-        await runSync({ agentkitRoot: tempAgentkitRoot, projectRoot, flags: { 'no-clean': true } });
+        await runSync({
+          agentkitRoot: tempAgentkitRoot,
+          projectRoot,
+          flags: { overlay: TEMPLATE_OVERLAY, 'no-clean': true },
+        });
         expect(existsSync(orphanPath)).toBe(true);
       } finally {
         removeTree(tempAgentkitRoot);
@@ -1301,7 +1346,7 @@ describe('syncEditorTheme — pre-existing settings.json merge', () => {
     await runSync({
       agentkitRoot: AGENTKIT_ROOT,
       projectRoot,
-      flags: { quiet: true, overwrite: true },
+      flags: { overlay: TEMPLATE_OVERLAY, quiet: true, overwrite: true },
     });
   }, 120_000);
   afterAll(() => {
@@ -1372,7 +1417,11 @@ describe('syncGitattributes (merge driver sync)', () => {
       writeFileSync(gitattrsPath, '# My custom rules\n*.pdf binary\n\n' + existing, 'utf-8');
 
       // Re-sync
-      await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { quiet: true } });
+      await runSync({
+        agentkitRoot: AGENTKIT_ROOT,
+        projectRoot,
+        flags: { overlay: TEMPLATE_OVERLAY, quiet: true },
+      });
 
       const updated = readFileSync(gitattrsPath, 'utf-8');
       expect(updated).toContain('# My custom rules');
@@ -1387,7 +1436,11 @@ describe('syncGitattributes (merge driver sync)', () => {
   it('replaces stale managed section without duplication', { timeout: 120_000 }, async () => {
     const gitattrsPath = resolve(projectRoot, '.gitattributes');
     // Re-sync a second time to verify no duplication
-    await runSync({ agentkitRoot: AGENTKIT_ROOT, projectRoot, flags: { quiet: true } });
+    await runSync({
+      agentkitRoot: AGENTKIT_ROOT,
+      projectRoot,
+      flags: { overlay: TEMPLATE_OVERLAY, quiet: true },
+    });
 
     const content = readFileSync(gitattrsPath, 'utf-8');
     const startCount = (content.match(/# >>> Retort merge drivers/g) || []).length;

--- a/.agentkit/engines/node/src/overlay-resolver.mjs
+++ b/.agentkit/engines/node/src/overlay-resolver.mjs
@@ -3,9 +3,10 @@
  * Determines which overlay to use and collects template files from base + overlay.
  * Extracted from synchronize.mjs (Step 4 of modularization).
  */
-import { existsSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { existsSync, readdirSync } from 'fs';
 import { readdir } from 'fs/promises';
-import { basename, join, relative, resolve } from 'path';
+import { basename, dirname, join, relative, resolve } from 'path';
 import { readText } from './spec-loader.mjs';
 
 // ---------------------------------------------------------------------------
@@ -42,20 +43,185 @@ function inferOverlayFromProjectRoot(agentkitRoot, projectRoot) {
   return existsSync(settingsPath) ? inferredName : null;
 }
 
-export function resolveOverlaySelection(agentkitRoot, projectRoot, flags) {
-  if (flags?.overlay) {
-    return {
-      repoName: flags.overlay,
-      reason: '--overlay flag',
-    };
+/**
+ * Read and trim the `.agentkit-repo` marker in `dir`.
+ * Returns null when the marker is absent or blank.
+ *
+ * @param {string} dir
+ * @returns {string|null}
+ */
+function readMarkerName(dir) {
+  const markerPath = resolve(dir, '.agentkit-repo');
+  if (!existsSync(markerPath)) return null;
+  const raw = (readText(markerPath) || '').trim();
+  return raw || null;
+}
+
+/**
+ * Overlay directory names that actually carry a settings.yaml, sorted.
+ *
+ * @param {string} agentkitRoot
+ * @returns {string[]}
+ */
+function listAvailableOverlays(agentkitRoot) {
+  const overlaysDir = resolve(agentkitRoot, 'overlays');
+  let entries;
+  try {
+    entries = readdirSync(overlaysDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(resolve(overlaysDir, name, 'settings.yaml')))
+    .sort();
+}
+
+/**
+ * Root of the primary worktree when `projectRoot` is a linked git worktree.
+ *
+ * `git rev-parse --git-common-dir` resolves to the shared `.git` directory,
+ * which lives in the primary worktree no matter which linked worktree asks —
+ * so its parent is the primary worktree root. That root is where `retort init`
+ * wrote the marker, which is why it is a trustworthy second source.
+ *
+ * Returns null outside a git repository, in a bare repo, when git is
+ * unavailable, or when the common dir is not a conventional `<root>/.git`.
+ *
+ * @param {string} projectRoot
+ * @returns {string|null}
+ */
+function findPrimaryWorktreeRoot(projectRoot) {
+  let commonDir;
+  try {
+    commonDir = execFileSync('git', ['rev-parse', '--git-common-dir'], {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    }).trim();
+  } catch {
+    return null;
+  }
+  if (!commonDir) return null;
+
+  // Git may answer with a path relative to cwd (".git") or an absolute one.
+  const absoluteCommonDir = resolve(projectRoot, commonDir);
+  if (basename(absoluteCommonDir) !== '.git') return null;
+
+  const primaryRoot = dirname(absoluteCommonDir);
+  return primaryRoot === resolve(projectRoot) ? null : primaryRoot;
+}
+
+/**
+ * True when `name` addresses a direct child of `overlays/`.
+ * Rejects path separators and traversal segments before the name is ever
+ * joined onto a filesystem path.
+ *
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isSafeOverlayName(name) {
+  return Boolean(name) && basename(name) === name && name !== '.' && name !== '..';
+}
+
+function formatAvailableOverlays(agentkitRoot) {
+  const available = listAvailableOverlays(agentkitRoot);
+  return available.length ? available.join(', ') : '(none — is .agentkit/overlays/ present?)';
+}
+
+const FIX_HINTS = [
+  '  How to fix — pick one:',
+  '    retort init                       initialise this repo and write the marker',
+  '    retort sync --overlay <name>      select an overlay for this run only',
+  '    echo "<name>" > .agentkit-repo    pin the overlay for this checkout',
+  '    retort worktree create <path>     create worktrees with the marker already written',
+].join('\n');
+
+/**
+ * Confirm a candidate overlay resolves to a real overlay directory.
+ * Throws rather than letting an unknown name fall through to a silent
+ * base-templates-only render.
+ *
+ * @param {{repoName: string, reason: string}} selection
+ * @param {string} agentkitRoot
+ * @returns {{repoName: string, reason: string}}
+ */
+function assertOverlayExists(selection, agentkitRoot) {
+  const { repoName, reason } = selection;
+
+  if (!isSafeOverlayName(repoName)) {
+    throw new Error(
+      `Invalid overlay name "${repoName}" (from ${reason}).\n` +
+        '  An overlay name must be a single directory name under .agentkit/overlays/,\n' +
+        '  with no path separators or ".." segments.\n' +
+        `  Available overlays: ${formatAvailableOverlays(agentkitRoot)}\n` +
+        FIX_HINTS
+    );
   }
 
-  const markerPath = resolve(projectRoot, '.agentkit-repo');
-  if (existsSync(markerPath)) {
-    return {
-      repoName: readText(markerPath).trim(),
-      reason: '.agentkit-repo marker',
-    };
+  if (!existsSync(resolve(agentkitRoot, 'overlays', repoName, 'settings.yaml'))) {
+    throw new Error(
+      `Overlay "${repoName}" (from ${reason}) does not exist.\n` +
+        `  Expected: ${resolve(agentkitRoot, 'overlays', repoName, 'settings.yaml')}\n` +
+        `  Available overlays: ${formatAvailableOverlays(agentkitRoot)}\n` +
+        FIX_HINTS
+    );
+  }
+
+  return selection;
+}
+
+/**
+ * Decide which overlay this sync renders from — resolve or abort, never guess.
+ *
+ * Resolution order, most explicit first:
+ *   1. `--overlay <name>`
+ *   2. `.agentkit-repo` at the sync root
+ *   3. `.agentkit-repo` in the primary worktree (for linked git worktrees)
+ *   4. an overlay whose name matches the project root directory name
+ *   5. abort
+ *
+ * There is deliberately no `__TEMPLATE__` fallback. That fallback rendered
+ * mass wrong-content output whenever a marker was missing — silently, because
+ * every file still generated successfully — and is the documented root cause of
+ * PRs #478 and #479. `__TEMPLATE__` stays selectable, but only by name.
+ *
+ * See ADR-11 decision 3.
+ *
+ * @param {string} agentkitRoot
+ * @param {string} projectRoot
+ * @param {object} [flags]
+ * @returns {{repoName: string, reason: string}}
+ * @throws {Error} when no overlay can be resolved, or the resolved one is unknown
+ */
+export function resolveOverlaySelection(agentkitRoot, projectRoot, flags) {
+  if (flags?.overlay) {
+    return assertOverlayExists(
+      { repoName: String(flags.overlay).trim(), reason: '--overlay flag' },
+      agentkitRoot
+    );
+  }
+
+  const markerName = readMarkerName(projectRoot);
+  if (markerName) {
+    return assertOverlayExists(
+      { repoName: markerName, reason: '.agentkit-repo marker' },
+      agentkitRoot
+    );
+  }
+
+  const primaryWorktreeRoot = findPrimaryWorktreeRoot(projectRoot);
+  const primaryMarkerName = primaryWorktreeRoot ? readMarkerName(primaryWorktreeRoot) : null;
+  if (primaryMarkerName) {
+    return assertOverlayExists(
+      {
+        repoName: primaryMarkerName,
+        reason: `.agentkit-repo marker in primary worktree (${primaryWorktreeRoot})`,
+      },
+      agentkitRoot
+    );
   }
 
   const inferredOverlay = inferOverlayFromProjectRoot(agentkitRoot, projectRoot);
@@ -66,10 +232,18 @@ export function resolveOverlaySelection(agentkitRoot, projectRoot, flags) {
     };
   }
 
-  return {
-    repoName: '__TEMPLATE__',
-    reason: 'fallback to __TEMPLATE__ (no --overlay, no .agentkit-repo, no inferred overlay)',
-  };
+  const primaryNote = primaryWorktreeRoot
+    ? `  No .agentkit-repo marker in the primary worktree either (${primaryWorktreeRoot}).`
+    : '  Not inside a linked git worktree, so there is no primary worktree to fall back to.';
+
+  throw new Error(
+    'Cannot determine which overlay to render — refusing to guess.\n' +
+      `  No .agentkit-repo marker at ${resolve(projectRoot)}.\n` +
+      `${primaryNote}\n` +
+      `  No overlay is named "${basename(resolve(projectRoot))}" either.\n` +
+      `  Available overlays: ${formatAvailableOverlays(agentkitRoot)}\n` +
+      FIX_HINTS
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/.agentkit/engines/node/src/overlay-resolver.mjs
+++ b/.agentkit/engines/node/src/overlay-resolver.mjs
@@ -197,7 +197,7 @@ function assertOverlayExists(selection, agentkitRoot) {
  * @throws {Error} when no overlay can be resolved, or the resolved one is unknown
  */
 export function resolveOverlaySelection(agentkitRoot, projectRoot, flags) {
-  if (flags?.overlay) {
+  if (flags != null && Object.hasOwn(flags, 'overlay')) {
     return assertOverlayExists(
       { repoName: String(flags.overlay).trim(), reason: '--overlay flag' },
       agentkitRoot

--- a/.agentkit/engines/node/src/worktree.mjs
+++ b/.agentkit/engines/node/src/worktree.mjs
@@ -3,8 +3,10 @@
  * Wraps `git worktree add` and ensures the new worktree directory has an
  * `.agentkit-repo` marker so the sync engine picks the correct overlay.
  *
- * Without the marker, `runSync` falls back to `__TEMPLATE__` (or infers from
- * the directory name), causing an "overlay miss" that generates incorrect output.
+ * Since ADR-11 decision 3 a missing marker no longer silently renders
+ * `__TEMPLATE__` — `runSync` resolves the marker from the primary worktree, and
+ * aborts if that fails too. Writing the marker up front keeps the worktree
+ * self-describing and independent of git layout.
  * See: PRs #478 and #479 (required manual `.agentkit-repo` intervention).
  *
  * Usage:
@@ -136,8 +138,9 @@ export async function runWorktreeCreate({ agentkitRoot, projectRoot, flags }) {
   }
 
   // Write the .agentkit-repo marker — this is the core fix.
-  // Without it the sync engine would fall back to __TEMPLATE__ or infer
-  // incorrectly from the directory name, producing the wrong overlay output.
+  // The sync engine can now recover the overlay from the primary worktree, but
+  // only while this stays a linked worktree of that repo; the marker is what
+  // makes the directory correct on its own.
   writeMarker(worktreePath, repoName);
   console.log(`[retort:worktree] Created .agentkit-repo marker (overlay: "${repoName}")`);
 

--- a/docs/architecture/decisions/11-eliminate-sync-churn.md
+++ b/docs/architecture/decisions/11-eliminate-sync-churn.md
@@ -212,6 +212,15 @@ Two deviations from the text above, both deliberate:
   only ever select an overlay that genuinely exists — so it resolves rather than guesses. It is
   ranked below both marker sources because a marker is a declaration and a directory name is a
   coincidence.
+
+  This turned out to be load-bearing rather than merely conservative. `.agentkit-repo` is
+  **gitignored** (`.gitignore:51`) — deliberately, since the marker is per-checkout — so a CI
+  runner never has one. `ci.yml` runs the drift check as `cli.mjs sync` from a checkout directory
+  named `retort`, and inference against the `retort` overlay is the only thing that resolves it.
+  Removing that step as the decision text literally reads would have aborted the drift check on
+  every run. Anyone tightening this further needs to give CI a marker or an explicit `--overlay`
+  first.
+
 - **The resolved name is now validated**, whatever source produced it. A name that does not
   address `overlays/<name>/settings.yaml` aborts with the same guidance, which also closes a
   typo'd marker silently rendering base templates only, and a marker containing `..` walking out

--- a/docs/architecture/decisions/11-eliminate-sync-churn.md
+++ b/docs/architecture/decisions/11-eliminate-sync-churn.md
@@ -1,6 +1,6 @@
 # ADR-11: Eliminate Generated-File Churn in Sync Output
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-08-06
 **Deciders:** JustAGhosT
 **Related:** PRs #478 / #479 (overlay-miss regressions), issue #420 (EOL normalisation), [worktree-isolation rule](../../../.claude/rules/worktree-isolation.md)
@@ -197,6 +197,38 @@ Replace the silent `__TEMPLATE__` fallback with explicit resolution:
 3. Otherwise **abort with a non-zero exit** naming the missing marker and the available overlays.
 
 `__TEMPLATE__` remains selectable, but only when named explicitly — never as an implicit default.
+
+#### Implemented (2026-08-08)
+
+`resolveOverlaySelection` (`overlay-resolver.mjs`) now resolves in this order and throws when it
+reaches the end: `--overlay` flag → marker at the sync root → marker in the primary worktree →
+overlay matching the project root directory name → abort. The CLI's top-level handler turns the
+throw into exit 1.
+
+Two deviations from the text above, both deliberate:
+
+- **The directory-name inference step was kept**, sitting after the primary-worktree lookup. It
+  was pre-existing behaviour with test coverage, and unlike the `__TEMPLATE__` fallback it can
+  only ever select an overlay that genuinely exists — so it resolves rather than guesses. It is
+  ranked below both marker sources because a marker is a declaration and a directory name is a
+  coincidence.
+- **The resolved name is now validated**, whatever source produced it. A name that does not
+  address `overlays/<name>/settings.yaml` aborts with the same guidance, which also closes a
+  typo'd marker silently rendering base templates only, and a marker containing `..` walking out
+  of the overlays directory.
+
+The abort message names the missing marker, whether a primary worktree was consulted, the
+available overlays, and four ways to fix it (`retort init`, `--overlay`, writing the marker,
+`retort worktree create`).
+
+Test coverage is in `__tests__/overlay-resolver.test.mjs` — 15 cases including two that create a
+real linked git worktree to exercise the `--git-common-dir` path rather than mocking it.
+
+Three existing suites relied on the removed fallback and now name `__TEMPLATE__` explicitly:
+`sync-integration` and `sync-agent-features` sync into randomly-named temp project roots with no
+marker, and one `--no-clean` case built a partial agentkit root that omitted `overlays/`
+entirely. In each case the previous behaviour was `__TEMPLATE__`, so the rendered output is
+unchanged — the tests were depending on the fallback without saying so.
 
 ### Sequencing
 


### PR DESCRIPTION
## Summary

A missing `.agentkit-repo` marker made sync fall back to the `__TEMPLATE__` overlay **silently**, rendering mass wrong-content output that still looked like a successful run. That is the documented root cause of #478 and #479, and it reproduced during the ADR-11 investigation — the marker was absent from both the worktree and the repo root.

This replaces the fallback with resolve-or-abort. It implements [ADR-11](../blob/dev/docs/architecture/decisions/11-eliminate-sync-churn.md) decision 3, the last of that ADR's three, so ADR-11 moves to **Accepted**.

## Motivation

Decisions 1 and 2 (shipped in #571) removed *noisy* output. This one removes *incorrect* output — the only class in ADR-11 that produces wrong files rather than churn.

## What changed

`resolveOverlaySelection` now resolves in order, and throws when it reaches the end:

1. `--overlay <name>`
2. `.agentkit-repo` at the sync root
3. `.agentkit-repo` in the primary worktree, via `git rev-parse --git-common-dir`
4. an overlay whose name matches the project root directory name
5. **abort** — no `__TEMPLATE__` fallback

`__TEMPLATE__` stays selectable, but only by name. The CLI's top-level handler turns the throw into exit 1.

Two things beyond the ADR text, both recorded in the ADR:

- **Directory-name inference was kept**, ranked below both marker sources. It was pre-existing behaviour with test coverage, and unlike the `__TEMPLATE__` fallback it can only ever select an overlay that genuinely exists — it resolves rather than guesses.
- **The resolved name is validated**, whatever source produced it. A name that does not address `overlays/<name>/settings.yaml` aborts with the same guidance. This closes a typo'd marker silently rendering base templates only, and a marker containing `..` walking out of the overlays directory.

The primary-worktree lookup means a worktree made with plain `git worktree add` now recovers the right overlay by itself, instead of needing the manual marker intervention #478 and #479 required.

## Test plan

New `__tests__/overlay-resolver.test.mjs` — 15 cases, all green. Two of them create a **real linked git worktree** rather than mocking `--git-common-dir`.

Verified against this repository:

| Check | Result |
| --- | --- |
| `retort:sync` (marker present) | `Using overlay: retort (.agentkit-repo marker)`, **0 files written**, tree clean — ADR-11's idempotence invariant still holds |
| `retort sync --diff` with the worktree marker removed | `Using overlay: retort (.agentkit-repo marker in primary worktree (C:\Users\smitj\repos\retort))` — the #478/#479 scenario, now self-healing |
| `retort sync --overlay does-not-exist` | Aborts with available overlays + four remedies, **exit 1** |
| `retort:validate` | PASSED (16 pre-existing warnings) |
| `prettier`, `markdownlint` | clean |

Three suites depended on the removed fallback without saying so, and now name `__TEMPLATE__` explicitly — rendered output is unchanged, since `__TEMPLATE__` is exactly what the implicit fallback selected. One of them (`--no-clean preserves orphaned files`) built a partial agentkit root that omitted `overlays/` entirely.

### Known failures, not from this change

`sync-integration` has 2 failures on Windows — `--diff shows create/update/skip without writing` and `--no-clean preserves orphaned files`, both timeouts. I baselined them by stashing this branch and re-running on unmodified code: **same two failures, same durations** (96s baseline vs 98s with the change). Pre-existing, and consistent with the Windows-only flakiness recorded in ADR-12. CI on Linux is the signal here.

## Upgrade note

This converts a currently-silent condition into a hard failure. Repos with worktrees created via `git worktree add` rather than `retort worktree create` will now either resolve from the primary worktree (the common case, and a fix) or fail with actionable guidance — where before they silently generated `__TEMPLATE__` content. ADR-11 called for release-note coverage of exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay selection during synchronization by validating explicit, marker-based, and inferred overlay names.
  * Sync now reports actionable errors when no valid overlay can be resolved instead of silently using a default.
  * Added support for resolving overlays from the primary worktree in linked worktree setups.
  * Preserved explicit selection of the `__TEMPLATE__` overlay for applicable workflows.

* **Documentation**
  * Updated synchronization behavior and overlay-resolution guidance, including failure handling and resolution order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->