### PR TITLE
docs(agents): add the startup-context budget guide

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -3,5 +3,7 @@
 This category catalogs all agent personas, roles, and team mappings for Retort. See:
 
 - [catalog.md](catalog.md)
+- [context-budget.md](context-budget.md) — what a session pays for before doing any work, and
+  where each kind of instruction belongs so that cost stays proportionate
 
 Add new agent docs here as needed.

--- a/docs/agents/context-budget.md
+++ b/docs/agents/context-budget.md
@@ -16,16 +16,16 @@ rule or agent.
 ## The multiplier
 
 Startup context is not paid once. A subagent gets a fresh context window — it does **not**
-inherit the parent conversation — but it *does* re-pay the global overhead:
+inherit the parent conversation — but it _does_ re-pay the global overhead:
 
-| Component                          | Re-paid per subagent dispatch?                          |
-| ---------------------------------- | -------------------------------------------------------- |
-| `CLAUDE.md`, `AGENTS.md`           | **Yes**                                                  |
-| `.claude/rules/`                   | **Yes**                                                  |
-| Directory-scoped `CLAUDE.md`       | Only when files in that directory are touched            |
-| Agent frontmatter (the roster)     | No — but paid every session at startup                   |
-| Agent **body**                     | Only on dispatch                                         |
-| MCP tool names                     | Gated by that agent's `tools:` allowlist                 |
+| Component                      | Re-paid per subagent dispatch?                |
+| ------------------------------ | --------------------------------------------- |
+| `CLAUDE.md`, `AGENTS.md`       | **Yes**                                       |
+| `.claude/rules/`               | **Yes**                                       |
+| Directory-scoped `CLAUDE.md`   | Only when files in that directory are touched |
+| Agent frontmatter (the roster) | No — but paid every session at startup        |
+| Agent **body**                 | Only on dispatch                              |
+| MCP tool names                 | Gated by that agent's `tools:` allowlist      |
 
 A session that dispatches six specialists pays for root memory **seven times**. That single
 fact should decide where every piece of instruction goes.
@@ -33,13 +33,13 @@ fact should decide where every piece of instruction goes.
 ## Where things belong
 
 | If it is…                              | Put it in…            | Cost                        |
-| ---------------------------------------- | --------------------- | --------------------------- |
-| True everywhere, needed often            | Root `CLAUDE.md`      | Every session × every agent |
-| An enforceable rule, needed everywhere   | `.claude/rules/`      | Every session × every agent |
-| True only under one directory            | `<dir>/CLAUDE.md`     | Only sessions touching it   |
-| Reference, looked up occasionally        | `docs/`               | Only when read              |
-| How one agent does its job               | That agent's **body** | Only on dispatch            |
-| Why a rule exists, a post-mortem         | Traces / history      | Only when read              |
+| -------------------------------------- | --------------------- | --------------------------- |
+| True everywhere, needed often          | Root `CLAUDE.md`      | Every session × every agent |
+| An enforceable rule, needed everywhere | `.claude/rules/`      | Every session × every agent |
+| True only under one directory          | `<dir>/CLAUDE.md`     | Only sessions touching it   |
+| Reference, looked up occasionally      | `docs/`               | Only when read              |
+| How one agent does its job             | That agent's **body** | Only on dispatch            |
+| Why a rule exists, a post-mortem       | Traces / history      | Only when read              |
 
 The recurring mistake is putting the last three categories in the first two.
 
@@ -62,13 +62,13 @@ it to ~14 KB with no loss of capability.
 
 ### Rules carry rules; rationale goes elsewhere
 
-A post-mortem explaining *why* a rule exists is read once and paid on every dispatch. Keep the
+A post-mortem explaining _why_ a rule exists is read once and paid on every dispatch. Keep the
 obligation in `.claude/rules/`, and link the trace for the reasoning.
 
 ### Every agent declares an explicit `tools:` allowlist
 
 The key is **`tools:`**. A file using `allowed-tools:` is silently ignored, and that agent is
-then granted the *entire* tool registry — including every deferred MCP name. This was live in
+then granted the _entire_ tool registry — including every deferred MCP name. This was live in
 mystira-workspace on its most frequently dispatched exploration agent, which made it the single
 largest source of per-dispatch overhead. It failed silently in both directions: nothing warned
 that the key was wrong, and nothing warned that the agent was over-privileged.
@@ -86,9 +86,9 @@ automated reviewer caught it. Scan for **the tool names each server provides**, 
 
 ### Keep the default MCP config lean
 
-Tool deferral keeps *schemas* out of context, but names still cost. A server earns a place in
+Tool deferral keeps _schemas_ out of context, but names still cost. A server earns a place in
 the always-loaded config only if it offers reach the built-ins do not. A filesystem MCP server
-alongside Read/Write/Edit costs names *and* a decision on every file operation.
+alongside Read/Write/Edit costs names _and_ a decision on every file operation.
 
 Put situational servers behind a profile loaded per session with `--mcp-config`, and register
 each server exactly once — split by secret, with token-reading servers in settings and
@@ -96,13 +96,13 @@ secret-free stdio servers in the committed config.
 
 ### Aggregation is not context reduction
 
-A gateway re-exporting N servers still surfaces N × tools. Only a task-shaped *facade* reduces
+A gateway re-exporting N servers still surfaces N × tools. Only a task-shaped _facade_ reduces
 the count, and it trades away the tool descriptions the model uses to choose correctly. Reach
 for denial, lean defaults, and per-agent allowlists first.
 
 ### Scope only as a relocation
 
-Add a directory-scoped `CLAUDE.md` when you are moving instruction *out of* something
+Add a directory-scoped `CLAUDE.md` when you are moving instruction _out of_ something
 always-loaded. Creating one for content that was not previously in root **adds** cost for every
 session in that directory.
 
@@ -114,12 +114,12 @@ Measured against `dev` at `871b6b7` on 2026-08-13 (identical on `main`). Re-meas
 
 ### Always-loaded memory is ~95 KB
 
-| File                     | Bytes      |
-| ------------------------ | ---------- |
-| `CLAUDE.md`              | 12,289     |
-| `AGENTS.md`              | 2,853      |
-| `.claude/rules/**/*.md`  | 80,075     |
-| **Total**                | **95,217** |
+| File                    | Bytes      |
+| ----------------------- | ---------- |
+| `CLAUDE.md`             | 12,289     |
+| `AGENTS.md`             | 2,853      |
+| `.claude/rules/**/*.md` | 80,075     |
+| **Total**               | **95,217** |
 
 Roughly 24k tokens before any work begins, re-paid on every subagent dispatch.
 

--- a/docs/agents/context-budget.md
+++ b/docs/agents/context-budget.md
@@ -53,12 +53,19 @@ Only frontmatter loads at startup; the body loads on dispatch. A `description:` 
 routing entry — domain, trigger, and sibling disambiguation where that is load-bearing. Worked
 examples belong in the body under a `## When to invoke` heading.
 
-**Retort already follows this** — 27 agents, ~712 bytes of frontmatter each, zero `<example>`
-blocks. It is written down here so onboarded projects inherit the convention rather than
-rediscovering it. For contrast, mystira-workspace had grown three to five worked example
-dialogues per description: 47,894 bytes of routing index paid every session, while 876 KB of
-actual agent knowledge sat correctly deferred in the bodies. Compacting to routing entries cut
-it to ~14 KB with no loss of capability.
+For contrast, mystira-workspace had grown three to five worked example dialogues per
+description: 47,894 bytes of routing index paid every session, while 876 KB of actual agent
+knowledge sat correctly deferred in the bodies. Compacting to routing entries cut it to ~14 KB
+with no loss of capability.
+
+**Retort partially follows this.** All 27 `agents/*.md` carry an `Examples:` list inside the
+frontmatter — trigger phrasings rather than full dialogues, which is why the roster is
+comparatively light at ~712 bytes per agent. But they are still worked examples living in the
+index, and the convention above says they belong in the body. Moving them is the same change
+mystira-workspace made, at a smaller scale.
+
+Note this is _not_ currently a startup cost — see "The roster is not registered" below — but it
+becomes one the moment that is fixed.
 
 ### Rules carry rules; rationale goes elsewhere
 
@@ -112,7 +119,7 @@ session in that directory.
 
 Measured against `dev` at `871b6b7` on 2026-08-13 (identical on `main`). Re-measure before acting.
 
-### Always-loaded memory is ~95 KB
+### Memory files total ~95 KB
 
 | File                    | Bytes      |
 | ----------------------- | ---------- |
@@ -122,6 +129,26 @@ Measured against `dev` at `871b6b7` on 2026-08-13 (identical on `main`). Re-meas
 | **Total**               | **95,217** |
 
 Roughly 24k tokens before any work begins, re-paid on every subagent dispatch.
+
+This counts memory files only. The agent roster is the other startup contributor, and it is
+covered separately below because in this repository it currently costs nothing — for a reason
+worth fixing.
+
+### The roster is not registered
+
+None of the 39 `.claude/agents/*.md` files carry YAML frontmatter — they begin with an HTML
+comment banner and a `#` heading. Claude Code registers a subagent from its frontmatter `name`
+and `description`, so as written **none of them register**, and ~200 KB of agent personas is
+inert rather than dispatchable.
+
+The properly-formed definitions live in `agents/*.md` at the repo root — 27 files with
+`description`, `model` and `tools` — which is not a directory Claude Code reads. Both are
+generated: `platform-syncer.mjs` writes `.claude/agents/<id>.md` from the agents spec.
+
+So the roster costs 0 bytes at startup today, and that is the symptom, not the win. Confirm
+against a live session (`/agents`, or check whether the personas are dispatchable at all)
+before acting — if they are in fact reachable by some path not visible in the repo, this
+finding is void and the 27 frontmatter blocks become a real ~19 KB startup cost instead.
 
 ### Ten rules files are duplicated across two directories, with divergent content
 
@@ -142,12 +169,42 @@ of the pairs are identical**:
 | `typescript.md`            | 1,529            | 4,147                      |
 
 This is a **correctness problem before it is a context problem**: there are two versions of the
-testing rule and two of the security rule, and nothing indicates which governs. Worth resolving
-regardless of the token cost.
+testing rule and two of the security rule, and nothing indicates which governs.
 
-**Verify first** whether the loader recurses into `.claude/rules/languages/` — check `/context`
-in a live session. If it does not, the subdirectory reads as authoritative while being inert;
-if it does, every session pays for both copies.
+**Neither copy is stale — both are generated, from two different sources.** `synchronize.mjs`
+runs two tasks per target under the `coding-rules` feature flag:
+
+| Generator call             | Source                                   | Output                     |
+| -------------------------- | ---------------------------------------- | -------------------------- |
+| `syncDirectCopy`           | `.agentkit/templates/claude/rules/` (13) | `.claude/rules/*.md`       |
+| `syncLanguageInstructions` | `.agentkit/spec/rules.yaml`              | `.claude/rules/languages/` |
+
+The two sets were never meant to overlap, but ten domain names now appear in both. The split is:
+
+- **Both** (10): agent-conduct, ci-cd, dependency-management, documentation, git-workflow, iac,
+  security, template-protection, testing, typescript
+- **Template only** (5): agent-delegation, hookify, pr-base-branch, quality, worktree-isolation
+- **Spec only** (3): ai-cost-ops, finops, plus the generated `README.md`
+
+The two versions are also structurally different, not near-duplicates. `.claude/rules/testing.md`
+is prose (`## Test Pyramid`, `## Coverage`, `## Mocking & Isolation`); the spec-generated one is
+schema-shaped (`## Applies To`, `## Enforcement Rules`, `## Advisory Rules`). They are different
+documents about the same subject.
+
+**The fix does not belong in the generated files** — every one is marked `DO NOT EDIT` and would
+be restored by the next `pnpm --dir .agentkit retort:sync`. It belongs in `.agentkit`, and it is
+a design decision for the maintainers:
+
+1. **Spec wins** — drop the 10 colliding files from `templates/claude/rules/`, keeping the 5
+   template-only ones. Makes `rules.yaml` the single source for any domain it covers.
+2. **Templates win** — drop those domains from `rules.yaml`, keeping it for genuine
+   language rules. Note the directory is named `languages/` but already carries non-language
+   domains (testing, iac, finops), which is what let the collision happen.
+3. **Namespace the output** — keep both and stop the name collision, accepting that two
+   documents cover each domain.
+
+Also verify whether the loader recurses into `.claude/rules/languages/`, since that decides
+whether the duplicate is inert-but-authoritative-looking or genuinely charged twice per session.
 
 ### No directory-scoped `CLAUDE.md`
 
@@ -158,14 +215,20 @@ Only the root file and a template. Candidates, if any guidance is subtree-specif
 
 ## Suggested sequence
 
-1. Resolve the duplicated rules directories — correctness first, context second.
-2. Measure `/context` before and after; record the number.
-3. Move rationale and post-mortems out of `.claude/rules/` into docs or history.
-4. Add two mechanical checks to the quality gates so onboarded projects cannot regress:
-   - an agent file using `allowed-tools:` instead of `tools:`, or declaring no tools at all
+1. **Confirm the roster registers at all.** Everything else is secondary if 39 agent files are
+   inert. Fix in `platform-syncer.mjs` by emitting `name`/`description` frontmatter.
+2. **Resolve the duplicated rules directories** — pick one of the three options above and change
+   `.agentkit`, not the generated output. Correctness first, context second.
+3. Measure `/context` before and after; record the number.
+4. Move rationale and post-mortems out of `.claude/rules/` into docs or history.
+5. Move the `Examples:` trigger lists from `agents/*.md` frontmatter into the bodies — after
+   step 1, since that is when they start costing anything.
+6. Add three mechanical checks to the quality gates so onboarded projects cannot regress:
+   - an agent file with no frontmatter, or using `allowed-tools:` instead of `tools:`, or
+     declaring no tools at all
    - an agent body referencing a tool outside its own allowlist (match on server tool names,
      not just the `mcp__` prefix)
-5. Keep the lean-description convention documented, since Retort already gets it right.
+   - a generated filename colliding across two generator outputs
 
 ## Checking the budget
 

--- a/docs/agents/context-budget.md
+++ b/docs/agents/context-budget.md
@@ -1,0 +1,182 @@
+# Startup context budget
+
+What a session pays for before it has done any work — and where each kind of instruction
+should live so that cost stays proportionate.
+
+This matters more for Retort than for any single project. Retort is the scaffolding other
+repos inherit: a convention that wastes 10k tokens per session costs that once here, and once
+again in every project Retort onboards.
+
+Ported from a startup-context reduction in `phoenixvc/mystira-workspace` (2026-08-13), which
+cut its always-loaded footprint from 86,073 to 31,184 bytes (63%) without dropping a single
+rule or agent.
+
+---
+
+## The multiplier
+
+Startup context is not paid once. A subagent gets a fresh context window — it does **not**
+inherit the parent conversation — but it *does* re-pay the global overhead:
+
+| Component                          | Re-paid per subagent dispatch?                          |
+| ---------------------------------- | -------------------------------------------------------- |
+| `CLAUDE.md`, `AGENTS.md`           | **Yes**                                                  |
+| `.claude/rules/`                   | **Yes**                                                  |
+| Directory-scoped `CLAUDE.md`       | Only when files in that directory are touched            |
+| Agent frontmatter (the roster)     | No — but paid every session at startup                   |
+| Agent **body**                     | Only on dispatch                                         |
+| MCP tool names                     | Gated by that agent's `tools:` allowlist                 |
+
+A session that dispatches six specialists pays for root memory **seven times**. That single
+fact should decide where every piece of instruction goes.
+
+## Where things belong
+
+| If it is…                              | Put it in…            | Cost                        |
+| ---------------------------------------- | --------------------- | --------------------------- |
+| True everywhere, needed often            | Root `CLAUDE.md`      | Every session × every agent |
+| An enforceable rule, needed everywhere   | `.claude/rules/`      | Every session × every agent |
+| True only under one directory            | `<dir>/CLAUDE.md`     | Only sessions touching it   |
+| Reference, looked up occasionally        | `docs/`               | Only when read              |
+| How one agent does its job               | That agent's **body** | Only on dispatch            |
+| Why a rule exists, a post-mortem         | Traces / history      | Only when read              |
+
+The recurring mistake is putting the last three categories in the first two.
+
+---
+
+## Conventions
+
+### Agent frontmatter is an index, not documentation
+
+Only frontmatter loads at startup; the body loads on dispatch. A `description:` should be one
+routing entry — domain, trigger, and sibling disambiguation where that is load-bearing. Worked
+examples belong in the body under a `## When to invoke` heading.
+
+**Retort already follows this** — 27 agents, ~712 bytes of frontmatter each, zero `<example>`
+blocks. It is written down here so onboarded projects inherit the convention rather than
+rediscovering it. For contrast, mystira-workspace had grown three to five worked example
+dialogues per description: 47,894 bytes of routing index paid every session, while 876 KB of
+actual agent knowledge sat correctly deferred in the bodies. Compacting to routing entries cut
+it to ~14 KB with no loss of capability.
+
+### Rules carry rules; rationale goes elsewhere
+
+A post-mortem explaining *why* a rule exists is read once and paid on every dispatch. Keep the
+obligation in `.claude/rules/`, and link the trace for the reasoning.
+
+### Every agent declares an explicit `tools:` allowlist
+
+The key is **`tools:`**. A file using `allowed-tools:` is silently ignored, and that agent is
+then granted the *entire* tool registry — including every deferred MCP name. This was live in
+mystira-workspace on its most frequently dispatched exploration agent, which made it the single
+largest source of per-dispatch overhead. It failed silently in both directions: nothing warned
+that the key was wrong, and nothing warned that the agent was over-privileged.
+
+### An agent must never be instructed to call a tool outside its allowlist
+
+Six agents in mystira-workspace had bodies invoking MCP tools their own frontmatter blocked.
+The most costly was its project-management agent: coordination through the shared task graph
+was its entire reason for existing, and every call it made was refused. Two others pointed at a
+server listed in `deniedMcpServers`.
+
+Note that a purely textual check is not enough. Scanning bodies for literal `mcp__` strings
+misses agents that describe a server in prose — that false negative hid a real bug until an
+automated reviewer caught it. Scan for **the tool names each server provides**, not the prefix.
+
+### Keep the default MCP config lean
+
+Tool deferral keeps *schemas* out of context, but names still cost. A server earns a place in
+the always-loaded config only if it offers reach the built-ins do not. A filesystem MCP server
+alongside Read/Write/Edit costs names *and* a decision on every file operation.
+
+Put situational servers behind a profile loaded per session with `--mcp-config`, and register
+each server exactly once — split by secret, with token-reading servers in settings and
+secret-free stdio servers in the committed config.
+
+### Aggregation is not context reduction
+
+A gateway re-exporting N servers still surfaces N × tools. Only a task-shaped *facade* reduces
+the count, and it trades away the tool descriptions the model uses to choose correctly. Reach
+for denial, lean defaults, and per-agent allowlists first.
+
+### Scope only as a relocation
+
+Add a directory-scoped `CLAUDE.md` when you are moving instruction *out of* something
+always-loaded. Creating one for content that was not previously in root **adds** cost for every
+session in that directory.
+
+---
+
+## Audit of this repository
+
+Measured against `dev` at `871b6b7` on 2026-08-13 (identical on `main`). Re-measure before acting.
+
+### Always-loaded memory is ~95 KB
+
+| File                     | Bytes      |
+| ------------------------ | ---------- |
+| `CLAUDE.md`              | 12,289     |
+| `AGENTS.md`              | 2,853      |
+| `.claude/rules/**/*.md`  | 80,075     |
+| **Total**                | **95,217** |
+
+Roughly 24k tokens before any work begins, re-paid on every subagent dispatch.
+
+### Ten rules files are duplicated across two directories, with divergent content
+
+`.claude/rules/` and `.claude/rules/languages/` both contain files of the same name, and **none
+of the pairs are identical**:
+
+| File                       | `.claude/rules/` | `.claude/rules/languages/` |
+| -------------------------- | ---------------- | -------------------------- |
+| `agent-conduct.md`         | 2,020            | 3,201                      |
+| `ci-cd.md`                 | 1,352            | 2,513                      |
+| `dependency-management.md` | 1,454            | 2,794                      |
+| `documentation.md`         | 1,650            | 2,975                      |
+| `git-workflow.md`          | 2,248            | 4,378                      |
+| `iac.md`                   | 2,973            | 6,484                      |
+| `security.md`              | 1,655            | 2,633                      |
+| `template-protection.md`   | 2,870            | 2,228                      |
+| `testing.md`               | 3,250            | 5,141                      |
+| `typescript.md`            | 1,529            | 4,147                      |
+
+This is a **correctness problem before it is a context problem**: there are two versions of the
+testing rule and two of the security rule, and nothing indicates which governs. Worth resolving
+regardless of the token cost.
+
+**Verify first** whether the loader recurses into `.claude/rules/languages/` — check `/context`
+in a live session. If it does not, the subdirectory reads as authoritative while being inert;
+if it does, every session pays for both copies.
+
+### No directory-scoped `CLAUDE.md`
+
+Only the root file and a template. Candidates, if any guidance is subtree-specific: `infra/`,
+`src/`, `skills/`. Apply the relocation test above before adding any.
+
+---
+
+## Suggested sequence
+
+1. Resolve the duplicated rules directories — correctness first, context second.
+2. Measure `/context` before and after; record the number.
+3. Move rationale and post-mortems out of `.claude/rules/` into docs or history.
+4. Add two mechanical checks to the quality gates so onboarded projects cannot regress:
+   - an agent file using `allowed-tools:` instead of `tools:`, or declaring no tools at all
+   - an agent body referencing a tool outside its own allowlist (match on server tool names,
+     not just the `mcp__` prefix)
+5. Keep the lean-description convention documented, since Retort already gets it right.
+
+## Checking the budget
+
+```bash
+wc -c CLAUDE.md AGENTS.md
+find .claude/rules -name '*.md' -exec cat {} \; | wc -c
+
+# agent index — per file, because awk's `exit` would stop at the first one
+for f in agents/*.md; do
+  awk '/^---$/{n++; if(n==2) exit; next} n==1{print}' "$f"
+done | wc -c
+```
+
+Roughly 3.5–4 characters per token for prose; markdown tables run denser.


### PR DESCRIPTION
## Summary

Adds `docs/agents/context-budget.md` — what a session pays for before it has done any work, and where each kind of instruction belongs so that cost stays proportionate.

Retort is the scaffolding other repos inherit, so a convention that wastes context here is paid once here and once again in every project Retort onboards. This ports the findings from a startup-context reduction in `phoenixvc/mystira-workspace` ([#3796](https://github.com/phoenixvc/mystira-workspace/pull/3796)), which cut that repo's always-loaded footprint from 86,073 to 31,184 bytes (63%) without dropping a rule or an agent.

The governing fact: startup memory is re-paid on **every subagent dispatch**, so a session dispatching six specialists pays for `CLAUDE.md` seven times.

## Changes

- [x] Add `docs/agents/context-budget.md` — the multiplier, a where-does-this-belong table, the tool-surface conventions, an audit of this repo, and a suggested sequence
- [x] Link it from `docs/agents/README.md`
- [x] No code, config, or rule changes — documentation only

## Audit findings

Three things worth attention independent of the guide. All measured against `dev` at `871b6b7`.

### 1. The agent roster does not appear to register

None of the 39 `.claude/agents/*.md` files carry YAML frontmatter — they open with an HTML comment banner and a `#` heading. Claude Code registers a subagent from its frontmatter `name`/`description`, so as written **none of them register**, and ~200 KB of agent personas is inert rather than dispatchable. The well-formed definitions (27 files with `description`, `model`, `tools`) live in `agents/*.md` at the repo root, which is not a directory Claude Code reads. `platform-syncer.mjs:934` generates the `.claude/agents/` output, so this is an output shape, not hand-authored drift.

**This needs a maintainer to confirm before anything acts on it** — if the personas are reachable by a path not visible in the repo, the finding is void. The guide states the check alongside the claim, and makes confirming it step 1 of the suggested sequence.

### 2. Ten rules files are duplicated, and neither copy is stale

`.claude/rules/` and `.claude/rules/languages/` collide on ten names — `testing.md` (3,250 vs 5,141), `security.md` (1,655 vs 2,633), and eight more — with **none of the pairs identical**.

The cause is not drift. `synchronize.mjs` runs two generator tasks per target under the `coding-rules` flag: `syncDirectCopy` emits `.claude/rules/*.md` from `.agentkit/templates/claude/rules/`, and `syncLanguageInstructions` emits `.claude/rules/languages/` from `.agentkit/spec/rules.yaml`. Both are intentional; the two sets were simply never meant to overlap. The documents are structurally different too — prose (`## Test Pyramid`, `## Mocking & Isolation`) versus schema-shaped (`## Applies To`, `## Enforcement Rules`).

**I have not touched either copy.** Every file is marked `DO NOT EDIT` and would be restored by the next `retort:sync` — the fix belongs in `.agentkit`, and choosing between "spec wins", "templates win", and "namespace the output" is a maintainer's call. The guide lays out all three with the domain split for each.

### 3. Agent descriptions are only partly lean

27/27 `agents/*.md` carry `Examples:` lists inside the frontmatter. They are trigger phrasings rather than full dialogues, which is why the roster is light at ~712 B/agent, but they are still worked examples in the index. Not currently a startup cost — see finding 1 — but they become one as soon as that is fixed, so the guide sequences moving them accordingly.

## Test Plan

Documentation-only; no runtime behaviour changes.

- [x] Manual testing performed — every measurement re-derived against `dev` at `871b6b7`
- [x] Formatting verified with the version CI actually resolves (`prettier@3.8.1` per `.agentkit/pnpm-lock.yaml`, not the `^3.5.3` specifier)

### Validation Commands

```bash
# Memory files (reported: 95,217 bytes)
wc -c CLAUDE.md AGENTS.md
find .claude/rules -name '*.md' -exec cat {} \; | wc -c

# The ten colliding rules files
for f in .claude/rules/*.md; do b=$(basename "$f"); \
  [ -f ".claude/rules/languages/$b" ] && \
  printf "%-28s %6s / %-6s %s\n" "$b" "$(wc -c < "$f")" \
    "$(wc -c < .claude/rules/languages/$b)" \
    "$(diff -q "$f" ".claude/rules/languages/$b" >/dev/null 2>&1 && echo IDENTICAL || echo differs)"; done

# Roster frontmatter — expect 0 bytes from .claude/agents (finding 1)
for f in .claude/agents/*.md; do head -1 "$f" | grep -c '^---$'; done | paste -sd+ | bc
```

## Suggested follow-up: three quality gates

From bugs found during the source work, all mechanical:

1. An agent file with no frontmatter, or using `allowed-tools:` instead of `tools:`, or declaring no tools. The wrong key is **silently ignored**, granting that agent the entire tool registry — this was live on mystira-workspace's most frequently dispatched agent.
2. An agent body referencing a tool outside its own allowlist. Match on **the tool names each server provides**, not the `mcp__` prefix — a prefix-only scan produced a false negative that hid a real bug until review caught it.
3. A generated filename colliding across two generator outputs (finding 2).

## Checklist

- [x] Tests pass locally — n/a, docs only
- [x] Linter passes with no new warnings
- [x] Build succeeds — no build inputs touched
- [x] Documentation updated (if behavior changed)
- [x] No secrets, tokens, or credentials in the diff
- [x] Breaking changes documented (if applicable) — none
- [x] Reviewed my own diff before requesting review

## Documentation

### Change Impact

- [ ] **High** — Architecture, major refactor, new feature, security, or breaking change
- [ ] **Medium** — Complex bug fix, major library upgrade, tooling change
- [x] **Low** — Minor fix, config change, style update

Documentation-only addition; no behaviour change. The audit findings — particularly finding 1 — likely warrant separate higher-impact PRs once a maintainer has confirmed them.

### Documentation Checklist (required for High impact)

- [x] Not applicable (Low/Medium impact without historical record needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Z9fM8DdVf4825YSq78xhW