### PR TITLE
docs(handoffs): record the documentation-gate work and two agent errors

### DIFF
--- a/docs/handoffs/2026-08-11.md
+++ b/docs/handoffs/2026-08-11.md
@@ -14,6 +14,8 @@
 | #600 | reverse-merge `main` into `dev`   | `396973a6` |
 | #602 | eight Codex review findings fixed | `b2f9b33b` |
 | #601 | **`dev` → `main` promotion**      | `cf7d98d7` |
+| #604 | doc gates enforce on every branch | `fcaa414b` |
+| #605 | 434 markdown violations → 0       | `3c64e94e` |
 
 Closed unmerged: #598 (conflicted), #599 (rejected by the dev-only policy gate). Both carry
 comments recording where their findings were resolved.
@@ -157,10 +159,70 @@ imports do not break module loading). And the obvious fix for the peer mismatch 
 worse: bumping to `^4.1.0` resolves 4.1.10, which peers exactly on 4.1.10. Both manifests
 had to be pinned to 4.1.0.
 
+## Part 4 — Documentation Gates and Lint Debt
+
+Two more gates were found in the same "looks enforcing, structurally cannot" family.
+
+**Gates that could only fire on the release PR (#604).** `documentation-quality.yml`,
+`documentation-validation.yml` and `quality-lint.yml` all errored only when
+`github.base_ref == 'main'` and warned otherwise. Under a dev-based release train every
+feature PR targets `dev`, so those gates could fire only on the aggregate promote-to-main
+PR — which this session made 747 files. Now a hard error on every branch.
+
+`check-documentation-requirement.sh` also honoured a `STRICT` env var and advertised a
+`--strict` flag in its header. **No workflow set `STRICT` and no argv parsing for
+`--strict` existed**, so the step could not fail under any invocation. Removed rather
+than wired up, and the header now states the script is advisory and always exits 0.
+
+Each gate was measured against `dev` before hardening, so none landed red:
+`validate-documentation.sh` exit 0, `validate-numbering.sh` exit 0, and
+`markdownlint docs/history/**` clean after tagging two unlabelled code fences `text`.
+
+**434 markdown violations cleared (#605).** `quality-lint.yml` was deliberately held back
+from #604 because `pnpm lint:md` reported 434 violations across 14 files, and that
+workflow fires on any PR touching `**/*.md` or `package.json` — hardening it then would
+have blocked nearly every PR, including dependabot. Cleared to zero:
+
+- `MD024: siblings_only` in `.markdownlint.json` — 202 of the 229 duplicate headings were
+  repeated subsections under different parents, which is what the option is for.
+- `markdownlint --fix` — all 205 MD026 trailing-punctuation hits.
+- The last 29 were structural, all in `WORKFLOWS.md`: `What the AI does` and
+  `Expected output` sat at `####`, the same level as the `#### Step N:` heading they
+  describe, so they were siblings rather than children. Demoted to `#####`; 50 headings
+  moved, 0 orphaned.
+
+The two rules interact — stripping a trailing colon turned `What the AI does:` into a
+second `What the AI does`, so the auto-fix raised MD024 from 27 to 29 before the nesting
+fix removed them. Run in the other order it looks like the fix regressed.
+
+## Incident — Two Agent Errors Worth Recording
+
+Both were caught, but the second nearly lost work.
+
+**`git add -A` swept in parked files.** The first #605 commit included all 45 files from
+baton `4f631ba5` — the migration pile explicitly parked for a maintainer decision. CI
+caught it: `powershell-encoding.test.mjs` failed six times because those `.codex/*.ps1`
+files lack the UTF-8 BOM that retort's own `writeScaffoldOutputs` applies — direct
+evidence they come from a different tool. The commit was rewritten to the intended 10
+files. Stage explicitly; `-A` in this repo will pick up that pile every time.
+
+**`git branch -D` deleted a branch carrying someone else's commit.** `fix/markdown-lint-debt`
+had an unmerged commit (`d2a3acd3`) authored by the maintainer on top of the agent's.
+Force-deleting orphaned it, and the following `git checkout dev` removed those files from
+the working tree because they were tracked in the deleted branch's HEAD. Recovered from
+reflog and the branch was recreated. Use `git branch -d` and investigate the refusal.
+
+Note `d2a3acd3` is titled "feat(test): add capacity preflight for full test-suite runs"
+but contains only the 45 migration files — no preflight code exists anywhere in the repo,
+on any branch, or in any stash. Flagged on baton `4f631ba5`.
+
 ## Notes for the Next Session
 
 - Engine test suite baseline on this Windows host: **~135–142s**, green. If it
   drifts well past that, suspect subprocess spawns rather than logic.
+- **`dev` still lacks `Prettier` as a required check** while `main` now has it. Both
+  governance scripts already declare the correct set, so `dev`'s live config is stale —
+  see baton `8dc69b4a`.
 - **`.agentkit/pnpm-lock.yaml` is not dead weight.** This is a pnpm workspace, so a normal
   install writes only the root lockfile — but `fresh-install.test.mjs` copies `.agentkit`
   with no workspace parent and resolves it standalone. After changing `.agentkit/package.json`,


### PR DESCRIPTION
Third and final extension of the 2026-08-11 handoff. It previously stopped at the release; #604 and #605 landed after that and were unrecorded, so archiving now would leave the account incomplete.

**Part 4 — documentation gates and lint debt.** Two more gates in the same 'looks enforcing, structurally cannot' family as the `branch-rules` context: doc gates that errored only on main-targeted PRs (so under a dev-based release train they could fire only on the 747-file promotion PR), and a `STRICT`/`--strict` mechanism in `check-documentation-requirement.sh` that no workflow set and no argv parsing implemented. Plus how the 434 markdown violations were cleared to zero, including the detail that MD026 and MD024 interact — stripping a trailing colon *creates* a duplicate heading, so running the passes in the wrong order looks like a regression.

**Incident section — two agent errors.** Recorded because both are repeatable:

- `git add -A` swept the 45 parked migration files into a commit. CI caught it via `powershell-encoding.test.mjs` — those `.codex/*.ps1` files lack the BOM retort's own writer applies, which is itself evidence they came from a different tool.
- `git branch -D` deleted a branch carrying an **unmerged maintainer commit**. Recovered from reflog and the branch restored, but the following `git checkout dev` had already removed those files from the working tree. Use `-d` and investigate the refusal.

Also notes that `dev` still lacks `Prettier` as a required check while `main` now has it (baton `8dc69b4a`).

Docs only.

Test plan: n/a — markdown only; Prettier verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)