### PR TITLE
docs(handoffs): record the 2026-08-11 vacuous-assertion sweep session

### DIFF
--- a/docs/handoffs/2026-08-11.md
+++ b/docs/handoffs/2026-08-11.md
@@ -1,0 +1,90 @@
+# Session Handoff
+
+**Date:** 2026-08-11
+**Branch:** `test/vacuous-assertion-sweep` (worktree `.claude/worktrees/pensive-leavitt-9f35ae`) — merged and removable
+**Base:** b5f94d0c — docs(history): fill in the unresolved PR links (#593)
+**Session Scope:** Sweep the engine test suite for tests that pass without executing the code they name
+**Overall Status:** [PR #594](https://github.com/phoenixvc/retort/pull/594) **merged** as `5fe767ca` on `dev`
+
+## What Was Done
+
+Systematic sweep for the defect class found three times by hand in #590/#591: a
+test whose sole assertion also holds when the subject does nothing.
+
+Six instances confirmed and fixed. Full detail in
+`docs/history/bug-fixes/0009-2026-08-11-tests-passing-without-executing-their-subject-bugfix.md`.
+
+| Outcome                                               | Count |
+| ----------------------------------------------------- | ----- |
+| Test cases containing a weak matcher                  | 155   |
+| Shortlist — no strong assertion at all                | 44    |
+| Confirmed and fixed                                   | 6     |
+| Cleared by mutation (mutant killed)                   | 3     |
+| Cleared by inspection (weak assertion _is_ the claim) | 35    |
+
+Four were genuine coverage holes — the mutant survived the **entire test file**:
+
+- `tracker-adapter` — both adapters expose `fetchIssues`, so swapping
+  `GitHubAdapter` for `LinearAdapter` kept the file green.
+- `agent-analysis` — `findConsolidationOpps` could `return []` unconditionally.
+- `template-utils` — `categorizeFile` could return one constant for every path;
+  the whole 17-branch mapping table was unverified.
+- `spec-accessor` — the fixture it called "a valid spec" was missing
+  `aliases.yaml` and `docs.yaml`, so `validate()` always returned two errors.
+
+## Method — Reusable
+
+Grep only shortlists. **Mutation decides**: break the thing the test claims to
+exercise, run the test, confirm it goes red. Green means the test never reached
+its subject.
+
+Two controls that mattered:
+
+1. **Run a control mutation first** — one that must be killed. Without it, a
+   harness that silently runs nothing reports every test as vacuous.
+2. **Re-run each survivor against its whole file.** Test-level survival means the
+   named test is weak; file-level survival means nothing tests the behaviour at
+   all. Only the second is a coverage hole.
+
+**Trap found during self-review:** `vitest -t` is a **regex**, not a substring
+match. Titles containing literal parentheses matched zero tests, and vitest exited
+0 — which the harness read as "survived". Three candidates were affected; all three
+had already been decided by unfiltered whole-file runs, so no verdict changed. Any
+future sweep using `-t` must escape the pattern or assert that the expected number
+of tests actually ran.
+
+The mutation harness was scratch tooling and was **not committed**. It is ~60 lines:
+apply a find/replace to a source file, run vitest, restore the file in a `finally`.
+Rebuilding it is cheaper than maintaining it, but if it recurs it is worth landing
+under `.agentkit/scripts/`.
+
+## Open Follow-Up
+
+**Baton `9be88861-f4c8-4d0b-bfd6-32631c5e3dbd`** — adopt Stryker incrementally.
+Costed with a real scoped run this session:
+
+- `@stryker-mutator/vitest-runner@9.6.1` peers `vitest >=2.0.0` — compatible with
+  the repo's Vitest 4.1.0. No version blocker.
+- Measured density **157 mutants from 192 LOC (0.82/LOC)** → roughly **22,500
+  mutants** across the 27.4k-LOC engine. Dry run executes the full suite (~135s)
+  first. A full-engine run is not viable as a blocking gate on this hardware.
+- **Blocker:** the dry run fails inside Stryker's sandbox.
+  `sync-agent-features.test.mjs:337` asserts `<repo>/docs/orchestration/concurrency-protocol.md`
+  exists, and `docs/` lives outside `.agentkit`, so the sandbox never copies it.
+  This is a sandboxing gap, not a test defect — **it will affect any sandboxed or
+  containerised runner, not only Stryker.** Worth knowing independently of whether
+  Stryker is ever adopted.
+
+Recommended path: fix the sandbox blocker, then run Stryker `--incremental` scoped
+to PR-changed files, advisory (non-blocking) at first.
+
+## Notes for the Next Session
+
+- Engine test suite baseline on this Windows host: **~135–142s**, green. If it
+  drifts well past that, suspect subprocess spawns rather than logic.
+- `prettier` is not installed at the repo root — run it from `.agentkit`
+  (`cd .agentkit && npx prettier --check ../path/to/file`). Prettier is a required
+  status check, so this bites on markdown edits.
+- Local `dev` ref in a fresh worktree can be stale; `git diff dev...HEAD` will show
+  commits that are already on `origin/dev`. Trust `gh pr view --json files` over the
+  local diff when sanity-checking PR scope.


### PR DESCRIPTION
Session handoff for the sweep merged in #594 (`5fe767ca`).

Captures three things worth surviving the session:

- **The reusable method** — grep shortlists, mutation decides; run a control mutation first; re-check survivors at file level to separate a real coverage hole from a weak-but-covered test.
- **A trap found during self-review** — `vitest -t` is a regex, not a substring match. Titles with literal parentheses matched zero tests and vitest exited 0, which a mutation harness reads as "survived". Three candidates were affected; all three had already been decided by unfiltered whole-file runs, so no verdict changed.
- **The open Stryker follow-up** (baton `9be88861`), including the sandbox blocker: `sync-agent-features.test.mjs:337` asserts a file under `docs/`, which lives outside `.agentkit` and so is never copied into a sandbox. That affects any sandboxed or containerised runner, not just Stryker — worth knowing regardless of whether Stryker is adopted.

Docs only, no code changes.

Test plan: n/a — markdown only; Prettier verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)