### PR TITLE
fix(docs): clear markdown lint debt and enforce the gate on every branch

### DIFF
--- a/.agentkit/docs/configuration/MCP_A2A_GUIDE.md
+++ b/.agentkit/docs/configuration/MCP_A2A_GUIDE.md
@@ -36,7 +36,7 @@ during a session. Each entry maps a server name to a command and its arguments.
 }
 ```
 
-#### Server descriptions:
+#### Server descriptions
 
 - **git** -- Provides git operations as MCP tools. Invokes the `git` binary
   directly with no additional arguments.
@@ -118,7 +118,7 @@ capabilities:
 }
 ```
 
-#### Roles:
+#### Roles
 
 - **coordinator** -- The orchestrator agent. Delegates tasks to executor agents,
   aggregates their results, and monitors overall progress. There is exactly one
@@ -126,7 +126,7 @@ capabilities:
 - **executor** -- A team agent that performs work within its domain. Receives
   tasks from the coordinator and reports results back.
 
-#### Registered agents:
+#### Registered agents
 
 | Agent ID        | Role        | Domain             | Capabilities                 |
 | --------------- | ----------- | ------------------ | ---------------------------- |

--- a/.agentkit/docs/getting-started/ONBOARDING.md
+++ b/.agentkit/docs/getting-started/ONBOARDING.md
@@ -56,19 +56,19 @@ git submodule update --init --recursive
 
 The `init` command bootstraps AgentKit Forge for your repository. It copies the overlay template and generates initial configuration files.
 
-#### On Linux/macOS:
+#### On Linux/macOS
 
 ```bash
 node agentkit-forge/.agentkit/engines/node/src/cli.mjs init
 ```
 
-#### On Windows (PowerShell):
+#### On Windows (PowerShell)
 
 ```powershell
 .\agentkit-forge\.agentkit\bin\init.ps1
 ```
 
-#### On Windows (Command Prompt):
+#### On Windows (Command Prompt)
 
 ```cmd
 agentkit-forge\.agentkit\bin\init.cmd

--- a/.agentkit/docs/getting-started/QUICK_START.md
+++ b/.agentkit/docs/getting-started/QUICK_START.md
@@ -174,7 +174,7 @@ Open Claude Code in your project directory and walk through this sequence. Each 
 
 **What you get:** An `AGENT_TEAMS.md` file in your repository root with a repository profile, team assignments tailored to your actual codebase, a folder map, and a list of detected issues.
 
-#### Example output:
+#### Example output
 
 ```text
 ## Repository Profile
@@ -204,7 +204,7 @@ Open Claude Code in your project directory and walk through this sequence. Each 
 
 **What you get:** A structured report showing pass/fail status for each check, with an overall health verdict of HEALTHY, DEGRADED, or BROKEN.
 
-#### Example output:
+#### Example output
 
 ```text
 ## Healthcheck Report

--- a/.agentkit/docs/guides/AGENTS_REFERENCE.md
+++ b/.agentkit/docs/guides/AGENTS_REFERENCE.md
@@ -42,7 +42,7 @@ Senior backend engineer responsible for API design, service architecture, core b
 - **Depends on:** `data`
 - **Notifies:** `test-lead`, `frontend`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 apps/api/**
@@ -53,7 +53,7 @@ middleware/**
 routes/**
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Design and implement RESTful and GraphQL APIs
 - Maintain service layer architecture and dependency injection patterns
@@ -63,12 +63,12 @@ routes/**
 - Review and approve changes to API contracts
 - Maintain API documentation (OpenAPI/Swagger)
 
-#### Conventions:
+#### Conventions
 
 - Prefer constructor injection and explicit interfaces at service boundaries
 - Keep controllers thin; move orchestration into application services
 
-#### Anti-patterns:
+#### Anti-patterns
 
 - Service locator usage inside handlers/controllers
 - Returning raw ORM entities directly from API responses
@@ -83,7 +83,7 @@ Senior frontend engineer responsible for UI implementation, component architectu
 - **Depends on:** `backend`
 - **Notifies:** `test-lead`, `brand-guardian`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 apps/web/**
@@ -94,7 +94,7 @@ styles/**
 public/**
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Build and maintain UI components following design system patterns
 - Implement state management with appropriate patterns (stores, context)
@@ -104,12 +104,12 @@ public/**
 - Maintain component documentation and Storybook stories
 - Review and approve changes to shared component libraries
 
-#### Conventions:
+#### Conventions
 
 - Prefer server components by default, client components only when interactive state is required
 - Keep Tailwind utility composition in reusable component primitives
 
-#### Anti-patterns:
+#### Anti-patterns
 
 - Using arbitrary inline styles where design tokens already exist
 - Duplicating component variants instead of using props/composition
@@ -124,7 +124,7 @@ Senior data engineer responsible for database design, migrations, data models, a
 - **Depends on:** None
 - **Notifies:** `backend`, `test-lead`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 db/**
@@ -135,7 +135,7 @@ seeds/**
 scripts/db/**
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Design and maintain database schemas and data models
 - Write and review migration scripts for safety and reversibility
@@ -145,12 +145,12 @@ scripts/db/**
 - Ensure data integrity constraints and referential integrity
 - Plan and execute data migration strategies for breaking changes
 
-#### Conventions:
+#### Conventions
 
 - Write backward-compatible migrations first, then deploy code that uses new schema
 - Add explicit indexes for every new high-cardinality filter path
 
-#### Anti-patterns:
+#### Anti-patterns
 
 - Destructive migrations without rollback/backup strategy
 - Large schema + data transformation in a single migration step
@@ -165,7 +165,7 @@ Senior DevOps engineer responsible for CI/CD pipelines, build automation, contai
 - **Depends on:** `infra`
 - **Notifies:** `test-lead`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 .github/workflows/**
@@ -176,7 +176,7 @@ Dockerfile*
 docker-compose*.yml
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Design and maintain CI/CD pipelines (GitHub Actions, Azure DevOps)
 - Optimize build times and caching strategies
@@ -196,7 +196,7 @@ Senior infrastructure engineer responsible for Infrastructure as Code, cloud res
 - **Depends on:** None
 - **Notifies:** `devops`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 infra/**
@@ -209,7 +209,7 @@ helm/**
 modules/**
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Design and maintain IaC modules (Terraform + Terragrunt as primary toolchain)
 - Follow resource naming convention `{org}-{env}-{project}-{resourcetype}-{region}`
@@ -224,12 +224,12 @@ modules/**
 - Enforce mandatory resource tagging (environment, project, owner, cost-center)
 - Manage Terraform state backend and locking configuration
 
-#### Conventions:
+#### Conventions
 
 - Keep root modules thin and delegate reusable logic to versioned shared modules
 - Run terraform fmt/validate and plan before apply in every environment
 
-#### Anti-patterns:
+#### Anti-patterns
 
 - Inline hardcoded secrets in Terraform variables or locals
 - Shared mutable state backends without locking configuration
@@ -246,7 +246,7 @@ Brand consistency specialist ensuring all visual and written outputs align with 
 - **Depends on:** None
 - **Notifies:** None
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 styles/**
@@ -257,7 +257,7 @@ public/assets/**
 docs/brand/**
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Enforce brand guidelines across all UI components and marketing pages
 - Maintain design token definitions (colors, typography, spacing)
@@ -276,7 +276,7 @@ UI/UX design specialist responsible for interaction patterns, component design, 
 - **Depends on:** None
 - **Notifies:** `frontend`, `brand-guardian`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 components/**
@@ -286,7 +286,7 @@ storybook/**
 design/**
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Define and maintain component design patterns and variants
 - Ensure consistent interaction patterns across the application
@@ -308,7 +308,7 @@ Content strategy specialist responsible for messaging, copy, documentation voice
 - **Depends on:** None
 - **Notifies:** None
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 docs/**
@@ -318,7 +318,7 @@ blog/**
 *.md
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Define and maintain content style guide and voice/tone standards
 - Review documentation for clarity, accuracy, and completeness
@@ -337,7 +337,7 @@ Growth and analytics specialist focused on user acquisition, activation, retenti
 - **Depends on:** None
 - **Notifies:** `product-manager`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 docs/product/**
@@ -346,7 +346,7 @@ apps/marketing/**
 docs/metrics/**
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Analyze user funnel metrics and identify growth opportunities
 - Define and track key performance indicators (KPIs)
@@ -367,7 +367,7 @@ Dependency management specialist responsible for monitoring, updating, and audit
 - **Depends on:** None
 - **Notifies:** `security-auditor`, `devops`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 package.json
@@ -380,7 +380,7 @@ requirements*.txt
 Directory.Packages.props
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Monitor dependencies for security vulnerabilities (npm audit, cargo audit)
 - Evaluate and plan dependency updates (major, minor, patch)
@@ -400,7 +400,7 @@ Environment configuration specialist ensuring consistent, secure, and documented
 - **Depends on:** `infra`
 - **Notifies:** `devops`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 .env.example
@@ -411,7 +411,7 @@ scripts/setup*
 docs/setup/**
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Maintain environment variable documentation and .env.example templates
 - Ensure environment parity across dev, CI, staging, and production
@@ -430,7 +430,7 @@ Security audit specialist performing continuous security analysis, vulnerability
 - **Depends on:** None
 - **Notifies:** `devops`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 auth/**
@@ -441,7 +441,7 @@ infra/**
 **/.env*
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Perform regular security audits of code and configurations
 - Scan for hardcoded secrets, credentials, and sensitive data
@@ -464,7 +464,7 @@ Product management specialist responsible for feature definition, prioritization
 - **Depends on:** None
 - **Notifies:** `backend`, `frontend`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 docs/product/**
@@ -473,7 +473,7 @@ docs/roadmap/**
 docs/features/**
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Write and maintain Product Requirements Documents (PRDs)
 - Define acceptance criteria for features and user stories
@@ -493,7 +493,7 @@ Roadmap and milestone tracking specialist maintaining visibility into project pr
 - **Depends on:** None
 - **Notifies:** `product-manager`, `project-shipper`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 docs/roadmap/**
@@ -502,7 +502,7 @@ docs/milestones/**
 CHANGELOG.md
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Maintain and update the product roadmap with current status
 - Track milestone progress and identify schedule risks
@@ -523,7 +523,7 @@ Test strategy lead responsible for overall test architecture, test planning, and
 - **Depends on:** None
 - **Notifies:** `devops`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 **/*.test.*
@@ -536,7 +536,7 @@ vitest.config.*
 playwright.config.*
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Define and maintain the overall test strategy and test pyramid balance
 - Review test quality, coverage, and effectiveness
@@ -556,7 +556,7 @@ Test coverage analysis specialist monitoring code coverage metrics, identifying 
 - **Depends on:** None
 - **Notifies:** `test-lead`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 coverage/**
@@ -567,7 +567,7 @@ vitest.config.*
 .nycrc*
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Monitor and report code coverage metrics across all packages
 - Identify uncovered code paths and critical untested areas
@@ -586,7 +586,7 @@ Integration and end-to-end test specialist responsible for testing cross-service
 - **Depends on:** `backend`, `frontend`
 - **Notifies:** `test-lead`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 e2e/**
@@ -596,7 +596,7 @@ tests/e2e/**
 docker-compose.test.yml
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Design and maintain E2E test suites using Playwright or Cypress
 - Write integration tests for cross-service communication
@@ -618,7 +618,7 @@ Delivery-focused project management specialist responsible for moving work throu
 - **Depends on:** None
 - **Notifies:** `release-manager`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 docs/**
@@ -627,7 +627,7 @@ docs/**
 docs/ai_handoffs/**
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Break down features into deliverable tasks with clear definitions of done
 - Track task progress and remove blockers
@@ -647,7 +647,7 @@ Release management specialist responsible for coordinating releases, managing ve
 - **Depends on:** `devops`
 - **Notifies:** `product-manager`
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 CHANGELOG.md
@@ -659,7 +659,7 @@ scripts/release*
 docs/releases/**
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Coordinate release planning and scheduling across teams
 - Manage semantic versioning and version bumps
@@ -689,7 +689,7 @@ Session knowledge capture specialist that reviews conversation history to extrac
 - **Depends on:** None
 - **Notifies:** None
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 docs/history/issues/**
@@ -697,7 +697,7 @@ docs/history/lessons-learned/**
 docs/history/.index.json
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Extract and classify issues by severity (critical/high/medium/low) and status
 - Categorize lessons (technical, process, tooling, architecture, communication)
@@ -718,7 +718,7 @@ Kit feature management specialist responsible for analyzing, configuring, and au
 - **Depends on:** None
 - **Notifies:** None
 
-#### Focus scope:
+#### Focus scope
 
 ```text
 .agentkit/spec/features.yaml
@@ -729,7 +729,7 @@ CLAUDE.md
 .agentkit/spec/agents.yaml
 ```
 
-#### Key responsibilities:
+#### Key responsibilities
 
 - Analyze repository patterns and recommend appropriate feature presets
 - Configure features with dependency validation and conflict resolution

--- a/.agentkit/docs/guides/AGENTS_VS_TEAMS.md
+++ b/.agentkit/docs/guides/AGENTS_VS_TEAMS.md
@@ -184,7 +184,7 @@ Session knowledge capture agent activated via `/review --focus=retrospective`. E
 
 Kit feature management agent that helps teams choose, configure, and audit feature presets. Activated via `/feature-configure`, `/feature-flow`, and `/feature-review`.
 
-#### When these branches merge, update:
+#### When these branches merge, update
 
 1. The agent count heading from "19" to "21"
 2. Add a "Feature Management" category (1 agent) to the category tables

--- a/.agentkit/docs/guides/COMMAND_REFERENCE.md
+++ b/.agentkit/docs/guides/COMMAND_REFERENCE.md
@@ -64,19 +64,19 @@ These seven commands form the core orchestration and lifecycle workflow.
 
 **One-line:** Master coordinator that runs the 5-phase lifecycle (discover, plan, implement, validate, ship) across all teams.
 
-#### When to use:
+#### When to use
 
 - You have a complex task that spans multiple teams or multiple files.
 - You want an end-to-end automated workflow from assessment through shipping.
 - You need to resume a previously started orchestration session.
 
-#### When NOT to use:
+#### When NOT to use
 
 - The task is small and fits within a single team's scope. Use `/team-<name>` instead.
 - You only need to check quality. Use `/check` instead.
 - You only need to understand the codebase. Use `/discover` instead.
 
-#### Flags:
+#### Flags
 
 | Flag             | Description                                                                                |
 | ---------------- | ------------------------------------------------------------------------------------------ |
@@ -88,7 +88,7 @@ These seven commands form the core orchestration and lifecycle workflow.
 | `--dry-run`      | Show what would be done without making changes.                                            |
 | `--force-unlock` | Clear a stale lock from a previous crashed session.                                        |
 
-#### Example invocation:
+#### Example invocation
 
 ```text
 /orchestrate --assess-only
@@ -96,7 +96,7 @@ These seven commands form the core orchestration and lifecycle workflow.
 /orchestrate "Add rate limiting to auth endpoints"
 ```
 
-#### Expected output sample:
+#### Expected output sample
 
 ```text
 ## Orchestration Summary
@@ -125,18 +125,18 @@ These seven commands form the core orchestration and lifecycle workflow.
 
 **One-line:** Scans the repository and produces a full codebase inventory including tech stacks, infrastructure, CI/CD, test frameworks, and issues.
 
-#### When to use:
+#### When to use
 
 - First time working in a repository.
 - The codebase has changed significantly and you need an updated map.
 - The orchestrator needs a fresh `AGENT_TEAMS.md` before planning.
 
-#### When NOT to use:
+#### When NOT to use
 
 - You already know the stack and just need to run checks. Use `/check`.
 - You want to fix something. Discovery is read-only.
 
-#### Flags:
+#### Flags
 
 | Flag                            | Description                                                           |
 | ------------------------------- | --------------------------------------------------------------------- |
@@ -144,14 +144,14 @@ These seven commands form the core orchestration and lifecycle workflow.
 | `--depth <n>`                   | Limit directory traversal depth during scanning.                      |
 | `--include-deps`                | Include dependency analysis in the discovery report.                  |
 
-#### Example invocation:
+#### Example invocation
 
 ```text
 /discover
 /discover --output json
 ```
 
-#### Expected output sample:
+#### Expected output sample
 
 ```text
 ## Repository Profile
@@ -177,18 +177,18 @@ These seven commands form the core orchestration and lifecycle workflow.
 
 **One-line:** Pre-flight validation that verifies dependencies, build, lint, typecheck, and tests are all passing.
 
-#### When to use:
+#### When to use
 
 - Starting a new session and you want to confirm the project is in a working state.
 - Before running `/orchestrate` or `/plan` to establish a baseline.
 - After pulling changes to verify nothing is broken.
 
-#### When NOT to use:
+#### When NOT to use
 
 - You want to fix issues. Healthcheck only reports; it does not fix.
 - You need auto-fix capabilities. Use `/check --fix` instead.
 
-#### Flags:
+#### Flags
 
 | Flag             | Description                                     |
 | ---------------- | ----------------------------------------------- |
@@ -196,13 +196,13 @@ These seven commands form the core orchestration and lifecycle workflow.
 | `--fix`          | Attempt to auto-fix issues found during checks. |
 | `--verbose`      | Show detailed output for each check step.       |
 
-#### Example invocation:
+#### Example invocation
 
 ```text
 /healthcheck
 ```
 
-#### Expected output sample:
+#### Expected output sample
 
 ```text
 ## Healthcheck Report
@@ -230,19 +230,19 @@ These seven commands form the core orchestration and lifecycle workflow.
 
 **One-line:** Produces a structured implementation plan with steps, file touch list, validation commands, and rollback strategy before any code is written.
 
-#### When to use:
+#### When to use
 
 - A backlog item involves more than 2 files.
 - The change touches shared infrastructure, APIs, or database schemas.
 - The orchestrator requests a plan before delegating to teams.
 - You want to think through an approach before committing to code.
 
-#### When NOT to use:
+#### When NOT to use
 
 - The change is trivial (single config tweak, typo fix).
 - You are ready to implement and the path is obvious. Go directly to `/team-<name>`.
 
-#### Flags:
+#### Flags
 
 | Flag                            | Description                                    |
 | ------------------------------- | ---------------------------------------------- |
@@ -250,14 +250,14 @@ These seven commands form the core orchestration and lifecycle workflow.
 | `--output markdown\|yaml\|json` | Output format for the plan. Default: markdown. |
 | `--depth high\|medium\|low`     | Level of detail in the plan. Default: medium.  |
 
-#### Example invocation:
+#### Example invocation
 
 ```text
 /plan "Add rate limiting to POST /api/auth/login"
 /plan P1: Fix auth middleware token validation
 ```
 
-#### Expected output sample:
+#### Expected output sample
 
 ```text
 ## Implementation Plan
@@ -302,18 +302,18 @@ after 5 failed attempts within 15 minutes per IP address.
 
 **One-line:** Universal quality gate that runs format, lint, typecheck, test, and build checks in a single pass with auto-detection.
 
-#### When to use:
+#### When to use
 
 - After making changes, before committing or creating a PR.
 - As a final validation step before shipping.
 - To get a full quality report on the current state of the codebase.
 
-#### When NOT to use:
+#### When NOT to use
 
 - You only need to run tests. Use `/test` for a faster, focused test run.
 - You only need to format. Use `/format` for formatting only.
 
-#### Flags:
+#### Flags
 
 | Flag              | Description                                                                     |
 | ----------------- | ------------------------------------------------------------------------------- |
@@ -322,7 +322,7 @@ after 5 failed attempts within 15 minutes per IP address.
 | `--stack <scope>` | Limit checks to a subdirectory or workspace (e.g., `frontend`, `packages/api`). |
 | `--bail`          | Stop at the first failing step instead of running all steps.                    |
 
-#### Example invocation:
+#### Example invocation
 
 ```text
 /check
@@ -331,7 +331,7 @@ after 5 failed attempts within 15 minutes per IP address.
 /check --fix --bail
 ```
 
-#### Expected output sample:
+#### Expected output sample
 
 ```text
 ## Quality Gate Results
@@ -362,18 +362,18 @@ Lint errors:
 
 **One-line:** Structured code review that evaluates changes for correctness, security, performance, test coverage, and documentation quality.
 
-#### When to use:
+#### When to use
 
 - Before creating or merging a pull request.
 - After a team completes implementation and you want an automated review pass.
 - To catch security issues, missing tests, or logic errors.
 
-#### When NOT to use:
+#### When NOT to use
 
 - You want to run linters and formatters. Use `/check`.
 - You have not made any changes yet. Review operates on diffs.
 
-#### Flags:
+#### Flags
 
 | Flag                 | Description                                                                   |
 | -------------------- | ----------------------------------------------------------------------------- |
@@ -383,7 +383,7 @@ Lint errors:
 | `--focus <area>`     | Focus area: security, performance, correctness, style, or all. Default: all.  |
 | `--severity <level>` | Minimum severity to report: info, warning, error, critical. Default: warning. |
 
-#### Example invocation:
+#### Example invocation
 
 ```text
 /review
@@ -391,7 +391,7 @@ Lint errors:
 /review --file src/auth/middleware.ts
 ```
 
-#### Expected output sample:
+#### Expected output sample
 
 ```text
 ## Code Review
@@ -420,18 +420,18 @@ Lint errors:
 
 **One-line:** Generates a session handoff document so the next session (human or AI) can pick up exactly where this one left off.
 
-#### When to use:
+#### When to use
 
 - You are ending a work session and want to preserve context.
 - You need to pass work to another developer or agent.
 - The orchestrator has completed a run and needs to record what happened.
 
-#### When NOT to use:
+#### When NOT to use
 
 - You are in the middle of active work. Finish or reach a stopping point first.
 - You have not done anything yet this session. There is nothing to hand off.
 
-#### Flags:
+#### Flags
 
 | Flag             | Description                                                                                     |
 | ---------------- | ----------------------------------------------------------------------------------------------- |
@@ -440,14 +440,14 @@ Lint errors:
 | `--include-diff` | Include a summary of all file changes in the handoff.                                           |
 | `--tag <tag>`    | Tag for categorizing the handoff (e.g., feature, bugfix, spike).                                |
 
-#### Example invocation:
+#### Example invocation
 
 ```text
 /handoff
 /handoff --save
 ```
 
-#### Expected output sample:
+#### Expected output sample
 
 ````text
 # Session Handoff
@@ -502,7 +502,7 @@ Team commands invoke a specialized agent scoped to a particular domain. Each tea
 | --------------- | ------------------------------------------------------------ |
 | `--task <text>` | Specify a specific task instead of pulling from the backlog. |
 
-#### How team commands work:
+#### How team commands work
 
 1. The team agent activates with its predefined role, scope, and conventions.
 2. Without `--task`, it reads `AGENT_BACKLOG.md` and picks the highest-priority item within its scope.
@@ -511,7 +511,7 @@ Team commands invoke a specialized agent scoped to a particular domain. Each tea
 
 **What happens when no backlog items exist:** The team agent reports that no actionable items are in its scope and suggests running `/discover` or `/sync-backlog` to populate the backlog.
 
-#### Example invocations:
+#### Example invocations
 
 ```text
 /team-backend                              -- picks up highest-priority backend backlog items
@@ -533,7 +533,7 @@ These commands perform focused, single-purpose operations. They are often invoke
 
 Build the project with auto-detected stack. Supports scoped builds for monorepos.
 
-#### Flags:
+#### Flags
 
 | Flag               | Description                                                        |
 | ------------------ | ------------------------------------------------------------------ |
@@ -554,7 +554,7 @@ Build the project with auto-detected stack. Supports scoped builds for monorepos
 
 Run the test suite with auto-detected framework. Supports scoped runs, filters, watch mode, and coverage.
 
-#### Flags:
+#### Flags
 
 | Flag                 | Description                                        |
 | -------------------- | -------------------------------------------------- |
@@ -580,7 +580,7 @@ Run the test suite with auto-detected framework. Supports scoped runs, filters, 
 
 Run code formatters across the project. Defaults to write mode (applies fixes). Supports scoped formatting and staged-files-only mode.
 
-#### Flags:
+#### Flags
 
 | Flag             | Description                                                             |
 | ---------------- | ----------------------------------------------------------------------- |
@@ -603,7 +603,7 @@ Run code formatters across the project. Defaults to write mode (applies fixes). 
 
 Deployment automation with safety checks, explicit confirmation gates, and rollback support. Requires user confirmation before executing any deployment.
 
-#### Flags:
+#### Flags
 
 | Flag                  | Description                                         |
 | --------------------- | --------------------------------------------------- |
@@ -626,7 +626,7 @@ Deployment automation with safety checks, explicit confirmation gates, and rollb
 
 Full security audit covering OWASP Top 10, dependency vulnerabilities, auth flow review, and hardcoded secrets scan.
 
-#### Flags:
+#### Flags
 
 | Flag                                        | Description                                             |
 | ------------------------------------------- | ------------------------------------------------------- |
@@ -648,7 +648,7 @@ Full security audit covering OWASP Top 10, dependency vulnerabilities, auth flow
 
 Updates `AGENT_BACKLOG.md` by gathering work items from discovery findings, healthcheck results, orchestrator state, code TODOs, and review findings. Prioritizes and assigns items to teams.
 
-#### Flags:
+#### Flags
 
 | Flag                           | Description                                                       |
 | ------------------------------ | ----------------------------------------------------------------- |
@@ -668,7 +668,7 @@ Updates `AGENT_BACKLOG.md` by gathering work items from discovery findings, heal
 
 Runs a comprehensive project-wide audit combining discovery, healthcheck, security scan, and quality gate checks into a single consolidated report. Use this for periodic full-project health assessments.
 
-#### Flags:
+#### Flags
 
 | Flag             | Description                                                           |
 | ---------------- | --------------------------------------------------------------------- |
@@ -687,7 +687,7 @@ Runs a comprehensive project-wide audit combining discovery, healthcheck, securi
 
 Displays AI token usage summaries, session costs, and budget status. See [COST_TRACKING.md](../architecture/COST_TRACKING.md) for full details on cost tracking configuration.
 
-#### Flags:
+#### Flags
 
 | Flag                | Description                                                  |
 | ------------------- | ------------------------------------------------------------ |
@@ -716,13 +716,13 @@ These commands manage the delegated task system used by the orchestrator and tea
 
 **One-line:** List, filter, and inspect delegated tasks across all teams.
 
-#### When to use:
+#### When to use
 
 - You want to see what tasks are pending, in-progress, or completed.
 - You need to check the status of a specific task by ID.
 - You want to filter tasks by team, priority, or status before deciding what to work on next.
 
-#### Flags:
+#### Flags
 
 | Flag                 | Description                                                                                                                                                      |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -733,7 +733,7 @@ These commands manage the delegated task system used by the orchestrator and tea
 | `--priority <level>` | Filter by priority (P0, P1, P2, P3).                                                                                                                             |
 | `--process-handoffs` | Process handoff chains before listing tasks.                                                                                                                     |
 
-#### Example invocations:
+#### Example invocations
 
 ```text
 /tasks                                  -- list all tasks
@@ -742,7 +742,7 @@ These commands manage the delegated task system used by the orchestrator and tea
 /tasks --priority P0 --status submitted   -- show urgent unstarted work
 ```
 
-#### Expected output sample:
+#### Expected output sample
 
 ```text
 ## Delegated Tasks
@@ -762,13 +762,13 @@ Total: 3 tasks (1 completed, 1 in-progress, 1 pending)
 
 **One-line:** Create a new delegated task and assign it to a team with optional dependencies and handoff chains.
 
-#### When to use:
+#### When to use
 
 - You want to break a large effort into team-scoped tasks.
 - The orchestrator has identified work that should be routed to a specific team.
 - You need to set up task dependencies (task B waits for task A).
 
-#### Flags:
+#### Flags
 
 | Flag                     | Description                                                                          |
 | ------------------------ | ------------------------------------------------------------------------------------ |
@@ -781,7 +781,7 @@ Total: 3 tasks (1 completed, 1 in-progress, 1 pending)
 | `--scope <path>`         | File path or directory scope for the task.                                           |
 | `--description <text>`   | Detailed description of what needs to be done.                                       |
 
-#### Example invocations:
+#### Example invocations
 
 ```text
 /delegate --to backend --title "Add pagination to GET /api/users" --priority P1
@@ -789,7 +789,7 @@ Total: 3 tasks (1 completed, 1 in-progress, 1 pending)
 /delegate --to docs --title "Update API reference" --handoff-to quality --type document
 ```
 
-#### Expected output sample:
+#### Expected output sample
 
 ```text
 ## Task Created
@@ -816,31 +816,31 @@ Task added to AGENT_BACKLOG.md. Run `/team-backend` to begin work.
 
 **One-line:** Runs AgentKit Forge diagnostics to verify your setup, configuration, and environment health.
 
-#### When to use:
+#### When to use
 
 - Something is not working and you need to identify the problem.
 - After initial setup to verify everything is configured correctly.
 - After upgrading AgentKit Forge to verify the migration succeeded.
 
-#### When NOT to use:
+#### When NOT to use
 
 - You want to check code quality. Use `/check` instead.
 - You want to validate generated outputs. Use `agentkit validate` (CLI) instead.
 
-#### Flags:
+#### Flags
 
 | Flag        | Description                      |
 | ----------- | -------------------------------- |
 | `--verbose` | Show detailed diagnostic output. |
 
-#### Example invocations:
+#### Example invocations
 
 ```text
 /doctor
 /doctor --verbose
 ```
 
-#### Expected output sample:
+#### Expected output sample
 
 ```text
 ## AgentKit Forge Diagnostics
@@ -875,12 +875,12 @@ These commands are available only as slash commands within AI coding tools. They
 
 **One-line:** Generates convention-aligned code skeletons (files, modules, components) based on project patterns and stack.
 
-#### When to use:
+#### When to use
 
 - You need to create a new file that should follow project conventions (component, service, test, migration).
 - You want boilerplate generated with correct imports, naming, and structure.
 
-#### Flags:
+#### Flags
 
 | Flag             | Description                                                            |
 | ---------------- | ---------------------------------------------------------------------- |
@@ -889,7 +889,7 @@ These commands are available only as slash commands within AI coding tools. They
 | `--stack <name>` | Tech stack context (auto-detected if omitted).                         |
 | `--path <path>`  | Target directory for the generated file(s).                            |
 
-#### Example invocations:
+#### Example invocations
 
 ```text
 /scaffold --type component --name UserProfile
@@ -903,12 +903,12 @@ These commands are available only as slash commands within AI coding tools. They
 
 **One-line:** Release-readiness checks that verify the project is ready to ship, including changelog, version, tests, and documentation.
 
-#### When to use:
+#### When to use
 
 - Before cutting a release to verify all release criteria are met.
 - As part of a release checklist to catch missing items.
 
-#### Flags:
+#### Flags
 
 | Flag              | Description                                              |
 | ----------------- | -------------------------------------------------------- |
@@ -917,7 +917,7 @@ These commands are available only as slash commands within AI coding tools. They
 | `--range <range>` | Git commit range to check (e.g., v1.0.0..HEAD).          |
 | `--strict`        | Fail on warnings in addition to errors.                  |
 
-#### Example invocations:
+#### Example invocations
 
 ```text
 /preflight
@@ -939,13 +939,13 @@ These commands are available only as slash commands within AI coding tools. They
 
 **One-line:** Risk-aware infrastructure and codebase fitness evaluation scoring 8 weighted dimensions with hard gate enforcement.
 
-#### When to use:
+#### When to use
 
 - Quarterly reassessment of infrastructure health.
 - Pre-funding due diligence on technical maturity.
 - Before architectural decisions that affect reliability or cost.
 
-#### Flags:
+#### Flags
 
 | Flag             | Description                                                                                      |
 | ---------------- | ------------------------------------------------------------------------------------------------ |
@@ -956,7 +956,7 @@ These commands are available only as slash commands within AI coding tools. They
 | `--no-save`      | Do not save report.                                                                              |
 | `--gates-only`   | Run hard gate checks only (skip dimensional scoring).                                            |
 
-#### 8 evaluation dimensions (weighted):
+#### 8 evaluation dimensions (weighted)
 
 1. Reliability & Resilience (18%)
 2. Cost Efficiency (16%)
@@ -985,13 +985,13 @@ These commands are available only as slash commands within AI coding tools. They
 
 **One-line:** Brand management and editor theme generation from a centralized `brand.yaml` specification.
 
-#### When to use:
+#### When to use
 
 - Scaffolding a new brand identity for your repository.
 - Generating editor themes (VS Code, Cursor, Windsurf) from brand colors.
 - Auditing accessibility compliance (WCAG) of your color palette.
 
-#### Modes:
+#### Modes
 
 | Flag         | Description                                              |
 | ------------ | -------------------------------------------------------- |
@@ -1002,7 +1002,7 @@ These commands are available only as slash commands within AI coding tools. They
 | `--contrast` | Audit WCAG compliance of color combinations.             |
 | `--all`      | Run all validations and generation.                      |
 
-#### Key files:
+#### Key files
 
 - `.agentkit/spec/brand.yaml` — Brand identity specification (colors, typography, spacing, motion, accessibility)
 - `.agentkit/spec/editor-theme.yaml` — Maps brand colors to editor UI elements (light/dark mode)
@@ -1016,13 +1016,13 @@ These commands are available only as slash commands within AI coding tools. They
 
 **One-line:** Interactive workflow to configure which AgentKit Forge features are enabled for your repository.
 
-#### When to use:
+#### When to use
 
 - Initial setup to choose a feature preset (minimal, lean, standard, full).
 - Enabling or disabling specific features with dependency checking.
 - Previewing changes before applying with dry-run mode.
 
-#### Presets:
+#### Presets
 
 | Preset     | Features | Description                                          |
 | ---------- | -------- | ---------------------------------------------------- |
@@ -1031,12 +1031,12 @@ These commands are available only as slash commands within AI coding tools. They
 | `standard` | 12       | **Default** — teams + quality + docs + security      |
 | `full`     | 20       | Everything including cost tracking, MCP, healthcheck |
 
-#### Key files:
+#### Key files
 
 - `.agentkit/spec/features.yaml` — Canonical registry of all kit features with dependencies
 - `.agentkit/engines/node/src/feature-manager.mjs` — Feature resolution engine
 
-#### CLI equivalents:
+#### CLI equivalents
 
 ```bash
 agentkit features                          # List features and status
@@ -1053,13 +1053,13 @@ agentkit features preset <name>            # Apply preset
 
 **One-line:** End-to-end tracing of a feature from spec definition through template rendering to generated output.
 
-#### When to use:
+#### When to use
 
 - Debugging why a feature's generated output looks wrong.
 - Understanding the full resolution chain for a specific feature.
 - Verifying template variable injection is correct.
 
-#### Flags:
+#### Flags
 
 | Flag               | Description                                    |
 | ------------------ | ---------------------------------------------- |
@@ -1074,7 +1074,7 @@ agentkit features preset <name>            # Apply preset
 
 **One-line:** Audit feature configuration for consistency, recommend features based on codebase analysis, and detect stale configs.
 
-#### Flags:
+#### Flags
 
 | Flag          | Description                                                      |
 | ------------- | ---------------------------------------------------------------- |
@@ -1089,13 +1089,13 @@ agentkit features preset <name>            # Apply preset
 
 **One-line:** Session-aware retrospective mode that reviews conversation history to extract issues encountered and lessons learned.
 
-#### When to use:
+#### When to use
 
 - End of a sprint or development session to capture institutional knowledge.
 - After resolving a difficult bug to document the debugging process.
 - To build a library of lessons for future sessions.
 
-#### New `/review` flags (this branch):
+#### New `/review` flags (this branch)
 
 | Flag                    | Description                                                          |
 | ----------------------- | -------------------------------------------------------------------- |
@@ -1103,7 +1103,7 @@ agentkit features preset <name>            # Apply preset
 | `--open-issues`         | Automatically file issues in external tracker for critical findings. |
 | `--dry-run`             | Preview findings without writing files or creating issues.           |
 
-#### Expanded review criteria (7-10, new):
+#### Expanded review criteria (7-10, new)
 
 | #   | Criterion                 | Description                                                 |
 | --- | ------------------------- | ----------------------------------------------------------- |
@@ -1112,7 +1112,7 @@ agentkit features preset <name>            # Apply preset
 | 9   | Bug Detection             | Identifies latent bugs and race conditions                  |
 | 10  | Enhancement Opportunities | Non-blocking improvement suggestions                        |
 
-#### Output locations:
+#### Output locations
 
 - `docs/history/issues/` — Records of issues encountered during sessions
 - `docs/history/lessons-learned/` — Lessons extracted from retrospectives
@@ -1127,7 +1127,7 @@ agentkit features preset <name>            # Apply preset
 
 **What it adds:** Automated merge conflict resolution system for generated files. Not a slash command, but a supporting system.
 
-#### Key components:
+#### Key components
 
 - `scripts/resolve-merge.sh` / `.ps1` — Cross-platform resolution script
 - `.github/workflows/merge-conflict-detection.yml` — CI workflow that detects conflicts on open PRs and posts resolution instructions

--- a/.agentkit/docs/guides/TEAM_GUIDE.md
+++ b/.agentkit/docs/guides/TEAM_GUIDE.md
@@ -135,7 +135,7 @@ This is the standard feature lifecycle from requirements to verification.
                                                                          |  8. Report coverage gaps
 ```
 
-#### What gets handed off:
+#### What gets handed off
 
 - Product to Backend/Frontend: PRD document with user stories, acceptance criteria, and priority.
 - Backend/Frontend to Testing: Feature branch with implementation and unit tests. Testing uses the acceptance criteria from the PRD to write verification tests.
@@ -170,7 +170,7 @@ This pattern is used for security hardening and vulnerability remediation.
                                                                     | 10. Approve for merge
 ```
 
-#### What gets handed off:
+#### What gets handed off
 
 - Security to Backend: Audit report with severity-classified findings, exact file/line references, and remediation guidance.
 - Backend to Quality: Branch with fixes, tests, and documentation updates. Quality verifies the fixes are correct and complete.

--- a/.agentkit/docs/guides/WORKFLOWS.md
+++ b/.agentkit/docs/guides/WORKFLOWS.md
@@ -46,14 +46,14 @@ Use this flow for medium-to-large features that touch multiple parts of the code
 /discover
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Scans the entire repository for languages, frameworks, build tools, and folder structure
 - Detects Node.js and Express (or whatever framework is present)
 - Identifies existing test frameworks (Vitest, Jest, etc.)
 - Creates or updates `AGENT_TEAMS.md` with team assignments based on your actual code
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## Repository Profile
@@ -87,13 +87,13 @@ Use this flow for medium-to-large features that touch multiple parts of the code
 /plan Add JWT-based user authentication with login and registration endpoints, password hashing with bcrypt, and a React login form
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Reads the codebase to understand existing patterns (routing style, middleware conventions, database layer)
 - Produces a structured plan with: goal, assumptions, ordered implementation steps, file touch list, validation commands, rollback plan, and risks
 - Does NOT write any code -- planning only
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## 1. Goal
@@ -155,7 +155,7 @@ Add JWT-based authentication with login (POST /api/auth/login) and registration
 /team-backend Implement auth service, login and registration endpoints, and JWT middleware per the plan above
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Reads the plan and the relevant source files
 - Creates the auth service with password hashing and token generation
@@ -165,7 +165,7 @@ Add JWT-based authentication with login (POST /api/auth/login) and registration
 - Runs the quality gate (format, lint, typecheck, test) on changed files
 - Stays within the backend scope -- does not touch frontend files
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## Backend Report
@@ -202,7 +202,7 @@ Add JWT-based authentication with login (POST /api/auth/login) and registration
 /team-frontend Implement login and registration forms that connect to the auth API endpoints
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Reads the API endpoints created by the backend team
 - Creates React components for Login and Registration pages
@@ -211,7 +211,7 @@ Add JWT-based authentication with login (POST /api/auth/login) and registration
 - Adds tests for the new components
 - Runs the quality gate on frontend files
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## Frontend Report
@@ -245,13 +245,13 @@ Add JWT-based authentication with login (POST /api/auth/login) and registration
 /check
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Runs the full quality gate across the entire project (not just the files changed by one team)
 - Executes in order: format check, lint, typecheck, unit tests, build
 - Reports any issues, including cross-team integration problems that individual team checks might miss
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## Quality Gate Results
@@ -277,14 +277,14 @@ Add JWT-based authentication with login (POST /api/auth/login) and registration
 /review
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Diffs all changes since the orchestration began
 - Reviews every changed file against six criteria: correctness, security, performance, tests and coverage, documentation and readability, compatibility and standards
 - Classifies findings by severity: CRITICAL, HIGH, MEDIUM, LOW
 - Produces a verdict: APPROVE, REQUEST_CHANGES, or NEEDS_DISCUSSION
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## Code Review
@@ -320,14 +320,14 @@ correct, passwords are properly hashed with bcrypt, and test coverage is thoroug
 /handoff
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Collects the current state: git branch, last commit, orchestrator state, events log
 - Writes a structured handoff document with: what was done, current blockers, next 3 actions, validation commands, and open risks
 - Saves the handoff to `docs/ai_handoffs/` (if the directory exists)
 - Logs the handoff event to `.claude/state/events.log`
 
-#### Expected output:
+##### Expected output
 
 ```text
 # Session Handoff
@@ -394,7 +394,7 @@ Use this flow for focused bug fixes where you already know the symptom. The emph
 /discover
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Scans the repository for database-related files, connection configuration, and ORM setup
 - Identifies the database stack (PostgreSQL + Prisma, MySQL + Knex, etc.)
@@ -417,7 +417,7 @@ PostgreSQL and we use Prisma. Please investigate the connection handling,
 pool configuration, and any timeout settings.
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Reads the database configuration files (Prisma schema, environment variables, connection string format)
 - Examines the connection pool settings
@@ -425,7 +425,7 @@ pool configuration, and any timeout settings.
 - Reviews error handling in the affected endpoint
 - Reports findings with specific file and line references
 
-#### Expected findings:
+#### Expected findings
 
 ```text
 Investigation Results:
@@ -458,7 +458,7 @@ Fix the database connection timeout issue:
 3. Add a connect_timeout=5 parameter to the DATABASE_URL
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Makes minimal, targeted changes to fix the specific issue
 - Updates the Prisma configuration with pool settings
@@ -473,13 +473,13 @@ Fix the database connection timeout issue:
 /check --fast
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Runs format, lint, and typecheck only (skips the full build to save time)
 - The `--fast` flag is designed for quick iterations during bug fixes
 - Confirms the fix compiles and passes static analysis
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## Quality Gate Results
@@ -509,14 +509,14 @@ Then run the full check to make sure nothing else broke:
 /review
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Diffs the changes you just made
 - Checks specifically for regressions: did the fix break any existing behavior?
 - Verifies the fix actually addresses the root cause (not just the symptom)
 - Checks for security implications of the changes
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## Code Review
@@ -552,7 +552,7 @@ backwards-compatible. Transaction error handling now properly releases connectio
 
 Total time: 5-10 minutes for a focused bug fix.
 
-#### Tips for fast bug fixes:
+#### Tips for fast bug fixes
 
 - Skip `/discover` if you already have a recent `AGENT_TEAMS.md`
 - Use `/check --fast` for quick iterations while developing the fix
@@ -579,25 +579,25 @@ Use this flow when you need a thorough understanding of a project's health, qual
 /project-review
 ```
 
-#### What the AI does
+##### What the AI does
 
 The `/project-review` command runs a comprehensive multi-phase analysis of the entire project. It combines several checks into a single, structured assessment:
 
-#### Phase A -- Discovery and Inventory:
+#### Phase A -- Discovery and Inventory
 
 - Full codebase scan (same as `/discover`)
 - Technology stack identification
 - Dependency inventory with version currency
 - Folder structure mapping
 
-#### Phase B -- Health Validation:
+#### Phase B -- Health Validation
 
 - Build status (same as `/healthcheck`)
 - Test suite status and coverage
 - Lint and typecheck status
 - Dependency vulnerability scan
 
-#### Phase C -- Code Quality Assessment:
+#### Phase C -- Code Quality Assessment
 
 - Architecture pattern analysis
 - Code duplication detection
@@ -605,14 +605,14 @@ The `/project-review` command runs a comprehensive multi-phase analysis of the e
 - Test quality evaluation
 - Documentation coverage
 
-#### Phase D -- Security Review:
+#### Phase D -- Security Review
 
 - OWASP top 10 check (same as `/security`)
 - Hardcoded secrets scan
 - Dependency vulnerability audit
 - Authentication flow review
 
-#### Expected output -- Findings Table:
+##### Expected output -- Findings Table
 
 ```text
 ## Project Review: my-project
@@ -664,7 +664,7 @@ Let's focus on the top 3 items: the SQL injection, the hardcoded JWT secret,
 and the missing payment tests. Deprioritize the lint debt for now.
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Acknowledges the priority adjustment
 - Focuses subsequent planning on the selected items
@@ -678,14 +678,14 @@ and the missing payment tests. Deprioritize the lint debt for now.
 /plan Fix the top 3 findings from the project review: SQL injection in user search, hardcoded JWT secret, and missing payment processing tests
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Creates a structured implementation plan for each finding
 - Orders the steps by dependency (security fixes first, then tests)
 - Identifies the specific files and lines to change
 - Provides validation commands for each fix
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## 1. Goal
@@ -721,7 +721,7 @@ From here, you can either delegate to teams or fix manually:
 /orchestrate Fix the SQL injection, hardcoded JWT secret, and add payment tests per the plan
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Enters the 5-phase lifecycle starting from Implementation (since discovery and planning are done)
 - Delegates the security fixes to the relevant team
@@ -745,7 +745,7 @@ From here, you can either delegate to teams or fix manually:
 
 Total time: 20-40 minutes for the full assessment, plus implementation time for fixes.
 
-#### Tips for project assessments:
+#### Tips for project assessments
 
 - Run `/project-review` with a fresh eye -- do not assume you know what it will find
 - Share the findings table with your team. It is a useful conversation starter about technical debt
@@ -781,13 +781,13 @@ Read the most recent handoff document from docs/ai_handoffs/ and
 summarize where we left off.
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Lists files in the `docs/ai_handoffs/` directory
 - Reads the most recent handoff (sorted by date)
 - Summarizes the key information: what was done, what is blocked, and what the next actions are
 
-#### Expected handoff content:
+#### Expected handoff content
 
 ```text
 # Session Handoff
@@ -832,14 +832,14 @@ summarize where we left off.
 /orchestrate --status
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Reads `.claude/state/orchestrator.json`
 - Reads the recent entries from `.claude/state/events.log`
 - Reports the current phase, active teams, completed work, and pending items
 - Does NOT make any changes -- this is read-only
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## Orchestrator Status
@@ -894,7 +894,7 @@ You can now pick up exactly where the previous session left off.
 /team-frontend Build the NotificationBell and NotificationList components, and the WebSocket client hook for real-time notification updates. The backend API is already complete -- see src/api/notifications.ts for the endpoints.
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Reads the handoff and orchestrator state for full context
 - Reads the backend API endpoints to understand the contract
@@ -903,7 +903,7 @@ You can now pick up exactly where the previous session left off.
 - Writes tests for all new components
 - Runs the quality gate on changed files
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## Frontend Report
@@ -956,13 +956,13 @@ Review all changes made across both sessions (backend + frontend).
 /handoff --save
 ```
 
-#### What the AI does with `--save`:
+##### What the AI does with `--save`
 
 - Writes the handoff document to console AND to `docs/ai_handoffs/`
 - Updates the orchestrator state to Phase 5 (Ship)
 - Logs the session completion to events.log
 
-#### Expected handoff:
+#### Expected handoff
 
 ```text
 # Session Handoff
@@ -1038,7 +1038,7 @@ Human-readable markdown files with structured summaries. These serve as the "col
 
 Total time: 10-15 minutes for the continuation session.
 
-#### Tips for multi-session work:
+#### Tips for multi-session work
 
 - Always run `/handoff` at the end of every session. Even if you plan to continue immediately, the handoff is your safety net
 - Read the handoff BEFORE checking orchestrator state. The handoff is written for humans and gives you context faster
@@ -1083,14 +1083,14 @@ Run a full quality gate to establish a passing baseline. Refactoring should star
 /plan Refactor src/services/orderService.ts into smaller modules: extract payment processing, inventory management, and notification logic into separate service files. Maintain all existing behavior and test coverage.
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Analyzes the existing file to identify logical boundaries
 - Maps all imports and dependents that reference `orderService`
 - Produces a plan with extraction steps, new file locations, and updated imports
 - Includes a validation strategy to confirm no behavior changes
 
-#### Expected plan highlights:
+#### Expected plan highlights
 
 ```text
 ## Steps
@@ -1114,7 +1114,7 @@ Run a full quality gate to establish a passing baseline. Refactoring should star
 /team-backend Refactor orderService.ts per the plan: extract paymentService, inventoryService, and notificationService. Update all imports. Do NOT change any test files -- all existing tests must pass as-is.
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Extracts each module one at a time, running tests after each extraction
 - Updates import paths in all dependent files
@@ -1145,7 +1145,7 @@ Review the changes specifically for correctness — are the extracted modules fu
 /handoff --save --tag refactoring
 ```
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## What Was Done
@@ -1195,7 +1195,7 @@ Use this flow when responding to security audit findings, penetration test repor
 /security
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Scans for OWASP Top 10 vulnerabilities
 - Checks dependency vulnerabilities via `npm audit` or equivalent
@@ -1203,7 +1203,7 @@ Use this flow when responding to security audit findings, penetration test repor
 - Reviews authentication and authorization flows
 - Reports findings by severity
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## Security Audit
@@ -1235,7 +1235,7 @@ Use this flow when responding to security audit findings, penetration test repor
 /team-security Fix the SQL injection vulnerability in src/api/search.ts, restrict CORS configuration to allowed origins, and add rate limiting to /api/auth/* endpoints
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Replaces raw SQL with parameterized queries
 - Configures CORS with an explicit allowlist read from environment variables
@@ -1251,7 +1251,7 @@ Use this flow when responding to security audit findings, penetration test repor
 /security --scan-type deps --fix
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Identifies packages with known vulnerabilities
 - Upgrades to patched versions where available
@@ -1328,14 +1328,14 @@ Run discovery and healthcheck to establish a baseline. You need to know what is 
 /plan Upgrade React from v18 to v19. Identify all breaking changes, deprecated APIs in use, and files that need migration. Include a rollback strategy.
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Reviews the changelog and migration guide for the target version
 - Scans the codebase for deprecated patterns and breaking change impacts
 - Produces a file-by-file migration plan
 - Lists specific API changes (e.g., removed hooks, changed signatures)
 
-#### Expected plan highlights:
+#### Expected plan highlights
 
 ```text
 ## Breaking Changes Affecting This Project
@@ -1377,7 +1377,7 @@ Option B — use a single team for a more controlled approach:
 /team-frontend Upgrade React from v18 to v19. Start by updating package.json and running pnpm install, then migrate each breaking change one at a time, running tests after each change.
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Updates the dependency version in `package.json`
 - Applies each migration step incrementally
@@ -1429,7 +1429,7 @@ Preview what would be deployed to catch any deployment-specific issues from the 
 /handoff --save --tag dependency-upgrade
 ```
 
-#### Expected output:
+##### Expected output
 
 ```text
 ## What Was Done
@@ -1464,7 +1464,7 @@ Preview what would be deployed to catch any deployment-specific issues from the 
 /handoff --save      Document the session
 ```
 
-#### Tips for major dependency upgrades:
+#### Tips for major dependency upgrades
 
 - Always start from a clean, passing baseline. Run `/healthcheck` first.
 - Make changes incrementally and test after each step. Do not update everything at once.
@@ -1518,7 +1518,7 @@ evaluation:
 /infra-eval
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Scans the repository for evidence across all 8 dimensions
 - Scores each dimension on a 0–5 scale
@@ -1590,7 +1590,7 @@ Use this flow when onboarding a new repository, when a solo developer wants to d
 /feature-review
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Lists all features by category with current enabled/disabled status
 - Highlights dependency issues or conflicts
@@ -1598,7 +1598,7 @@ Use this flow when onboarding a new repository, when a solo developer wants to d
 
 #### Step 2: Choose a Preset or Customize
 
-#### Option A — Apply a preset:
+#### Option A — Apply a preset
 
 ```text
 /feature-configure
@@ -1606,7 +1606,7 @@ Use this flow when onboarding a new repository, when a solo developer wants to d
 
 The AI walks you through an interactive preset selection with diff preview.
 
-#### Option B — CLI direct:
+#### Option B — CLI direct
 
 ```bash
 agentkit features preset lean              # Solo developer, no team overhead
@@ -1625,7 +1625,7 @@ agentkit sync                              # Regenerate configs with new feature
 /feature-review --audit
 ```
 
-#### What the AI does
+##### What the AI does
 
 - Checks that every enabled feature has corresponding generated files
 - Flags stale configurations (enabled features with missing output)
@@ -1637,7 +1637,7 @@ agentkit sync                              # Regenerate configs with new feature
 /feature-flow team-orchestration --show-output
 ```
 
-#### What the AI does for tracing
+##### What the AI does for tracing
 
 - Shows the full resolution chain: spec definition → overlay config → template variables → generated output
 - Useful for debugging why a command or agent is missing from generated configs
@@ -1688,7 +1688,7 @@ Finish whatever task you were working on. The retrospective works best when ther
 /review --focus=retrospective
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Reviews the full conversation history for the current session
 - Identifies issues encountered (bugs, blockers, misunderstandings, tooling failures)
@@ -1751,7 +1751,7 @@ Use this flow when you want consistent visual identity in your editor workspace,
 /brand --init
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Creates `.agentkit/spec/brand.yaml` with a template brand identity
 - Creates `.agentkit/spec/editor-theme.yaml` with default color mappings
@@ -1774,7 +1774,7 @@ Edit `.agentkit/spec/brand.yaml` with your brand's colors, fonts, and identity a
 /brand --contrast
 ```
 
-#### What the AI does:
+##### What the AI does
 
 - Validates required fields and color format
 - Previews the resolved color palette

--- a/.github/workflows/quality-lint.yml
+++ b/.github/workflows/quality-lint.yml
@@ -2,7 +2,9 @@ name: Quality Lint
 
 # Runs markdown lint checks on PRs. Prettier is checked by the `Prettier` job in
 # ci.yml — it needs to run on every change, not just this workflow's path filters.
-# Required on main (hard error). Warning-only on dev (surfaces issues without blocking).
+# Hard error on every branch. This previously errored only when the PR targeted
+# `main`, which under a dev-based release train meant the gate could fire only on
+# the aggregate promote-to-main PR — the worst possible place to find lint debt.
 # Split from ci.yml so branch protection can enforce separately per branch.
 
 on:
@@ -54,8 +56,6 @@ jobs:
 
       - name: Report results
         if: steps.mdlint.outcome == 'failure'
-        env:
-          TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: |
           {
             echo "## Markdown Lint Issues"
@@ -70,9 +70,5 @@ jobs:
             head -50 /tmp/mdlint-output.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          if [ "$TARGET_BRANCH" = "main" ]; then
-            echo "::error::Markdown lint failed. Fix lint issues before merging to main."
-            exit 1
-          else
-            echo "::warning::Markdown lint issues found. These must be fixed before merging to main."
-          fi
+          echo "::error::Markdown lint failed."
+          exit 1

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "MD013": false,
   "MD033": false,
-  "MD041": false
+  "MD041": false,
+  "MD024": { "siblings_only": true }
 }


### PR DESCRIPTION
Completes #604. That PR hardened the documentation gates but deliberately left `quality-lint.yml` alone, because `pnpm lint:md` reported **434 violations across 14 files** — hardening it then would have turned red every PR touching `**/*.md`, `.markdownlint*`, `.prettierrc*` or `package.json`, including every dependabot bump.

Now **0 errors across 85 files**, so the gate lands green.

## How the 434 were cleared

| Step | Cleared | Approach |
| --- | --- | --- |
| `MD024: siblings_only` | 202 | Most duplicate headings were repeated subsections under *different* parents (`Summary`/`Motivation` per issue, `Fix` per problem). That is precisely what the option exists for — renaming 229 headings would have been pure churn. |
| `markdownlint --fix` | 205 | All MD026 trailing punctuation. Mechanical: every changed line is a heading, and each is identical once trailing punctuation is stripped — verified, nothing else rode along. |
| Heading nesting | 29 | All in one file. |

The last 29 were structural rather than cosmetic. In `WORKFLOWS.md`, `What the AI does` and `Expected output` sat at `####` — the *same level* as the `#### Step N:` heading they describe — so they were siblings, not children:

```text
#### Step 2: Plan the Implementation
#### What the AI does        <- sibling of the step
#### Expected output
```

Demoted to `#####` so they nest under their step. Correct document structure, and the duplicates stop being siblings. 50 headings moved; verified 0 orphaned (no `#####` without a `####` parent above it).

## A detail worth noting

MD026 and MD024 interact. Stripping a trailing colon turned `What the AI does:` into a second `What the AI does`, so the auto-fix *raised* the MD024 count from 27 to 29 before the nesting fix removed them. Running the two passes in the other order would have looked like the fix regressed.

## The gate

With the tree clean, `quality-lint.yml` now errors on every branch instead of only when the PR targets `main` — the change held back from #604.

Test plan: `pnpm -C .agentkit lint:md` → 0 errors; Prettier verified on all modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a broad set of skills and command guidance for discovery, validation, diagnostics, project reviews, backlog management, team workflows, and status reporting.
  - Added lifecycle safeguards for sensitive files, destructive commands, budgets, pushes, build checks, and uncommitted changes.
  - Added session-start context and repository health information.

- **Documentation**
  - Standardized heading formatting across guides and references.
  - Added a skills inventory report.

- **Chores**
  - Markdown linting now consistently fails on errors.
  - Refined Markdown heading validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->