### PR TITLE
fix(ci): enforce documentation gates on every branch, not only main

### DIFF
--- a/.agentkit/templates/github/workflows/documentation-quality.yml
+++ b/.agentkit/templates/github/workflows/documentation-quality.yml
@@ -3,7 +3,10 @@
 # Regenerate: {{packageManager}} -C .agentkit retort:sync
 #
 # Lints and validates documentation quality for history records.
-# Required on main (hard error). Warning-only on dev (surfaces issues without blocking).
+# Hard error on every branch. This previously errored only when the PR targeted
+# `main`, which under a dev-based release train meant the gate could fire only on
+# the aggregate promote-to-main PR — the worst possible place to discover a docs
+# defect. Enforcement now happens on the PR that introduces the defect.
 
 name: Documentation Quality
 
@@ -70,8 +73,6 @@ jobs:
 
       - name: Report results
         if: steps.mdlint.outcome == 'failure' || steps.doc-structure.outcome == 'failure' || steps.doc-numbering.outcome == 'failure'
-        env:
-          TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: |
           {
             echo "## Documentation Quality Issues"
@@ -95,9 +96,5 @@ jobs:
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-          if [ "$TARGET_BRANCH" = "main" ]; then
-            echo "::error::Documentation quality checks failed on main."
-            exit 1
-          else
-            echo "::warning::Documentation quality issues found. These must be fixed before merging to main."
-          fi
+          echo "::error::Documentation quality checks failed."
+          exit 1

--- a/.agentkit/templates/github/workflows/documentation-validation.yml
+++ b/.agentkit/templates/github/workflows/documentation-validation.yml
@@ -3,7 +3,13 @@
 # Regenerate: pnpm --dir .agentkit retort:sync
 #
 # Validates documentation requirements and structure on pull requests.
-# Required on main (hard error). Warning-only on dev (surfaces issues without blocking).
+# Structure and numbering are a hard error on every branch. This previously
+# errored only when the PR targeted `main`, which under a dev-based release train
+# meant the gate could fire only on the aggregate promote-to-main PR.
+#
+# The "Check documentation requirement" step is advisory by design — it reports
+# impact level and never fails. It is not a gate; do not read its green as proof
+# that a history doc exists.
 
 name: Documentation Validation
 
@@ -50,8 +56,6 @@ jobs:
 
       - name: Report validation results
         if: steps.doc-structure.outcome == 'failure' || steps.doc-numbering.outcome == 'failure'
-        env:
-          TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: |
           {
             echo "## Documentation Validation Issues"
@@ -71,9 +75,5 @@ jobs:
             echo ""
             echo "Run \`./scripts/validate-documentation.sh\` locally to see full details."
           } >> "$GITHUB_STEP_SUMMARY"
-          if [ "$TARGET_BRANCH" = "main" ]; then
-            echo "::error::Documentation validation failed. Fix issues before merging to main."
-            exit 1
-          else
-            echo "::warning::Documentation validation issues found. These must be fixed before merging to main."
-          fi
+          echo "::error::Documentation validation failed."
+          exit 1

--- a/.agentkit/templates/scripts/check-documentation-requirement.sh
+++ b/.agentkit/templates/scripts/check-documentation-requirement.sh
@@ -6,23 +6,31 @@ agentkit:
 # scripts/check-documentation-requirement.sh
 # Analyzes staged or changed files to determine whether PR documentation is required.
 #
+# ADVISORY ONLY — this script always exits 0. It reports the impact level of a
+# change so an author can decide whether to write a history doc; it does not
+# gate anything. Do not read its success as evidence that documentation exists.
+#
+# It previously honoured a STRICT env var (and its header advertised a --strict
+# flag) that would exit 1 when documentation was required. No workflow ever set
+# STRICT and no argv parsing for --strict was ever implemented, so both were
+# dead: the step could not fail. They were removed rather than wired up so the
+# script's behaviour matches its contract. Structural enforcement lives in
+# validate-documentation.sh and validate-numbering.sh, which do exit non-zero.
+#
 # Usage (pre-commit hook):
 #   ./scripts/check-documentation-requirement.sh
 #
 # Exit codes:
-#   0 — documentation not required or already present
-#   1 — documentation required but not present (when --strict is passed)
+#   0 — always
 #
 # Environment variables:
 #   GITHUB_BASE_REF  — set automatically in GitHub Actions PR workflows
-#   STRICT           — set to "true" to exit 1 when documentation is required
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 HISTORY_DIR="$REPO_ROOT/docs/history"
-STRICT="${STRICT:-false}"
 
 # ---------------------------------------------------------------------------
 # Collect changed files
@@ -102,9 +110,6 @@ if [[ "$IMPACT_HIGH" == true ]]; then
   else
     echo "   Run: ./scripts/create-doc.sh <type> \"<title>\" <pr-number>"
     echo "   See: docs/engineering/06_pr_documentation.md"
-    if [[ "$STRICT" == "true" ]]; then
-      exit 1
-    fi
   fi
 elif [[ "$IMPACT_MEDIUM" == true ]]; then
   echo "ℹ️  MEDIUM IMPACT change detected — documentation recommended"

--- a/.github/workflows/documentation-quality.yml
+++ b/.github/workflows/documentation-quality.yml
@@ -3,7 +3,10 @@
 # Regenerate: pnpm -C .agentkit retort:sync
 #
 # Lints and validates documentation quality for history records.
-# Required on main (hard error). Warning-only on dev (surfaces issues without blocking).
+# Hard error on every branch. This previously errored only when the PR targeted
+# `main`, which under a dev-based release train meant the gate could fire only on
+# the aggregate promote-to-main PR — the worst possible place to discover a docs
+# defect. Enforcement now happens on the PR that introduces the defect.
 
 name: Documentation Quality
 
@@ -68,8 +71,6 @@ jobs:
 
       - name: Report results
         if: steps.mdlint.outcome == 'failure' || steps.doc-structure.outcome == 'failure' || steps.doc-numbering.outcome == 'failure'
-        env:
-          TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: |
           {
             echo "## Documentation Quality Issues"
@@ -93,9 +94,5 @@ jobs:
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-          if [ "$TARGET_BRANCH" = "main" ]; then
-            echo "::error::Documentation quality checks failed on main."
-            exit 1
-          else
-            echo "::warning::Documentation quality issues found. These must be fixed before merging to main."
-          fi
+          echo "::error::Documentation quality checks failed."
+          exit 1

--- a/.github/workflows/documentation-validation.yml
+++ b/.github/workflows/documentation-validation.yml
@@ -3,7 +3,13 @@
 # Regenerate: pnpm --dir .agentkit retort:sync
 #
 # Validates documentation requirements and structure on pull requests.
-# Required on main (hard error). Warning-only on dev (surfaces issues without blocking).
+# Structure and numbering are a hard error on every branch. This previously
+# errored only when the PR targeted `main`, which under a dev-based release train
+# meant the gate could fire only on the aggregate promote-to-main PR.
+#
+# The "Check documentation requirement" step is advisory by design — it reports
+# impact level and never fails. It is not a gate; do not read its green as proof
+# that a history doc exists.
 
 name: Documentation Validation
 
@@ -50,8 +56,6 @@ jobs:
 
       - name: Report validation results
         if: steps.doc-structure.outcome == 'failure' || steps.doc-numbering.outcome == 'failure'
-        env:
-          TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: |
           {
             echo "## Documentation Validation Issues"
@@ -71,9 +75,5 @@ jobs:
             echo ""
             echo "Run \`./scripts/validate-documentation.sh\` locally to see full details."
           } >> "$GITHUB_STEP_SUMMARY"
-          if [ "$TARGET_BRANCH" = "main" ]; then
-            echo "::error::Documentation validation failed. Fix issues before merging to main."
-            exit 1
-          else
-            echo "::warning::Documentation validation issues found. These must be fixed before merging to main."
-          fi
+          echo "::error::Documentation validation failed."
+          exit 1

--- a/docs/history/bug-fixes/0004-2026-08-07-orphaned-hook-scripts-never-wired-bugfix.md
+++ b/docs/history/bug-fixes/0004-2026-08-07-orphaned-hook-scripts-never-wired-bugfix.md
@@ -76,7 +76,7 @@ per event.
 The defining invariant is checked programmatically against generated output
 rather than asserted by inspection:
 
-```
+```text
 wired: 14   on disk: 14
 ORPHANS (emitted, never wired): none
 DANGLING (wired, not emitted): none

--- a/docs/history/bug-fixes/0007-2026-08-10-real-process-spawns-behind-a-mocked-commandexists-bugfix.md
+++ b/docs/history/bug-fixes/0007-2026-08-10-real-process-spawns-behind-a-mocked-commandexists-bugfix.md
@@ -141,7 +141,7 @@ Both rewrites were mutation-checked rather than assumed.
 
 Restoring the old coverage fixture fails with:
 
-```
+```text
 AssertionError: expected [ 'node -e ""', 'node -e ""' ] to include 'npx vitest run --coverage'
 ```
 

--- a/scripts/check-documentation-requirement.sh
+++ b/scripts/check-documentation-requirement.sh
@@ -5,23 +5,31 @@
 # scripts/check-documentation-requirement.sh
 # Analyzes staged or changed files to determine whether PR documentation is required.
 #
+# ADVISORY ONLY — this script always exits 0. It reports the impact level of a
+# change so an author can decide whether to write a history doc; it does not
+# gate anything. Do not read its success as evidence that documentation exists.
+#
+# It previously honoured a STRICT env var (and its header advertised a --strict
+# flag) that would exit 1 when documentation was required. No workflow ever set
+# STRICT and no argv parsing for --strict was ever implemented, so both were
+# dead: the step could not fail. They were removed rather than wired up so the
+# script's behaviour matches its contract. Structural enforcement lives in
+# validate-documentation.sh and validate-numbering.sh, which do exit non-zero.
+#
 # Usage (pre-commit hook):
 #   ./scripts/check-documentation-requirement.sh
 #
 # Exit codes:
-#   0 — documentation not required or already present
-#   1 — documentation required but not present (when --strict is passed)
+#   0 — always
 #
 # Environment variables:
 #   GITHUB_BASE_REF  — set automatically in GitHub Actions PR workflows
-#   STRICT           — set to "true" to exit 1 when documentation is required
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 HISTORY_DIR="$REPO_ROOT/docs/history"
-STRICT="${STRICT:-false}"
 
 # ---------------------------------------------------------------------------
 # Collect changed files
@@ -101,9 +109,6 @@ if [[ "$IMPACT_HIGH" == true ]]; then
   else
     echo "   Run: ./scripts/create-doc.sh <type> \"<title>\" <pr-number>"
     echo "   See: docs/engineering/06_pr_documentation.md"
-    if [[ "$STRICT" == "true" ]]; then
-      exit 1
-    fi
   fi
 elif [[ "$IMPACT_MEDIUM" == true ]]; then
   echo "ℹ️  MEDIUM IMPACT change detected — documentation recommended"


### PR DESCRIPTION
## The problem

The documentation gates errored only when a PR targeted `main`, and warned otherwise:

```yaml
if [ "$TARGET_BRANCH" = "main" ]; then
  echo "::error::..."; exit 1
else
  echo "::warning::... must be fixed before merging to main."
fi
```

Under a dev-based release train **every** feature PR targets `dev`, so these gates could only ever fire on the aggregate promote-to-main PR. Today's promotion (#601) was **747 files** — the worst possible place to discover documentation debt. Enforcement now happens on the PR that introduces the defect.

Same class of defect as the `Branch Protection / branch-rules` context fixed earlier today: a gate that looks like it enforces but structurally cannot.

## Dead `--strict` removed

`check-documentation-requirement.sh` honoured a `STRICT` env var and its header advertised a `--strict` flag. **No workflow ever set `STRICT`, and no argv parsing for `--strict` was ever implemented** — so the step could not fail under any invocation. Removed rather than wired up, so the contract matches the behaviour: it reports impact level and always exits 0. Structural enforcement lives in `validate-documentation.sh` and `validate-numbering.sh`, which do exit non-zero.

## Verified green before hardening

Each gate was run against `dev` as it stands, so this lands green rather than red:

| Check | Result on dev |
| --- | --- |
| `validate-documentation.sh` | exit 0 |
| `validate-numbering.sh` | exit 0 |
| `markdownlint docs/history/**` | 0 errors (after the two fixes below) |

`documentation-quality.yml` lints `docs/history/**`, which had 2 MD040 violations (unlabelled code fences) in `0004-…` and `0007-…`. Tagged them `text`.

## Deliberately NOT included

`quality-lint.yml` is left unhardened. `pnpm lint:md` currently reports **434 violations across 14 files** (229 MD024 duplicate-heading, 205 MD026 trailing-punctuation), and that workflow fires on any PR touching `**/*.md`, `.markdownlint*`, `.prettierrc*` or `package.json`. Hardening it now would turn nearly every PR red on merge — including every dependabot bump and most of today's work.

Follow-up: `lint:md:fix` clears the 205 MD026 automatically; the 229 MD024 are repeated subsections under different parents (`Summary`/`Motivation` per issue, `Fix` per problem), which is what MD024's `siblings_only` option exists for — a config change, not 229 heading renames.

No drift: templates and generated outputs both updated, `sync --dry-run --diff` reports no pending changes.

Test plan: `bash scripts/validate-documentation.sh`, `bash scripts/validate-numbering.sh`, `pnpm -C .agentkit markdownlint-cli2 --config ../.markdownlint.json "../docs/history/**/*.md"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Documentation structure, numbering, and quality checks now consistently block pull requests when validation fails, regardless of branch.
  - Documentation requirement checks remain advisory and no longer block validation.

- **Documentation**
  - Improved syntax highlighting and formatting for verification and regression-testing examples in historical documentation.
  - Clarified documentation-check behavior and reporting expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->