### PR TITLE
docs(history): fill in the unresolved PR links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Activate the commit template: `git config commit.template .gitmessage`
 - Hook-based safety guardrails
 - Automated quality gates and validation
 - Hook wiring generated from spec ([#575](../../pull/575), [history](docs/history/implementations/0010-2026-08-07-hook-wiring-generated-from-spec-implementation.md))
-- Hook spec validation and windowsFirst emit filter ([history](docs/history/features/0001-2026-08-08-hook-spec-validation-and-windowsfirst-emit-filter-feature.md))
+- Hook spec validation and windowsFirst emit filter ([#582](../../pull/582), [history](docs/history/features/0001-2026-08-08-hook-spec-validation-and-windowsfirst-emit-filter-feature.md))
 
 ### Changed
 

--- a/docs/history/.index.json
+++ b/docs/history/.index.json
@@ -61,7 +61,7 @@
       "type": "feature",
       "title": "Hook spec validation and windowsFirst emit filter",
       "date": "2026-08-08",
-      "pr": "",
+      "pr": "582",
       "file": "features/0001-2026-08-08-hook-spec-validation-and-windowsfirst-emit-filter-feature.md"
     },
     {

--- a/docs/history/bug-fixes/0008-2026-08-10-windows-test-flakiness-from-subprocess-startup-cost-bugfix.md
+++ b/docs/history/bug-fixes/0008-2026-08-10-windows-test-flakiness-from-subprocess-startup-cost-bugfix.md
@@ -2,7 +2,7 @@
 
 **Completed**: 2026-08-10
 **Bug ID**: [ADR-12](../../architecture/decisions/12-test-suite-reliability.md)
-**PR**: [#PR-Number]
+**PR**: [#591](https://github.com/phoenixvc/retort/pull/591)
 **Severity**: Medium (developer experience; CI was never affected)
 
 ## Problem Description

--- a/docs/history/features/0001-2026-08-08-hook-spec-validation-and-windowsfirst-emit-filter-feature.md
+++ b/docs/history/features/0001-2026-08-08-hook-spec-validation-and-windowsfirst-emit-filter-feature.md
@@ -1,7 +1,7 @@
 # Hook spec validation and windowsFirst emit filter - Historical Summary
 
 **Launched**: 2026-08-08
-**PR**: [#PR-Number]
+**PR**: [#582](https://github.com/phoenixvc/retort/pull/582)
 **Feature Type**: Enhancement (validation hardening + one new setting)
 
 ## Feature Overview


### PR DESCRIPTION
## Summary

Two history docs still carried the literal `[#PR-Number]` placeholder that `create-doc.sh` emits, against the resolved form their siblings (0005/0006/0007) use.

| Doc | Now links |
| --- | --- |
| `bug-fixes/0008-…-bugfix.md` | [#591](https://github.com/phoenixvc/retort/pull/591) |
| `features/0001-…-feature.md` | [#582](https://github.com/phoenixvc/retort/pull/582) |

Both numbers were verified against the merged PR titles rather than inferred — #591 is *fix(test): remove subprocess spawns causing Windows suite flakiness*, and #582 is *feat(claude-hooks): validate the hooks spec and make windowsFirst an emit filter*, matching the feature doc's title exactly.

Also fills the matching `pr` fields in `.index.json` and `CHANGELOG.md`, which were empty for the feature entry.

## Deliberately left alone

- `bug-fixes/0001` (Infra-Eval Review Fixes, 2026-03-04) has no PR recorded anywhere and predates the convention. Guessing one would be worse than leaving it blank.
- The `[#PR-Number]` occurrence in `bug-fixes/0003` is prose *about* the placeholder, not an unfilled field.

## Test plan

Docs only — no code paths touched.

- `prettier --check` clean on all four changed files
- `.index.json` re-parsed after edit; the only remaining entry without a `pr` is `bug-fixes/0001` above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected release history references for hook specification validation and Windows event filtering.
  * Added the associated pull request reference to the changelog.
  * Updated the historical bug-fix entry with its correct pull request reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->