### PR TITLE
fix(test): stop check-coverage spawning a real formatter, correct ADR-12 evidence

### DIFF
--- a/.agentkit/engines/node/src/__tests__/check-coverage.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/check-coverage.test.mjs
@@ -916,6 +916,16 @@ describe('runCheck — advanced flag paths', () => {
       expect(result.stacks[0].steps.map((s) => s.step)).toEqual(
         expect.arrayContaining(['format', 'test'])
       );
+
+      // The name of this test promises an ordering, which the assertion above
+      // does not check — it passes whenever both steps merely exist. Now that
+      // the runner is stubbed its call log is available, so assert the ordering
+      // directly: resolveFormatter maps black to fix `black .` and check
+      // `black --check .`, and check.mjs runs the fix first when --fix is set.
+      const commands = vi.mocked(execCommand).mock.calls.map(([command]) => command);
+      expect(commands).toContain('black .');
+      expect(commands).toContain('black --check .');
+      expect(commands.indexOf('black .')).toBeLessThan(commands.indexOf('black --check .'));
     } finally {
       cleanupFixture(fx.root);
     }

--- a/.agentkit/engines/node/src/__tests__/check-coverage.test.mjs
+++ b/.agentkit/engines/node/src/__tests__/check-coverage.test.mjs
@@ -18,6 +18,11 @@ vi.mock('../runner.mjs', async () => {
   return {
     ...actual,
     commandExists: vi.fn(() => true),
+    // Wrapped rather than replaced: almost every test here wants the real
+    // implementation, but a test that forces commandExists to true needs to be
+    // able to stub this, or the step it is exercising spawns whatever binary
+    // the stack names. beforeEach restores the real implementation.
+    execCommand: vi.fn(actual.execCommand),
   };
 });
 
@@ -30,7 +35,8 @@ vi.mock('../agent-integration.mjs', async () => {
   };
 });
 
-const { commandExists } = await import('../runner.mjs');
+const { commandExists, execCommand } = await import('../runner.mjs');
+const actualRunner = await vi.importActual('../runner.mjs');
 const { resolveCoverageCommand, parseCoveragePercentage } =
   await import('../agent-integration.mjs');
 const {
@@ -61,6 +67,7 @@ function cleanupFixture(root) {
 
 beforeEach(() => {
   vi.mocked(commandExists).mockReset().mockReturnValue(true);
+  vi.mocked(execCommand).mockReset().mockImplementation(actualRunner.execCommand);
   vi.mocked(resolveCoverageCommand)
     .mockReset()
     .mockReturnValue({ command: null, parser: 'unknown' });
@@ -874,6 +881,22 @@ describe('runCheck — advanced flag paths', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     vi.mocked(commandExists).mockReturnValue(true);
+
+    // The assertion below is about which steps get built, not about formatting
+    // anything, so nothing here needs a real process. Stubbing the runner is
+    // what keeps that true: `black` is a real binary, and mocking commandExists
+    // to true removes the skip-not-found guard that would otherwise stop it
+    // being spawned. On a machine with black installed, the step therefore ran
+    // `black .` and `black --check .` for real — two Python interpreter
+    // startups against this test's 20s budget, which is why it failed under
+    // full-suite load while passing in isolation. execCommand's own default
+    // timeout is 300s, so it could never have rescued the shorter test budget.
+    vi.mocked(execCommand).mockReturnValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      durationMs: 0,
+    });
 
     const fx = makeFixture();
     try {

--- a/docs/architecture/decisions/12-test-suite-reliability.md
+++ b/docs/architecture/decisions/12-test-suite-reliability.md
@@ -320,3 +320,104 @@ All three Windows runs exited zero with the same pass set and no fixture-cleanup
 closes the PR #584 repeatability gate on the environment that exposed the defect; it does not
 claim that every remaining Windows-only contention source in the wider suite has been
 eliminated.
+
+### The criterion does not hold on merged `dev`
+
+Re-running the gate on 2026-08-09 against `dev` at `6848f3f7` — that is, after #584 merged and
+after #583, #585 and #581 landed on top of it — **all three runs failed**, with a different
+failure set each time:
+
+| Run | Exit | Files failed | Tests failed | Note                       |
+| --- | ---- | ------------ | ------------ | -------------------------- |
+| 1   | 1    | 6            | 10           | plus one worker-fork crash |
+| 2   | 1    | 2            | 2            |                            |
+| 3   | 1    | 1            | 1            |                            |
+
+The moving failure set is the exact condition this ADR opens by describing, so the problem
+statement stands rather than being closed.
+
+Two measurement notes matter more than the numbers, because both produce false green:
+
+**Exit codes must not be read through a pipe.** An earlier attempt at this gate ran
+`vitest | perl | grep` and captured `$?`, which is _grep's_ status. Grep matched on every run, so
+it reported success every time regardless of what Vitest did. The runs above capture Vitest's
+status directly. Any future evidence added to this ADR must do the same — the pass/fail counts
+in Vitest's own summary are trustworthy, a piped exit code is not.
+
+This applies retroactively to the preceding section: its "all three runs exited zero" was
+produced before the flaw was found and cannot now be re-verified, so read that block as
+counts-only evidence. The counts themselves come from Vitest's summary and stand.
+
+**A crashed worker still prints a passing summary.** One run logged
+`Error: Worker exited unexpectedly`, silently dropped 53 tests and a whole file — `2273 passed`
+against a `2327` total — and summarised as passing. Vitest's own warning for this is that it
+"might cause false positive tests". Treat any run whose passed + skipped does not reconcile with
+the total as void, whatever the summary says. This is what decision 5 (make flakes visible) is
+for, and it is not yet implemented.
+
+### Headroom: the suite needs ~27 GB of free disk
+
+Re-running the gate surfaced the quantity that made the original ENOSPC inevitable, which none
+of the decisions above had put a number to. Sampling free space every 30s through a full run
+shows it dropping ~27 GB below idle and then holding flat for the rest of the run: fixture trees
+are created and reclaimed continuously, so the figure is a **steady-state working set**, not a
+slow climb.
+
+That reframes the failure this ADR opens with. The attempt that produced it began with 17.4 GB
+free, so it could not have finished regardless of any timeout budget — every test file failed to
+_load_, which reads as catastrophic breakage rather than as a full disk. A run starting below
+roughly 30 GB free should be treated as unable to produce a valid result, and a suite-wide
+failure with no meaningful assertion output should prompt a `df` before any code is suspected.
+
+The cleanup fix is what holds that working set flat. Across three consecutive full suites, free
+space moved 17,780 MB → 17,731 MB — a 49 MB net change, with leaked fixture directories going
+41 → 36 rather than climbing. Before the fix, 126 stranded trees of 600+ files each had
+accumulated.
+
+### Headroom: the page file is the second capacity limit
+
+Verifying an unrelated fix produced `ERR_DLOPEN_FAILED` loading Rollup's native module, caused by
+`The paging file is too small for this operation to complete` — not by the change under test.
+
+The host has 32 GB of RAM and a **fixed 8 GB page file**. A full run forks a worker per test file,
+and committed memory across that fleet can exceed physical plus page file even while plenty of
+physical RAM appears free. When it does, forks die — which is the most likely mechanism behind
+the `Worker exited unexpectedly` crash recorded above, and behind run 1's six-file failure set.
+
+This matters because it is invisible in the symptom. A dead fork surfaces as unrelated tests
+failing in varying combinations, which reads as flaky application code. Before attributing a
+moving failure set to the suite, confirm the run was not memory-starved: `Win32_PageFileUsage`
+reports allocated size and peak usage, and a peak far below the allocation (160 MB against 8 GB
+here) means the ceiling being hit is the commit limit, not the page file's working size.
+
+Neither capacity limit is a code defect, and neither is fixed by a timeout budget. Both belong in
+whatever runbook precedes the next attempt at the acceptance criterion.
+
+### A real defect: mocking `commandExists` can start spawning real binaries
+
+`check-coverage.test.mjs > runs --fix command before the check command` failed in two of the
+three `dev` runs and passed in isolation (58/58 in 5.9s), which is the signature of contention
+rather than a logic error. The mechanism generalises decision 4 from ambient _git history_ to
+ambient _binaries_.
+
+The file's mock factory spreads `...actual` and replaces only `commandExists`, so `execCommand`
+stays real. The test then sets `formatter: "black"` and forces `commandExists` to true — and that
+second step is what does the damage, because the guard it removes is precisely the one that stops
+an absent binary being spawned. The test's own comment notes the guard is bypassed but reads it as
+harmless.
+
+It is harmless only where `black` is missing. On a machine that has it — this host does, via
+Python 3.13 — `black .` and `black --check .` genuinely execute: two Python interpreter startups
+against a 20s test budget. `execCommand`'s default timeout is 300s, 15× the test's, so the inner
+budget can never rescue the outer one. The test is therefore _fast on CI and slow on developer
+machines_, which is the opposite of the usual assumption and explains why it had not been
+attributed before.
+
+Fixed by stubbing `execCommand` for that test alone: it asserts which steps get built, not that
+formatting happens, so no real process is needed. The mock is wrapped
+(`vi.fn(actual.execCommand)`) rather than replaced, and `beforeEach` restores the real
+implementation, so the file's other tests are unaffected. Test-phase time for the file fell from
+4.83s to 2.04s.
+
+The general rule: forcing `commandExists` true removes a guard, and every step behind that guard
+must then be checked for whether it spawns something real.


### PR DESCRIPTION
## Summary

Fixes one real test defect and corrects ADR-12's acceptance evidence, which claimed more than the measurements supported.

## The defect

`check-coverage.test.mjs > runs --fix command before the check command` failed in 2 of 3 full-suite runs and passed in isolation (58/58 in 5.9s) — the signature of contention, not logic.

The file's mock factory spreads `...actual` and replaces only `commandExists`, so `execCommand` stays real. Forcing `commandExists` true then removes precisely the guard that stops an absent binary being spawned. Where `black` is installed — as it is on the host that reproduced this — the step really ran `black .` and `black --check .`: two Python interpreter startups against a 20s test budget. `execCommand`'s own default timeout is 300s, 15x the test's, so the inner budget could never rescue the outer one.

The consequence is inverted from the usual assumption: **fast on CI, slow on developer machines**, which is why it had not been attributed before.

The assertion is about which steps get built, not about formatting anything, so `execCommand` is stubbed for that test alone. The mock wraps the real implementation (`vi.fn(actual.execCommand)`) and `beforeEach` restores it, so the file's other tests are untouched.

This generalises ADR-12 decision 4 from ambient *git history* to ambient *binaries*.

## The acceptance criterion does not hold on `dev`

Re-run at `6848f3f7` (after #584 merged and #583/#585/#581 landed). All three runs failed, with a different failure set each time:

| Run | Exit | Files failed | Tests failed | Note |
| --- | ---- | ------------ | ------------ | ---- |
| 1 | 1 | 6 | 10 | plus one worker-fork crash |
| 2 | 1 | 2 | 2 | |
| 3 | 1 | 1 | 1 | |

The moving failure set is the condition ADR-12 opens by describing, so the problem statement stands rather than being closed.

## Two ways the suite reports false green

Both are recorded in the ADR so they are not repeated:

- **Piped exit codes measure the wrong process.** An earlier gate ran `vitest | perl | grep` and captured `$?` — grep's status, which matched every time. It reported success regardless of what Vitest did. This applies retroactively to the previous acceptance block, now marked counts-only.
- **A crashed worker still prints a passing summary.** One run logged `Worker exited unexpectedly`, silently dropped 53 tests and a whole file (`2273 passed` against a `2327` total), and summarised as passing. Any run whose passed + skipped does not reconcile with the total should be treated as void.

## Two host capacity limits that look like flaky code

- **~27 GB steady-state disk working set.** Sampling through a run shows free space dropping ~27 GB below idle then holding flat. The ENOSPC that opened this investigation began with 17.4 GB free, so it could not have finished under any timeout budget.
- **Fixed 8 GB page file on 32 GB RAM.** Verifying an unrelated change produced `ERR_DLOPEN_FAILED` caused by `The paging file is too small for this operation to complete`. Peak page-file usage of 160 MB against an 8 GB allocation means the ceiling being hit is the commit limit — the likeliest mechanism behind the worker crash and run 1's six-file failure set.

Neither is a code defect, and neither is fixed by a timeout budget.

## Test plan

- `check-coverage.test.mjs` in isolation: **exit 0, 58/58 passed**, test-phase time 4.83s -> 2.04s
- `prettier --check` clean on both changed files
- Exit codes captured directly from Vitest, not through a pipe

## Not claimed

This does not make the suite green. The other failures observed across the three runs (`sync-guard`, `cli`, `discover`, `check`, `sync-integration --overwrite`, `sync-agent-features`) are untouched, and ADR-12 decision 5 — make flakes visible — remains unimplemented; it is what would have caught the silent worker crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by preventing unintended formatter processes from running during checks.
  * Reduced false-positive test results caused by worker crashes and environmental resource limits.

* **Documentation**
  * Documented test-suite repeatability findings, environment constraints, and the corrective mocking approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->