### PR TITLE
fix(engine): resolve Codex review findings from the release PRs

### DIFF
--- a/.agentkit/engines/node/src/platform-syncer.mjs
+++ b/.agentkit/engines/node/src/platform-syncer.mjs
@@ -478,15 +478,35 @@ export async function syncEditorTheme(
   for (const [tool, outputPath] of Object.entries(outputs)) {
     if (!outputPath) continue; // null = skip this target
 
+    // Path traversal protection — resolve and verify the output stays inside tmpDir.
+    // This runs BEFORE the scaffold-once carry-forward below, which also resolves a
+    // destination and writes to it. Guarding only the render path left that branch
+    // able to read a tracked project file and write it outside tmpDir.
+    const normalizedPath = String(outputPath).replace(/^\/+/, ''); // strip leading slashes
+    const settingsPath = resolve(tmpDir, normalizedPath);
+    if (!settingsPath.startsWith(resolvedTmpDir + sep) && settingsPath !== resolvedTmpDir) {
+      log(`[retort:sync] BLOCKED: editor theme output path traversal detected — ${outputPath}`);
+      continue;
+    }
+
     // Scaffold-once: target already exists in projectRoot (unless --overwrite/--force).
     // Copy the existing content into tmpDir so it appears in the new manifest and
     // survives orphan cleanup. Without this carry-forward, the second sync run
     // sees the file in previousManifest, never in newManifestFiles, and deletes it.
     if (skipOutputs && skipOutputs.has(outputPath)) {
-      const normalizedRel = String(outputPath).replace(/^\/+/, '');
       if (projectRoot) {
-        const existingPath = resolve(projectRoot, normalizedRel);
-        const destFile = resolve(tmpDir, normalizedRel);
+        const resolvedProjectRoot = resolve(projectRoot);
+        const existingPath = resolve(projectRoot, normalizedPath);
+        // The source side needs the same containment check: without it a crafted
+        // path reads a file from outside projectRoot.
+        if (
+          !existingPath.startsWith(resolvedProjectRoot + sep) &&
+          existingPath !== resolvedProjectRoot
+        ) {
+          log(`[retort:sync] BLOCKED: editor theme source path traversal detected — ${outputPath}`);
+          continue;
+        }
+        const destFile = settingsPath;
         if (existsSync(existingPath)) {
           writePromises.push(
             (async () => {
@@ -507,14 +527,6 @@ export async function syncEditorTheme(
         // projectRoot to opt into the fix.
         log(`[retort:sync] Editor theme: ${outputPath} exists (scaffold-once) — skipping`);
       }
-      continue;
-    }
-
-    // Path traversal protection — resolve and verify the output stays inside tmpDir
-    const normalizedPath = String(outputPath).replace(/^\/+/, ''); // strip leading slashes
-    const settingsPath = resolve(tmpDir, normalizedPath);
-    if (!settingsPath.startsWith(resolvedTmpDir + sep) && settingsPath !== resolvedTmpDir) {
-      log(`[retort:sync] BLOCKED: editor theme output path traversal detected — ${outputPath}`);
       continue;
     }
 

--- a/.agentkit/engines/node/src/scaffold-engine.mjs
+++ b/.agentkit/engines/node/src/scaffold-engine.mjs
@@ -565,7 +565,14 @@ export async function writeGeneratedManifest({ agentkitRoot, version, overlay })
     if (existsSync(dest) && (await readFile(dest, 'utf-8')) === content) return false;
     await writeFile(dest, content, 'utf-8');
     return true;
-  } catch {
+  } catch (err) {
+    // GENERATED.json is the sole version/spec provenance record. Swallowing a
+    // write failure here let the generated tree be updated while provenance went
+    // stale, and runSync reported success regardless. Surface it instead.
+    console.warn(
+      `[retort:sync] WARNING: could not write provenance manifest ${dest}: ${err?.message ?? err}\n` +
+        '  The generated output may not match the recorded version/spec hash.'
+    );
     return false;
   }
 }

--- a/.agentkit/engines/node/src/synchronize.mjs
+++ b/.agentkit/engines/node/src/synchronize.mjs
@@ -26,7 +26,7 @@ import {
   loadFeatureSpec,
   resolveFeatures,
 } from './feature-manager.mjs';
-import { ensureDir, runConcurrent, walkDir, writeOutput } from './fs-utils.mjs';
+import { applyUtf8Bom, ensureDir, runConcurrent, walkDir, writeOutput } from './fs-utils.mjs';
 import {
   cleanStaleFiles,
   clearTemplateMeta,
@@ -1100,6 +1100,12 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
           if (err?.code === 'ENOENT') continue;
           throw err;
         }
+        // Match what the writer actually puts on disk. writeScaffoldOutputs runs
+        // content through applyUtf8Bom, so after one sync the generated .ps1 files
+        // carry a BOM while their temp-tree counterparts do not. Comparing raw made
+        // every PowerShell hook look updated: `sync --diff` reported changes a real
+        // sync then skipped, and interactive sync prompted for them.
+        newContent = applyUtf8Bom(destFile, newContent);
         if (!existsSync(destFile)) {
           createCount++;
           log(`  create ${normPath}`);
@@ -1166,6 +1172,12 @@ export async function runSync({ agentkitRoot, projectRoot, flags }) {
           if (err?.code === 'ENOENT') continue;
           throw err;
         }
+        // Match what the writer actually puts on disk. writeScaffoldOutputs runs
+        // content through applyUtf8Bom, so after one sync the generated .ps1 files
+        // carry a BOM while their temp-tree counterparts do not. Comparing raw made
+        // every PowerShell hook look updated: `sync --diff` reported changes a real
+        // sync then skipped, and interactive sync prompted for them.
+        newContent = applyUtf8Bom(destFile, newContent);
 
         if (!existsSync(destFile)) {
           changeList.push({ relPath: normPath, action: 'create', newContent });

--- a/.agentkit/package.json
+++ b/.agentkit/package.json
@@ -55,9 +55,9 @@
     "coverage": "vitest run --coverage"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "4.1.0",
     "markdownlint-cli2": "^0.18.1",
     "prettier": "^3.5.3",
-    "vitest": "^4.1.0"
+    "vitest": "4.1.0"
   }
 }

--- a/.agentkit/pnpm-lock.yaml
+++ b/.agentkit/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         version: 4.2.0
     devDependencies:
       '@vitest/coverage-v8':
-        specifier: ^4.0.18
-        version: 4.1.2(vitest@4.1.0(vite@7.3.1))
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0(vite@7.3.1))
       markdownlint-cli2:
         specifier: ^0.18.1
         version: 0.18.1
@@ -31,7 +31,7 @@ importers:
         specifier: ^3.5.3
         version: 3.8.1
       vitest:
-        specifier: ^4.1.0
+        specifier: 4.1.0
         version: 4.1.0(vite@7.3.1)
 
 packages:
@@ -407,11 +407,11 @@ packages:
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  '@vitest/coverage-v8@4.1.2':
-    resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
+  '@vitest/coverage-v8@4.1.0':
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
     peerDependencies:
-      '@vitest/browser': 4.1.2
-      vitest: 4.1.2
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -433,9 +433,6 @@ packages:
   '@vitest/pretty-format@4.1.0':
     resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
 
-  '@vitest/pretty-format@4.1.2':
-    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
-
   '@vitest/runner@4.1.0':
     resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
 
@@ -447,9 +444,6 @@ packages:
 
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
-
-  '@vitest/utils@4.1.2':
-    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1182,10 +1176,10 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.0(vite@7.3.1))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(vite@7.3.1))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.0
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -1217,10 +1211,6 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/pretty-format@4.1.2':
-    dependencies:
-      tinyrainbow: 3.1.0
-
   '@vitest/runner@4.1.0':
     dependencies:
       '@vitest/utils': 4.1.0
@@ -1238,12 +1228,6 @@ snapshots:
   '@vitest/utils@4.1.0':
     dependencies:
       '@vitest/pretty-format': 4.1.0
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
-
-  '@vitest/utils@4.1.2':
-    dependencies:
-      '@vitest/pretty-format': 4.1.2
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 

--- a/.agentkit/templates/scripts/update-changelog.ps1
+++ b/.agentkit/templates/scripts/update-changelog.ps1
@@ -105,7 +105,15 @@ if (sectionIdx === -1) {
   ) {
     insertAt++;
   }
-  lines.splice(insertAt, 0, entry);
+  // An empty section leaves insertAt on the next heading (the blank-line scan
+  // above stepped over the only blank), so a bare splice would butt the entry
+  // straight against that heading and trip MD022/MD032 — the very rules this
+  // branch exists to satisfy. Re-add the separating blank in that case.
+  const atBoundary =
+    insertAt >= blockEnd ||
+    lines[insertAt].startsWith('#') ||
+    lines[insertAt].trim() === '---';
+  lines.splice(insertAt, 0, ...(atBoundary ? [entry, ''] : [entry]));
 }
 
 fs.writeFileSync(changelogPath, lines.join('\n'), 'utf8');

--- a/.agentkit/templates/scripts/update-changelog.sh
+++ b/.agentkit/templates/scripts/update-changelog.sh
@@ -122,7 +122,15 @@ if (sectionIdx === -1) {
   ) {
     insertAt++;
   }
-  lines.splice(insertAt, 0, entry);
+  // An empty section leaves insertAt on the next heading (the blank-line scan
+  // above stepped over the only blank), so a bare splice would butt the entry
+  // straight against that heading and trip MD022/MD032 — the very rules this
+  // branch exists to satisfy. Re-add the separating blank in that case.
+  const atBoundary =
+    insertAt >= blockEnd ||
+    lines[insertAt].startsWith('#') ||
+    lines[insertAt].trim() === '---';
+  lines.splice(insertAt, 0, ...(atBoundary ? [entry, ''] : [entry]));
 }
 
 fs.writeFileSync(changelogPath, lines.join('\n'), 'utf8');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "start": "node dist/start/index.js",
-    "start:build": "esbuild src/start/index.js --bundle --platform=node --format=esm --outfile=dist/start/index.js --jsx=automatic --external:ink --external:react --external:ink-text-input --external:ink-select-input --external:fuse.js",
+    "start:build": "esbuild src/start/index.ts --bundle --platform=node --format=esm --outfile=dist/start/index.js --jsx=automatic --external:ink --external:react --external:ink-text-input --external:ink-select-input --external:fuse.js",
     "start:dev": "pnpm run start:build && node dist/start/index.js",
     "typecheck": "node -e \"\"",
     "test": "pnpm -C .agentkit test",
@@ -41,7 +41,7 @@
     "react": "19.2.4"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "4.0.18",
+    "@vitest/coverage-v8": "4.1.0",
     "esbuild": "0.28.1",
     "ink-testing-library": "4.0.0",
     "vitest": "4.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         version: 19.2.4
     devDependencies:
       '@vitest/coverage-v8':
-        specifier: 4.0.18
-        version: 4.0.18(vitest@4.1.0(vite@7.3.1))
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0(vite@7.3.1))
       esbuild:
         specifier: 0.28.1
         version: 0.28.1
@@ -53,8 +53,8 @@ importers:
         version: 4.2.0
     devDependencies:
       '@vitest/coverage-v8':
-        specifier: ^4.0.18
-        version: 4.0.18(vitest@4.1.0(vite@7.3.1))
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0(vite@7.3.1))
       markdownlint-cli2:
         specifier: ^0.18.1
         version: 0.18.1
@@ -62,7 +62,7 @@ importers:
         specifier: ^3.5.3
         version: 3.8.1
       vitest:
-        specifier: ^4.1.0
+        specifier: 4.1.0
         version: 4.1.0(vite@7.3.1)
 
 packages:
@@ -598,11 +598,11 @@ packages:
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  '@vitest/coverage-v8@4.0.18':
-    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+  '@vitest/coverage-v8@4.1.0':
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
     peerDependencies:
-      '@vitest/browser': 4.0.18
-      vitest: 4.0.18
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -621,9 +621,6 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.18':
-    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
-
   '@vitest/pretty-format@4.1.0':
     resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
 
@@ -635,9 +632,6 @@ packages:
 
   '@vitest/spy@4.1.0':
     resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
-
-  '@vitest/utils@4.0.18':
-    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
@@ -672,8 +666,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@0.3.12:
-    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   auto-bind@5.0.1:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
@@ -1085,9 +1079,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -1203,9 +1194,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -1243,10 +1231,6 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
-
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
-    engines: {node: '>=14.0.0'}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -1684,18 +1668,18 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.1.0(vite@7.3.1))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(vite@7.3.1))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.0.18
-      ast-v8-to-istanbul: 0.3.12
+      '@vitest/utils': 4.1.0
+      ast-v8-to-istanbul: 1.0.5
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
-      obug: 2.1.1
-      std-env: 3.10.0
-      tinyrainbow: 3.0.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
       vitest: 4.1.0(vite@7.3.1)
 
   '@vitest/expect@4.1.0':
@@ -1715,10 +1699,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1
 
-  '@vitest/pretty-format@4.0.18':
-    dependencies:
-      tinyrainbow: 3.1.0
-
   '@vitest/pretty-format@4.1.0':
     dependencies:
       tinyrainbow: 3.1.0
@@ -1736,11 +1716,6 @@ snapshots:
       pathe: 2.0.3
 
   '@vitest/spy@4.1.0': {}
-
-  '@vitest/utils@4.0.18':
-    dependencies:
-      '@vitest/pretty-format': 4.0.18
-      tinyrainbow: 3.0.3
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -1771,7 +1746,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@0.3.12:
+  ast-v8-to-istanbul@1.0.5:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -2309,8 +2284,6 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  obug@2.1.1: {}
-
   obug@2.1.3: {}
 
   onetime@5.1.2:
@@ -2427,8 +2400,6 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
-
   std-env@4.1.0: {}
 
   string-width@7.2.0:
@@ -2462,8 +2433,6 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-
-  tinyrainbow@3.0.3: {}
 
   tinyrainbow@3.1.0: {}
 

--- a/scripts/update-changelog.ps1
+++ b/scripts/update-changelog.ps1
@@ -108,7 +108,15 @@ if (sectionIdx === -1) {
   ) {
     insertAt++;
   }
-  lines.splice(insertAt, 0, entry);
+  // An empty section leaves insertAt on the next heading (the blank-line scan
+  // above stepped over the only blank), so a bare splice would butt the entry
+  // straight against that heading and trip MD022/MD032 — the very rules this
+  // branch exists to satisfy. Re-add the separating blank in that case.
+  const atBoundary =
+    insertAt >= blockEnd ||
+    lines[insertAt].startsWith('#') ||
+    lines[insertAt].trim() === '---';
+  lines.splice(insertAt, 0, ...(atBoundary ? [entry, ''] : [entry]));
 }
 
 fs.writeFileSync(changelogPath, lines.join('\n'), 'utf8');

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -121,7 +121,15 @@ if (sectionIdx === -1) {
   ) {
     insertAt++;
   }
-  lines.splice(insertAt, 0, entry);
+  // An empty section leaves insertAt on the next heading (the blank-line scan
+  // above stepped over the only blank), so a bare splice would butt the entry
+  // straight against that heading and trip MD022/MD032 — the very rules this
+  // branch exists to satisfy. Re-add the separating blank in that case.
+  const atBoundary =
+    insertAt >= blockEnd ||
+    lines[insertAt].startsWith('#') ||
+    lines[insertAt].trim() === '---';
+  lines.splice(insertAt, 0, ...(atBoundary ? [entry, ''] : [entry]));
 }
 
 fs.writeFileSync(changelogPath, lines.join('\n'), 'utf8');

--- a/src/start/components/App.tsx
+++ b/src/start/components/App.tsx
@@ -17,6 +17,7 @@ import { Box, Text, useApp, useInput } from 'ink';
 import StatusBar from './StatusBar.js';
 import MCPPanel from './MCPPanel.js';
 import TasksPanel from './TasksPanel.js';
+import WorktreesPanel from './WorktreesPanel.js';
 import ConversationFlow from './ConversationFlow.js';
 import CommandPalette from './CommandPalette.js';
 import type { RepoContext } from '../lib/detect.js';
@@ -113,6 +114,7 @@ function AppInner({ ctx }: AppProps) {
         </Box>
 
         <TasksPanel />
+        <WorktreesPanel />
         <MCPPanel />
         <StatusBar ctx={ctx} />
       </Box>
@@ -156,6 +158,7 @@ function AppInner({ ctx }: AppProps) {
       )}
 
       <TasksPanel />
+      <WorktreesPanel />
       <MCPPanel />
       <StatusBar ctx={ctx} />
     </Box>


### PR DESCRIPTION
Codex flagged nine issues across #598/#599/#601. I verified each before acting — **eight held up, one did not**.

## Fixed (8)

| Finding | What was actually wrong |
| --- | --- |
| **P1 path traversal** `platform-syncer.mjs` | The scaffold-once carry-forward resolved and wrote `destFile`, then `continue`d — never reaching the traversal guard below it. A crafted output path could read a tracked project file and write it **outside `tmpDir`**. Guard now runs before both branches; the carry-forward *source* is bounded to `projectRoot` too. |
| **P2 BOM false-updates** `synchronize.mjs` | `writeScaffoldOutputs` applies a UTF-8 BOM to generated `.ps1`, so the on-disk copy carried a BOM the temp-tree copy lacked. Every PowerShell hook compared as changed: `sync --diff` reported updates a real sync then skipped, and interactive sync prompted for them. Both comparison sites now apply the BOM first. |
| **P2 silent provenance failure** `scaffold-engine.mjs` | A failed `GENERATED.json` write was swallowed and `runSync` reported success — the generated tree could advance while its sole provenance record went stale. Now warns. |
| **P1 broken build** `package.json` | `start:build` pointed at `src/start/index.js`, deleted in the TS migration. `pnpm start:build` exited 1. Verified fixed — builds a 36.3kb bundle. |
| **P2 dead panel** `App.tsx` | `WorktreesPanel` had no non-test consumer despite README:118 advertising it. Rendered in **both** result paths; self-hides like `TasksPanel`. |
| **P1 peer mismatch** both manifests | `@vitest/coverage-v8` declares an **exact** peer on `vitest`; they had drifted (4.0.18 vs 4.1.0). Note a naive bump makes it worse — 4.1.10 peers 4.1.10. Both pinned to **4.1.0**; lockfile regenerated and `--frozen-lockfile` verified. |
| **P2 changelog spacing** templates | Filling a section that existed but was *empty* put the entry directly against the next heading, breaking the MD022/MD032 spacing the branch exists to preserve. Fixed in shell + PowerShell templates and regenerated. |

## Not a defect (1)

**TUI `.jsx` imports.** Codex predicted the suite would "abort during module loading". It does not — **156/156 pass**. Vite resolves the extension, and `App.tsx` uses the same `./Component.js` convention deliberately. No change made.

Codex was also wrong about the *impact* of the peer mismatch ("Vitest rejects the mismatched coverage package before executing the suite") — coverage runs fine. The mismatch was real, so it is fixed, but for hygiene rather than the stated reason.

## Deliberately not fixed — needs your decision

`retort run` reads `.agentkit/state/tasks`; the generated commands document `.claude/state/tasks`. The **engine is internally consistent** (task-protocol, orchestrator and every test agree) and the generated docs disagree — so agents following the docs would write where nothing reads.

But this is not a typo: `buildCommandVars` is called with a **per-platform** stateDir (`.claude/`, `.cursor/`, `.windsurf/`, `.github/`, `.agents/`). Aligning them is a design choice about whether task state is per-tool or shared. I started a fix, found the per-platform mechanism, and reverted it rather than impose an architecture decision.

## Verification

- Engine suite: **2382 passed, 1 skipped** — matches the dev baseline exactly, counts reconcile.
- TUI: **156 passed**. `pnpm start:build`: **exit 0**.
- One earlier run showed 2 failures and 7 "worker exited unexpectedly" errors with 33 tests unaccounted for — the crashed-worker signature `qa-run-reconciliation` describes. Reproduced as transient: the file passes in isolation (19/19) and a clean re-run matched baseline.

Test plan: `pnpm -C .agentkit test`, `pnpm test:start`, `pnpm start:build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Worktrees panel to the main application and result views.

- **Bug Fixes**
  - Improved generated-file safety by preventing invalid paths from writing outside approved project locations.
  - Improved handling of UTF-8 byte-order marks during comparisons.
  - Changelog updates now preserve spacing in empty sections.
  - Failed manifest writes now provide actionable warnings instead of being silently ignored.

- **Maintenance**
  - Updated the build and test tooling for more consistent releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->