### PR TITLE
fix(discover): pin commit-convention detection to the project repo

### DIFF
--- a/.agentkit/engines/node/src/__tests__/discover.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/discover.test.mjs
@@ -427,6 +427,39 @@ describe('detectCommitConvention() — git-log heuristic', () => {
   });
 
   it(
+    'reads the project repo, not one named by an ambient GIT_DIR',
+    { timeout: 15_000 },
+    async () => {
+      initGitRepo(tmpDir, [
+        'Updated the readme',
+        'Fixed some stuff',
+        'WIP',
+        'Cleaned up code',
+        'Initial commit',
+      ]);
+
+      const otherRepo = makeTmpDir();
+      initGitRepo(otherRepo, [
+        'feat(auth): add login flow',
+        'fix(api): handle null response',
+        'docs: update readme',
+        'chore(deps): bump vitest',
+      ]);
+
+      const originalGitDir = process.env.GIT_DIR;
+      process.env.GIT_DIR = join(otherRepo, '.git');
+      try {
+        // The project's own history is not conventional; the decoy's is.
+        expect(await detectCommitConvention(tmpDir)).toBeNull();
+      } finally {
+        if (originalGitDir === undefined) delete process.env.GIT_DIR;
+        else process.env.GIT_DIR = originalGitDir;
+        rmSync(otherRepo, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it(
     'file-based detection takes priority over git-log heuristic',
     { timeout: 15_000 },
     async () => {

--- a/.agentkit/engines/node/src/discover.mjs
+++ b/.agentkit/engines/node/src/discover.mjs
@@ -838,8 +838,16 @@ export async function detectCommitConvention(projectRoot, { currentConvention } 
     const { execFile } = await import('node:child_process');
     const { promisify } = await import('node:util');
     const execFileAsync = promisify(execFile);
+    // `cwd` alone does not pin git to projectRoot: these variables override it,
+    // and git exports them to hooks. Inheriting them would inspect the invoking
+    // repository instead of the project being discovered.
+    const env = { ...process.env };
+    for (const name of ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_OBJECT_DIRECTORY']) {
+      delete env[name];
+    }
     const { stdout } = await execFileAsync('git', ['log', '--pretty=format:%s', '-20'], {
       cwd: projectRoot,
+      env,
     });
     const subjects = stdout
       .split('\n')

--- a/docs/architecture/decisions/12-test-suite-reliability.md
+++ b/docs/architecture/decisions/12-test-suite-reliability.md
@@ -265,6 +265,13 @@ escaped double quotes (any subject containing a backslash would have been mangle
 identity via `git -c` removes the dependency on ambient user config — a machine with
 `commit.gpgsign` enabled previously failed here.
 
+The fixture-cost correction does not remove a separate product boundary defect found afterward:
+`detectCommitConvention()` passed only `cwd` to `git log`, but inherited `GIT_DIR`,
+`GIT_WORK_TREE`, `GIT_INDEX_FILE`, or `GIT_OBJECT_DIRECTORY` still override that directory.
+Detection now removes those inherited overrides for the subprocess. A two-repository regression
+fixture points `GIT_DIR` at a conventional decoy and confirms that discovery still reports the
+non-conventional project repository.
+
 ### Decision 6 — raise sync-heavy timeouts (partly done, and re-scoped)
 
 `hookTimeout` was already raised to 240s in #570, so the `beforeAll` half of this was addressed


### PR DESCRIPTION
## Summary

`detectCommitConvention` passed `cwd: projectRoot` to `git log` and nothing else. **`cwd` does not pin git to a repository** — `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` and `GIT_OBJECT_DIRECTORY` all override it, and git exports them to every hook it runs. Detection invoked from a hook, or from any wrapper that sets them, reported some other repository's convention as the project's.

Implements [ADR-12](../blob/dev/docs/architecture/decisions/12-test-suite-reliability.md) decision 4.

## The ADR's premise was half right

Decision 4 says the `detectCommitConvention()` tests "read ambient repository history … they must construct a fixture repository". They already did — `initGitRepo` has been there all along. The half that was true is that everything *around* the fixture was ambient, and the two symptoms had separate causes.

### Correctness — the bug was in the product, not the tests

The four `GIT_*` variables are now stripped from the environment for that call.

Covered by a test that builds two repositories — a project with non-conventional history and a decoy with conventional history — points `GIT_DIR` at the decoy, and asserts detection still reflects the project. I verified it fails with the product fix reverted (`"conventional"` instead of `null`), so it is load-bearing rather than decorative.

### Hermetic fixture

- `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` point at a path that does not exist, so a developer's global `commit.gpgsign`, `core.hooksPath` or `commit.template` cannot make fixture commits sign, hang, or run this repo's hooks.
- Identity moves to `GIT_AUTHOR_*`/`GIT_COMMITTER_*`, removing two `git config` subprocesses per fixture.
- `execSync` with an interpolated string → `execFileSync` with an argument array. No shell, so subjects containing `(`, `)` and `!` need no escaping.

### Reliability — the fixture was expensive

Each commit cost three subprocesses (`writeFileSync`, `git add`, `git commit`). The heuristic reads `%s` and nothing else, so the trees were dead weight: commits are now `--allow-empty --no-verify`. An eight-commit fixture went from **27 subprocesses to 9**.

## Test plan

Same product code, old fixture vs new:

| Fixture | Duration | Result |
| --- | --- | --- |
| Old, run 1 | 117s | 2 failing |
| Old, run 2 | 151s | 4 failing |
| New | 30s / 34s | **26 passing** |

Every failure under the old fixture was `Test timed out in 15000ms`, and in the four-failure run they were **exactly the four multi-commit git-log heuristic tests** — the ones building the largest fixtures. Nothing else in the file failed. That is the "pass in isolation, fail under load" behaviour decision 4 was written about, and it points at fixture cost rather than the assertions.

The old fixture's own spread (2 vs 4 failures, 117s vs 151s across two runs of identical code) is a reminder of ADR-12's standing caveat about wall-time on this machine — treat the ~4× as directional. The subprocess count is the reliable figure; the timeouts disappearing is the outcome that matters.

`prettier` and `markdownlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
