### PR TITLE
chore(repo): ignore .serena local tool metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ Thumbs.db
 *~
 .idea/
 *.iml
+.serena/
 
 # =============================================================================
 # Runtime state (generated at runtime, not by sync)

--- a/.prettierignore
+++ b/.prettierignore
@@ -61,3 +61,6 @@ COMMAND_GUIDE.md
 
 # Immutable canonical contract snapshots retain org-meta byte formatting
 .agentkit/contracts/*.schema.json
+
+# Local assistant/tool metadata
+.serena/**


### PR DESCRIPTION
Adds `.serena/` to `.gitignore` and `.serena/**` to `.prettierignore`.

The Serena MCP server writes project metadata into `.serena/`. It is local tool state, not source: without these entries it shows up as untracked in every `git status` and gets picked up by Prettier, which is now a required status check (#592).

Confirmed not already present on `dev` — the recent ignore-file changes there added `test-results/` and `.agentkit/contracts/*.schema.json`, neither of which covers this.

4 lines, no code changes.

Test plan: n/a — ignore files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded local assistant and tool metadata from version control and formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->