### PR TITLE
docs(skills): add md-agent sidecars and readme-map exploration schema

### DIFF
--- a/agents/doc-agent.md
+++ b/agents/doc-agent.md
@@ -4,7 +4,8 @@ description: >
   "document this feature", "create a history document", "update CLAUDE.md", "generate
   API docs", "review doc gaps", "write an ADR", or "document what we just built".
   Delegates to retort's document-history skill for session history. Maintains dual-file
-  convention (README.md + .readme.yaml) across all repos.
+  convention (README.md + .readme.yaml) and md-agent/v1 document sidecars
+  ({stem}.agent.yaml) across all repos.
 
   Examples:
   - "document what we just built"
@@ -36,7 +37,9 @@ Every documented component should have two files:
 - `.readme.yaml` — agent-readable structured metadata
 
 When creating or updating docs for any module, maintain both. Read
-`skills/doc-agent/references/readme-yaml-convention.md` for schema and examples.
+`skills/doc-agent/references/readme-yaml-convention.md` for the directory-card
+schema. Durable markdown also gets `{stem}.agent.yaml` — see
+`skills/md-agent-yaml/schema.yaml`. Do not mix the two shapes.
 
 ## Task Routing
 

--- a/agents/doc-agent.md
+++ b/agents/doc-agent.md
@@ -34,7 +34,7 @@ skill. Handles all other documentation tasks directly.
 Every documented component should have two files:
 
 - `README.md` — human-readable, markdown prose
-- `.readme.yaml` — agent-readable structured metadata
+- `.readme.yaml` — no-LSP directory exploration map
 
 When creating or updating docs for any module, maintain both. Read
 `skills/doc-agent/references/readme-yaml-convention.md` for the directory-card

--- a/agents/explorer-agent.md
+++ b/agents/explorer-agent.md
@@ -89,13 +89,11 @@ project that has such an agent, defer to it for this information rather than gen
 
 ### Cached Metadata Locations
 
-<!-- TODO: Document where the project's cached structural metadata lives — .readme.yaml
-     files, CLAUDE.md indexes, Serena project memory files. Reading these first avoids
-     redundant Serena calls for already-documented structure.
+Read `.readme.yaml` before any LSP/Serena call. Index files list `children`; leaf
+files list `entry_points` and `skip`. Schema:
+`skills/doc-agent/references/readme-yaml-convention.md`.
 
-     Implemented for: mystira-workspace → .claude/agents/mystira-explorer.md
-     § "Orientation: Read Metadata First" (repo root .readme.yaml, apps/.readme.yaml,
-       packages/.readme.yaml) + ~/.serena/memories/ for cross-session Serena memory -->
+Mystira: repo root, `apps/.readme.yaml`, `packages/.readme.yaml`.
 
 _Not populated. Metadata cache locations are project-specific._
 

--- a/skills/doc-agent/SKILL.md
+++ b/skills/doc-agent/SKILL.md
@@ -25,10 +25,14 @@ document lives from memory; always consult the location map.
 Every documented component should maintain two files in parallel:
 
 - `README.md` — human-readable, markdown prose
-- `.readme.yaml` — agent-readable structured metadata
+- `.readme.yaml` — directory exploration map (children / entry_points / skip)
 
 Schema and examples: `references/readme-yaml-convention.md` or the `document-creation`
 skill's `references/document-locations.md § Dual-File Convention`.
+
+Durable markdown itself (`README.md`, `docs/**`, ADRs, specs) also gets a sibling
+`{stem}.agent.yaml` in the md-agent/v1 shape. That is a different contract — see
+`skills/md-agent-yaml/schema.yaml`. Do not write md-agent fields into `.readme.yaml`.
 
 ## When to Write What
 
@@ -60,5 +64,6 @@ To assess what's missing:
 
 ### Reference Files
 
-- **`references/readme-yaml-convention.md`** — Full .readme.yaml schema and examples
+- **`references/readme-yaml-convention.md`** — .readme.yaml exploration-map schema (`readme-map/v1`)
+- **`skills/md-agent-yaml/`** — Per-document `{stem}.agent.yaml` schema and converter
 - **`document-creation` skill** → **`references/document-locations.md`** — Canonical location map for all document types

--- a/skills/doc-agent/references/readme-yaml-convention.md
+++ b/skills/doc-agent/references/readme-yaml-convention.md
@@ -21,15 +21,15 @@ directory itself needs a further map.
 
 ## Required fields
 
-| Field | Index | Leaf |
-| --- | --- | --- |
-| `schema` | `readme-map/v1` | `readme-map/v1` |
-| `kind` | `index` | `leaf` |
-| `purpose` | yes | yes |
-| `children` | yes | no |
-| `entry_points` | optional | yes |
-| `skip` | recommended | recommended |
-| `last_synced` | yes | yes |
+| Field          | Index           | Leaf            |
+| -------------- | --------------- | --------------- |
+| `schema`       | `readme-map/v1` | `readme-map/v1` |
+| `kind`         | `index`         | `leaf`          |
+| `purpose`      | yes             | yes             |
+| `children`     | yes             | no              |
+| `entry_points` | optional        | yes             |
+| `skip`         | recommended     | recommended     |
+| `last_synced`  | yes             | yes             |
 
 Optional on either: `name`, `type`, `stack`, `status`, `owner`, `depends_on`,
 `deployment`. Those help orientation; they do not replace `children` / `entry_points`.
@@ -40,19 +40,19 @@ Optional on either: `name`, `type`, `stack`, `status`, `owner`, `depends_on`,
 schema: readme-map/v1
 kind: index
 name: apps
-purpose: "Application projects for the Mystira platform"
+purpose: 'Application projects for the Mystira platform'
 children:
   - name: publisher
     path: apps/publisher
     stack: typescript
-    description: "Publisher frontend SPA"
+    description: 'Publisher frontend SPA'
   - name: identity
     path: apps/identity
     stack: dotnet
-    description: "Identity/auth service"
+    description: 'Identity/auth service'
 skip:
   - publish
-last_synced: "2026-08-14"
+last_synced: '2026-08-14'
 ```
 
 ## Leaf example
@@ -61,7 +61,7 @@ last_synced: "2026-08-14"
 schema: readme-map/v1
 kind: leaf
 name: shared-ts
-purpose: "Shared TypeScript utilities — dates, errors, validation."
+purpose: 'Shared TypeScript utilities — dates, errors, validation.'
 type: package
 stack: [typescript]
 entry_points:
@@ -69,7 +69,7 @@ entry_points:
 skip:
   - dist
   - node_modules
-last_synced: "2026-08-14"
+last_synced: '2026-08-14'
 ```
 
 ## Explorer rule

--- a/skills/doc-agent/references/readme-yaml-convention.md
+++ b/skills/doc-agent/references/readme-yaml-convention.md
@@ -1,119 +1,83 @@
 # .readme.yaml Convention
 
-Every documented component carries two files:
+`.readme.yaml` is a **directory exploration map**. An agent with no LSP / Serena
+reads it instead of listing the tree or parsing `README.md`.
 
-- `README.md` — human-readable prose
-- `.readme.yaml` — agent-readable structured metadata
+It is not a conversion of the README. Compact YAML for durable documents is
+`{stem}.agent.yaml` (`skills/md-agent-yaml/schema.yaml`). Do not mix the shapes.
 
-The `.readme.yaml` exists so that agents can scan the workspace quickly without parsing
-markdown prose. It is the machine-readable source of truth for what a component is,
-its stack, status, and key contacts.
+Machine schema: `readme-yaml.schema.yaml` (`schema: readme-map/v1`).
 
-## Required Fields
+## Two kinds
+
+**Index** (`apps/`, `packages/`, repo root of a monorepo): lists `children` so the
+next hop is obvious.
+
+**Leaf** (one app, package, or service): `entry_points` and `skip` so the agent
+opens the right file instead of crawling.
+
+A child listed on an index does not need its own `.readme.yaml` until that
+directory itself needs a further map.
+
+## Required fields
+
+| Field | Index | Leaf |
+| --- | --- | --- |
+| `schema` | `readme-map/v1` | `readme-map/v1` |
+| `kind` | `index` | `leaf` |
+| `purpose` | yes | yes |
+| `children` | yes | no |
+| `entry_points` | optional | yes |
+| `skip` | recommended | recommended |
+| `last_synced` | yes | yes |
+
+Optional on either: `name`, `type`, `stack`, `status`, `owner`, `depends_on`,
+`deployment`. Those help orientation; they do not replace `children` / `entry_points`.
+
+## Index example
 
 ```yaml
-name: string # Same as the directory/package name
-type: string # app | library | package | service | infrastructure | tool
-description: string # One sentence. What does this do?
-status: string # active | deprecated | experimental | archived
-stack: [string] # e.g. [dotnet, csharp, ef-core] or [typescript, react, vite]
-owner: string # GitHub handle or team name
+schema: readme-map/v1
+kind: index
+name: apps
+purpose: "Application projects for the Mystira platform"
+children:
+  - name: publisher
+    path: apps/publisher
+    stack: typescript
+    description: "Publisher frontend SPA"
+  - name: identity
+    path: apps/identity
+    stack: dotnet
+    description: "Identity/auth service"
+skip:
+  - publish
+last_synced: "2026-08-14"
 ```
 
-## Full Schema
+## Leaf example
 
 ```yaml
-name: mystira-app-pwa
-type: app
-description: 'Blazor WebAssembly PWA — the main player-facing client application.'
-status: active
-stack:
-  - dotnet
-  - blazor
-  - webassembly
-  - pwa
-owner: phoenixvc
-
-# Optional but recommended
-version: '1.0.0'
-repo: https://github.com/phoenixvc/mystira-workspace
-path: apps/app/src/Mystira.App.PWA
-
-# Relationships
-depends_on:
-  - name: Mystira.App.Core
-    type: package
-    local: true
-  - name: Mystira.App.API
-    type: service
-    local: true
-
-# Deployment (services/apps)
-deployment:
-  environment: azure-static-web-apps
-  url: https://app.mystira.io
-  ci_workflow: .github/workflows/deploy-app.yml
-
-# Docs
-docs:
-  adr_dir: docs/architecture/decisions
-  history_dir: docs/history
-  prd_dir: docs/product/prd
-
-# Deprecation (if status: deprecated)
-deprecated:
-  reason: 'Replaced by apps/publisher'
-  successor: apps/publisher
-  deadline: '2026-06-01'
-```
-
-## Examples by Component Type
-
-### Library / Package
-
-```yaml
+schema: readme-map/v1
+kind: leaf
 name: shared-ts
+purpose: "Shared TypeScript utilities — dates, errors, validation."
 type: package
-description: 'Shared TypeScript utilities — date formatting, error types, validation helpers.'
-status: active
 stack: [typescript]
-owner: phoenixvc
-version: '2.3.1'
+entry_points:
+  - src/index.ts
+skip:
+  - dist
+  - node_modules
+last_synced: "2026-08-14"
 ```
 
-### .NET API Service
+## Explorer rule
 
-```yaml
-name: Mystira.App.API
-type: service
-description: 'Main application REST API — story sessions, user profiles, AI companion.'
-status: active
-stack: [dotnet, csharp, ef-core, postgresql]
-owner: phoenixvc
-deployment:
-  environment: azure-container-apps
-  url: https://api.mystira.io
-  ci_workflow: .github/workflows/deploy-api.yml
-depends_on:
-  - name: Mystira.App.Core
-    type: package
-    local: true
-  - name: Mystira.App.Infrastructure.Data
-    type: package
-    local: true
-```
-
-### Infrastructure Module
-
-```yaml
-name: infra-identity
-type: infrastructure
-description: 'Terraform module provisioning Azure resources for the identity service.'
-status: active
-stack: [terraform, azure]
-owner: phoenixvc
-path: infra/modules/identity
-```
+1. Read `.readme.yaml` in the current directory (or the nearest ancestor).
+2. Follow `children` or open `entry_points`.
+3. Do not recurse into `skip`.
+4. Use LSP / Serena only after the map has pointed at a symbol or file.
 
 ## ADR Format
 

--- a/skills/doc-agent/references/readme-yaml.schema.yaml
+++ b/skills/doc-agent/references/readme-yaml.schema.yaml
@@ -4,21 +4,21 @@
 # Purpose: walk the tree, read this file, know what is here and where to go next.
 
 schema: readme-map/v1
-kind: leaf                    # leaf | index
-name: mystira-app-pwa         # directory / package name
-purpose: "One sentence: what lives in this directory."
-type: app                     # app | library | package | service | infrastructure | tool | index
+kind: leaf # leaf | index
+name: mystira-app-pwa # directory / package name
+purpose: 'One sentence: what lives in this directory.'
+type: app # app | library | package | service | infrastructure | tool | index
 stack: [dotnet, blazor]
-entry_points:                 # leaf: where to start without LSP
+entry_points: # leaf: where to start without LSP
   - Mystira.App.PWA.csproj
   - Program.cs
-children:                     # index: next hop for an explorer
+children: # index: next hop for an explorer
   - name: publisher
     path: apps/publisher
     stack: typescript
-    description: "Publisher frontend SPA"
-skip:                         # do not crawl
+    description: 'Publisher frontend SPA'
+skip: # do not crawl
   - bin
   - obj
   - artifacts
-last_synced: "2026-08-14"
+last_synced: '2026-08-14'

--- a/skills/doc-agent/references/readme-yaml.schema.yaml
+++ b/skills/doc-agent/references/readme-yaml.schema.yaml
@@ -1,0 +1,24 @@
+# readme-map/v1 — directory exploration map for agents when LSP is unavailable
+#
+# File: .readme.yaml in a directory (not {stem}.agent.yaml, not .agent-summary.yaml)
+# Purpose: walk the tree, read this file, know what is here and where to go next.
+
+schema: readme-map/v1
+kind: leaf                    # leaf | index
+name: mystira-app-pwa         # directory / package name
+purpose: "One sentence: what lives in this directory."
+type: app                     # app | library | package | service | infrastructure | tool | index
+stack: [dotnet, blazor]
+entry_points:                 # leaf: where to start without LSP
+  - Mystira.App.PWA.csproj
+  - Program.cs
+children:                     # index: next hop for an explorer
+  - name: publisher
+    path: apps/publisher
+    stack: typescript
+    description: "Publisher frontend SPA"
+skip:                         # do not crawl
+  - bin
+  - obj
+  - artifacts
+last_synced: "2026-08-14"

--- a/skills/document-creation/SKILL.md
+++ b/skills/document-creation/SKILL.md
@@ -65,7 +65,7 @@ All slugs: lowercase kebab-case. No spaces. No version numbers in filenames (ver
 
 - **Internal only** → commit to repo in the canonical location
 - **Client-facing** → goes to Notion or the configured external system; do NOT commit to repo
-- **AI-readable** → pair a `.readme.yaml` or use YAML frontmatter; see dual-file convention
+- **AI-readable** → directory card is `.readme.yaml`; durable markdown also gets `{stem}.agent.yaml` (md-agent/v1)
 - **Public** → consider if it belongs in a docs site rather than repo markdown
 
 If a document spans audiences (e.g. a spec that's both client-facing AND needs to feed
@@ -86,9 +86,10 @@ Before creating a new file:
 Every documented component maintains two files:
 
 - `README.md` — human prose
-- `.readme.yaml` — structured agent-readable metadata
+- `.readme.yaml` — no-LSP directory map
 
-See `references/document-locations.md § Dual-File Convention` for the full schema.
+Durable docs (`README.md`, `docs/**`, ADRs, specs) also get `{stem}.agent.yaml`.
+See `references/document-locations.md` and `skills/md-agent-yaml/schema.yaml`.
 
 ## Creating an ADR
 

--- a/skills/document-creation/references/document-locations.md
+++ b/skills/document-creation/references/document-locations.md
@@ -53,8 +53,9 @@ The sync-agent monitors drift between the two.
 
 | Type                    | Location                  | Naming                            | Notes                                     |
 | ----------------------- | ------------------------- | --------------------------------- | ----------------------------------------- |
-| README                  | Package / app root        | `README.md`                       | Always paired with `.readme.yaml`         |
-| Agent-readable metadata | Same dir as README        | `.readme.yaml`                    | See Dual-File Convention below            |
+| README                  | Package / app root        | `README.md`                       | Paired with `.readme.yaml` plus `README.agent.yaml` |
+| Directory map           | Directory being mapped    | `.readme.yaml`                    | No-LSP exploration map — Dual-File Convention below |
+| Document sidecar        | Same dir as the markdown  | `{stem}.agent.yaml`               | md-agent/v1 — `skills/md-agent-yaml/schema.yaml`    |
 | CLAUDE.md               | Repo root or `.claude/`   | Fixed                             | AI agent instructions; do not auto-create |
 | Runbook                 | `docs/runbooks/`          | `topic.md`                        | Stable; update in place                   |
 | Onboarding guide        | `docs/onboarding/`        | `topic.md` or `README.md`         |                                           |
@@ -102,81 +103,24 @@ The sync-agent monitors drift between the two.
 
 ## Dual-File Convention
 
-Every component, app, package, or service that has a README should also have a `.readme.yaml` partner:
+`.readme.yaml` is a no-LSP exploration map for a directory. Schema and examples:
+`skills/doc-agent/references/readme-yaml-convention.md` (`readme-map/v1`).
 
 ```
-component/
-├── README.md        # Human-readable prose
-└── .readme.yaml     # Agent-readable structured metadata
+apps/
+├── .readme.yaml     # index: children + skip
+└── publisher/
+    ├── README.md
+    └── .readme.yaml # leaf, only if this folder needs its own map
 ```
 
-### `.readme.yaml` Required Fields
+An index that already lists a child does not require a leaf card in that child.
 
-```yaml
-name: string # canonical name (matches directory/package name)
-type: app | library | service | infrastructure | tool | package
-description: string # one sentence
-status: active | deprecated | planned | experimental
-stack: [string] # primary technologies
-owner: string # GitHub team or individual (e.g. phoenixvc/backend)
-```
+### Document sidecars (md-agent/v1)
 
-### `.readme.yaml` Optional Fields
-
-```yaml
-version: string # semver if versioned
-repo: string # GitHub URL
-deployment:
-  environments: [dev, staging, prod]
-  url_pattern: https://...
-  platform: azure-app-service | azure-swa | container-app | vercel | cloudflare
-depends_on: [string] # other services/packages this depends on
-deprecated:
-  reason: string
-  replacement: string
-  sunset_date: YYYY-MM-DD
-client-doc: string # Notion URL if a client-facing counterpart exists
-```
-
-### Type-specific Examples
-
-**Library / shared package:**
-
-```yaml
-name: shared-messaging
-type: library
-description: Domain event types and message bus abstraction for Mystira services.
-status: active
-stack: [dotnet, csharp]
-owner: phoenixvc/backend
-```
-
-**App / service:**
-
-```yaml
-name: story-generator
-type: service
-description: AI story generation API for Mystira interactive narratives.
-status: active
-stack: [dotnet, csharp, openai]
-owner: phoenixvc/backend
-deployment:
-  environments: [dev, staging, prod]
-  url_pattern: https://mys-{env}-story-gen.azurewebsites.net
-  platform: azure-app-service
-depends_on: [identity, shared-messaging]
-```
-
-**Infrastructure module:**
-
-```yaml
-name: infra-identity
-type: infrastructure
-description: Terraform module for the Mystira Identity service (Container App + Key Vault).
-status: active
-stack: [terraform, azure]
-owner: phoenixvc/infra
-```
+Durable markdown also gets a sibling `{stem}.agent.yaml` (`SPEC-001.md` → `SPEC-001.agent.yaml`).
+Fields: `title`, `purpose`, `audience`, `facts`, `last_synced`. Schema:
+`skills/md-agent-yaml/schema.yaml`. Do not put those fields in `.readme.yaml`.
 
 ---
 

--- a/skills/document-creation/references/document-locations.md
+++ b/skills/document-creation/references/document-locations.md
@@ -51,18 +51,18 @@ The sync-agent monitors drift between the two.
 
 ## Technical Reference Documents
 
-| Type                    | Location                  | Naming                            | Notes                                     |
-| ----------------------- | ------------------------- | --------------------------------- | ----------------------------------------- |
-| README                  | Package / app root        | `README.md`                       | Paired with `.readme.yaml` plus `README.agent.yaml` |
-| Directory map           | Directory being mapped    | `.readme.yaml`                    | No-LSP exploration map — Dual-File Convention below |
-| Document sidecar        | Same dir as the markdown  | `{stem}.agent.yaml`               | md-agent/v1 — `skills/md-agent-yaml/schema.yaml`    |
-| CLAUDE.md               | Repo root or `.claude/`   | Fixed                             | AI agent instructions; do not auto-create |
-| Runbook                 | `docs/runbooks/`          | `topic.md`                        | Stable; update in place                   |
-| Onboarding guide        | `docs/onboarding/`        | `topic.md` or `README.md`         |                                           |
-| API reference           | `docs/api/`               | `service-name.md` or OpenAPI yaml |                                           |
-| OpenAPI spec            | `openapi/` or `docs/api/` | `service-name.yaml`               |                                           |
-| Migration guide         | `docs/migrations/`        | `vX-to-vY.md`                     |                                           |
-| Contributing guide      | Repo root                 | `CONTRIBUTING.md`                 | Fixed name                                |
+| Type               | Location                  | Naming                            | Notes                                               |
+| ------------------ | ------------------------- | --------------------------------- | --------------------------------------------------- |
+| README             | Package / app root        | `README.md`                       | Paired with `.readme.yaml` plus `README.agent.yaml` |
+| Directory map      | Directory being mapped    | `.readme.yaml`                    | No-LSP exploration map — Dual-File Convention below |
+| Document sidecar   | Same dir as the markdown  | `{stem}.agent.yaml`               | md-agent/v1 — `skills/md-agent-yaml/schema.yaml`    |
+| CLAUDE.md          | Repo root or `.claude/`   | Fixed                             | AI agent instructions; do not auto-create           |
+| Runbook            | `docs/runbooks/`          | `topic.md`                        | Stable; update in place                             |
+| Onboarding guide   | `docs/onboarding/`        | `topic.md` or `README.md`         |                                                     |
+| API reference      | `docs/api/`               | `service-name.md` or OpenAPI yaml |                                                     |
+| OpenAPI spec       | `openapi/` or `docs/api/` | `service-name.yaml`               |                                                     |
+| Migration guide    | `docs/migrations/`        | `vX-to-vY.md`                     |                                                     |
+| Contributing guide | Repo root                 | `CONTRIBUTING.md`                 | Fixed name                                          |
 
 ---
 

--- a/skills/md-agent-yaml/SKILL.md
+++ b/skills/md-agent-yaml/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: md-agent-yaml
+description: Create and update md-agent/v1 YAML sidecars for durable markdown (README.md, docs/**, ADRs, specs). Use when converting markdown to YAML for agents, syncing .agent.yaml sidecars, or when the user runs /md-agent-yaml. Distinct from .readme.yaml directory cards.
+---
+
+# md-agent YAML sidecars
+
+Durable markdown gets a sibling `{stem}.agent.yaml` so agents can read structured facts instead of parsing prose.
+
+Do not invent a different shape. Use `schema.yaml` in this skill.
+
+## Two YAML contracts
+
+| File | Scope | Schema |
+| --- | --- | --- |
+| `.readme.yaml` | No-LSP directory map | `skills/doc-agent/references/readme-yaml-convention.md` |
+| `{stem}.agent.yaml` | One durable markdown file | `schema.yaml` in this skill |
+
+Never write md-agent fields into `.readme.yaml`. Never write exploration-map fields (`children`, `entry_points`, `skip`) into `{stem}.agent.yaml`.
+
+## When to run
+
+- After creating or materially editing `README.md`, `docs/**`, ADRs, or specs
+- When asked to convert markdown to YAML for AI use
+
+Do not convert `CLAUDE.md`, `AGENTS.md`, plans, skills, handoffs, vendor trees, or generated files.
+
+## File name
+
+`docs/architecture/specs/SPEC-001.md` → `docs/architecture/specs/SPEC-001.agent.yaml`
+
+## Commands
+
+```text
+python skills/md-agent-yaml/scripts/md_agent_yaml.py convert <path>
+python skills/md-agent-yaml/scripts/md_agent_yaml.py convert --repo
+python skills/md-agent-yaml/scripts/md_agent_yaml.py check
+```
+
+`convert` writes a stub only when the sidecar is missing. Fill `facts` yourself. Refresh `last_synced` when you change the sidecar.
+
+## Fields
+
+- `title` — first H1 or a short title
+- `purpose` — one or two sentences
+- `audience` — `agent` and/or `human`
+- `facts` — durable claims, not a restatement of the whole document
+- `last_synced` — ISO date

--- a/skills/md-agent-yaml/SKILL.md
+++ b/skills/md-agent-yaml/SKILL.md
@@ -11,10 +11,10 @@ Do not invent a different shape. Use `schema.yaml` in this skill.
 
 ## Two YAML contracts
 
-| File | Scope | Schema |
-| --- | --- | --- |
-| `.readme.yaml` | No-LSP directory map | `skills/doc-agent/references/readme-yaml-convention.md` |
-| `{stem}.agent.yaml` | One durable markdown file | `schema.yaml` in this skill |
+| File                | Scope                     | Schema                                                  |
+| ------------------- | ------------------------- | ------------------------------------------------------- |
+| `.readme.yaml`      | No-LSP directory map      | `skills/doc-agent/references/readme-yaml-convention.md` |
+| `{stem}.agent.yaml` | One durable markdown file | `schema.yaml` in this skill                             |
 
 Never write md-agent fields into `.readme.yaml`. Never write exploration-map fields (`children`, `entry_points`, `skip`) into `{stem}.agent.yaml`.
 

--- a/skills/md-agent-yaml/schema.yaml
+++ b/skills/md-agent-yaml/schema.yaml
@@ -1,0 +1,19 @@
+# md-agent/v1 — agent sidecar for one durable markdown file
+#
+# Sibling file: {stem}.agent.yaml next to {stem}.md
+# Example: docs/specs/SPEC-006.md → docs/specs/SPEC-006.agent.yaml
+#
+# Do not write this schema into .readme.yaml (directory cards) or
+# .agent-summary.yaml (repo summaries). Those are different contracts.
+
+schema: md-agent/v1
+source: docs/example.md          # repo-relative path of the markdown file
+title: "Short document title"    # usually the first H1
+purpose: "One or two sentences on what this document is for."
+audience:                        # who should read the sidecar
+  - agent
+  - human
+facts:                           # durable claims an agent can trust without parsing the markdown
+  - "Concrete fact 1"
+  - "Concrete fact 2"
+last_synced: "2026-08-14"        # ISO date the sidecar was last aligned to the markdown

--- a/skills/md-agent-yaml/schema.yaml
+++ b/skills/md-agent-yaml/schema.yaml
@@ -7,13 +7,13 @@
 # .agent-summary.yaml (repo summaries). Those are different contracts.
 
 schema: md-agent/v1
-source: docs/example.md          # repo-relative path of the markdown file
-title: "Short document title"    # usually the first H1
-purpose: "One or two sentences on what this document is for."
-audience:                        # who should read the sidecar
+source: docs/example.md # repo-relative path of the markdown file
+title: 'Short document title' # usually the first H1
+purpose: 'One or two sentences on what this document is for.'
+audience: # who should read the sidecar
   - agent
   - human
-facts:                           # durable claims an agent can trust without parsing the markdown
-  - "Concrete fact 1"
-  - "Concrete fact 2"
-last_synced: "2026-08-14"        # ISO date the sidecar was last aligned to the markdown
+facts: # durable claims an agent can trust without parsing the markdown
+  - 'Concrete fact 1'
+  - 'Concrete fact 2'
+last_synced: '2026-08-14' # ISO date the sidecar was last aligned to the markdown

--- a/skills/md-agent-yaml/scripts/md_agent_yaml.py
+++ b/skills/md-agent-yaml/scripts/md_agent_yaml.py
@@ -373,7 +373,7 @@ def map_gaps(changed: list[Path], root: Path) -> tuple[list[Path], list[tuple[Pa
             if listed_in_map(directory, parent_dir, listed, skip):
                 covered = True
                 break
-            if listed or skip:
+            if listed:
                 stale_parents.append((map_path, repo_rel(directory, root)))
                 covered = True
                 break

--- a/skills/md-agent-yaml/scripts/md_agent_yaml.py
+++ b/skills/md-agent-yaml/scripts/md_agent_yaml.py
@@ -311,12 +311,30 @@ def parse_map_lists(text: str) -> tuple[set[str], set[str]]:
     return listed, skip
 
 
-def listed_in_map(child: Path, parent: Path, listed: set[str], skip: set[str]) -> bool:
-    rel = posix(child.relative_to(parent)) if child != parent else child.name
-    names = {child.name, rel, posix(child)}
-    if names & skip:
-        return True
-    return bool(names & listed)
+def _norm_key(value: str) -> str:
+    return value.replace("\\", "/").strip("/")
+
+
+def listed_in_map(
+    child: Path,
+    parent: Path,
+    listed: set[str],
+    skip: set[str],
+    root: Path | None = None,
+) -> bool:
+    rel_parent = _norm_key(posix(child.relative_to(parent))) if child != parent else child.name
+    needles = {rel_parent}
+    if root is not None:
+        try:
+            needles.add(_norm_key(posix(child.relative_to(root))))
+        except ValueError:
+            pass
+    hay = {_norm_key(item) for item in listed | skip if item}
+    for item in hay:
+        for needle in needles:
+            if needle == item or needle.startswith(item + "/") or item.endswith("/" + needle):
+                return True
+    return False
 
 
 def ancestor_maps(directory: Path, root: Path) -> list[Path]:
@@ -370,7 +388,7 @@ def map_gaps(changed: list[Path], root: Path) -> tuple[list[Path], list[tuple[Pa
                 continue
             listed, skip = parse_map_lists(text)
             parent_dir = map_path.parent
-            if listed_in_map(directory, parent_dir, listed, skip):
+            if listed_in_map(directory, parent_dir, listed, skip, root):
                 covered = True
                 break
             if listed:
@@ -479,11 +497,28 @@ def check_stop() -> int:
     return 0
 
 
+def selftest() -> int:
+    root = Path("C:/repo")
+    parent = root / "apps"
+    listed = {"publisher", "apps/publisher", "admin-api", "apps/admin/api", "apps/app"}
+    skip = {"publish"}
+    assert listed_in_map(parent / "publisher", parent, listed, skip, root)
+    assert listed_in_map(parent / "admin" / "api", parent, listed, skip, root)
+    assert listed_in_map(parent / "app" / "src" / "Mystira.App.PWA", parent, listed, skip, root)
+    assert listed_in_map(parent / "publish", parent, listed, skip, root)
+    assert not listed_in_map(parent / "newapp", parent, listed, skip, root)
+    leaf_listed, _ = parse_map_lists("schema: readme-map/v1\nkind: leaf\nskip:\n  - dist\n")
+    assert leaf_listed == set()
+    print("selftest ok")
+    return 0
+
+
 def usage() -> str:
     return (
         "usage: md_agent_yaml.py convert [--repo] [paths...]\n"
         "       md_agent_yaml.py check [--repo] [paths...]\n"
-        "       md_agent_yaml.py check-stop"
+        "       md_agent_yaml.py check-stop\n"
+        "       md_agent_yaml.py selftest"
     )
 
 
@@ -513,6 +548,8 @@ def main(argv: list[str]) -> int:
     try:
         if command == "check-stop":
             return check_stop()
+        if command == "selftest":
+            return selftest()
 
         start = Path.cwd()
         root = git_root(start)

--- a/skills/md-agent-yaml/scripts/md_agent_yaml.py
+++ b/skills/md-agent-yaml/scripts/md_agent_yaml.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""md-agent sidecar helper.
+
+convert   create missing {stem}.agent.yaml stubs (does not overwrite)
+check     print durable markdown missing a sidecar, and .readme.yaml drift
+check-stop
+          Stop-hook mode: remind once if this turn left durable markdown
+          without a sidecar, or (opt-in) a .readme.yaml map gap.
+          Always exit 0 (fail-open).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+SCHEMA = "md-agent/v1"
+SIDECAR_SUFFIX = ".agent.yaml"
+README_MAP = ".readme.yaml"
+COMPONENT_FILES = {"package.json", "cargo.toml", "pyproject.toml", "go.mod"}
+COMPONENT_SUFFIXES = {".csproj", ".sln"}
+MAP_SECTIONS = {"children", "apps", "packages"}
+INDEX_NOISE_DIRS = {
+    "docs",
+    "doc",
+    "plans",
+    "plan",
+    "skills",
+    "handoffs",
+    "handoff",
+    ".github",
+    "coverage",
+    "tests",
+    "test",
+    "scripts",
+}
+
+EXCLUDE_DIR_NAMES = {
+    ".git",
+    "node_modules",
+    "vendor",
+    "dist",
+    "build",
+    "artifacts",
+    ".next",
+    ".nuget",
+    "bin",
+    "obj",
+    "worktrees",
+    "coverage",
+    "lcov-report",
+    "__pycache__",
+    ".venv",
+    "venv",
+}
+
+EXCLUDE_PATH_PARTS = (
+    "/.git/",
+    "/.claude/",
+    "/.grok/",
+    "/.agents/",
+    "/.cursor/",
+    "/plans/",
+    "/plan/",
+    "/skills/",
+    "/handoffs/",
+    "/handoff/",
+    "/node_modules/",
+    "/vendor/",
+    "/worktrees/",
+)
+
+EXCLUDE_NAMES = {
+    "claude.md",
+    "agents.md",
+    "changelog.md",
+    "license.md",
+    "contributing.md",
+    "code_of_conduct.md",
+    "security.md",
+}
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n.*?\n---\s*\n", re.DOTALL)
+HEADING_RE = re.compile(r"^#{1,6}\s+(.*\S)\s*$", re.MULTILINE)
+LIST_RE = re.compile(r"^[-*+]\s+(.*\S)\s*$", re.MULTILINE)
+
+
+def posix(path: Path) -> str:
+    return path.as_posix()
+
+
+def git_root(start: Path) -> Path | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def repo_rel(path: Path, root: Path | None) -> str:
+    resolved = path.resolve()
+    if root:
+        try:
+            return posix(resolved.relative_to(root.resolve()))
+        except ValueError:
+            pass
+    return path.name
+
+
+def is_excluded_dir(path: Path) -> bool:
+    if any(part in EXCLUDE_DIR_NAMES for part in path.parts):
+        return True
+    lowered = f"/{posix(path).lower()}/"
+    return any(part in lowered for part in EXCLUDE_PATH_PARTS)
+
+
+def is_durable_markdown(path: Path) -> bool:
+    if path.suffix.lower() != ".md":
+        return False
+    if path.name.lower() in EXCLUDE_NAMES:
+        return False
+    if is_excluded_dir(path.parent):
+        return False
+    name = path.name.lower()
+    if name == "readme.md":
+        return True
+    parts_lower = {part.lower() for part in path.parts}
+    if parts_lower & {"docs", "doc", "adr", "adrs", "specs", "spec"}:
+        return True
+    stem = path.stem.upper()
+    return stem.startswith("ADR-") or stem.startswith("SPEC-") or stem.startswith("PRD-")
+
+
+def sidecar_for(md_path: Path) -> Path:
+    return md_path.with_name(md_path.stem + SIDECAR_SUFFIX)
+
+
+def yaml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def emit_sidecar(payload: dict) -> str:
+    facts = payload.get("facts") or []
+    if facts:
+        facts_block = "\n".join(f"  - {yaml_string(item)}" for item in facts)
+    else:
+        facts_block = "  []"
+    audience = payload.get("audience") or ["agent"]
+    audience_block = "[" + ", ".join(yaml_string(item) for item in audience) + "]"
+    return (
+        f"schema: {SCHEMA}\n"
+        f"source: {payload['source']}\n"
+        f"title: {yaml_string(payload['title'])}\n"
+        f"purpose: {yaml_string(payload['purpose'])}\n"
+        f"audience: {audience_block}\n"
+        f"facts:\n{facts_block}\n"
+        f"last_synced: {payload['last_synced']}\n"
+    )
+
+
+def strip_frontmatter(text: str) -> str:
+    return FRONTMATTER_RE.sub("", text, count=1)
+
+
+def first_paragraph(text: str) -> str:
+    chunks: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if chunks:
+                break
+            continue
+        if line.startswith("#") or line.startswith("```") or line.startswith(">"):
+            if chunks:
+                break
+            continue
+        if line.startswith("|") or line.startswith("- ") or line.startswith("* "):
+            if chunks:
+                break
+            continue
+        chunks.append(line)
+    return " ".join(chunks).strip()
+
+
+def extract_from_markdown(md_path: Path, root: Path | None) -> dict:
+    text = md_path.read_text(encoding="utf-8", errors="replace")
+    body = strip_frontmatter(text)
+    heading = HEADING_RE.search(body)
+    title = heading.group(1).strip() if heading else md_path.stem.replace("-", " ")
+    purpose = first_paragraph(body)
+    if not purpose:
+        purpose = f"Agent sidecar for {md_path.name}."
+    facts = [item.strip() for item in LIST_RE.findall(body) if len(item.strip()) > 8][:8]
+    parts_lower = {part.lower() for part in md_path.parts}
+    if md_path.name.lower() == "readme.md":
+        audience = ["human", "agent"]
+    elif parts_lower & {"adr", "adrs", "specs", "spec"}:
+        audience = ["agent", "human"]
+    else:
+        audience = ["agent"]
+    return {
+        "schema": SCHEMA,
+        "source": repo_rel(md_path, root),
+        "title": title,
+        "purpose": purpose[:400],
+        "audience": audience,
+        "facts": facts,
+        "last_synced": date.today().isoformat(),
+    }
+
+
+def changed_paths(root: Path) -> list[Path]:
+    commands = (
+        ["git", "-C", str(root), "diff", "--name-only", "--diff-filter=ACMR", "HEAD"],
+        ["git", "-C", str(root), "diff", "--name-only", "--cached", "--diff-filter=ACMR"],
+        ["git", "-C", str(root), "ls-files", "--others", "--exclude-standard"],
+    )
+    names: set[str] = set()
+    for command in commands:
+        try:
+            result = subprocess.run(command, capture_output=True, text=True, check=False)
+        except OSError:
+            continue
+        if result.returncode != 0:
+            continue
+        names.update(line.strip() for line in result.stdout.splitlines() if line.strip())
+    return [root / name for name in sorted(names)]
+
+
+def missing_sidecars(paths: list[Path]) -> list[Path]:
+    missing: list[Path] = []
+    for path in paths:
+        if not path.is_file() or not is_durable_markdown(path):
+            continue
+        if not sidecar_for(path).is_file():
+            missing.append(path)
+    return missing
+
+
+def git_tracked_readme_maps(root: Path) -> list[Path]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return []
+    if result.returncode != 0:
+        return []
+    maps: list[Path] = []
+    for name in result.stdout.split("\0"):
+        if name == README_MAP or name.endswith("/" + README_MAP):
+            maps.append(root / name)
+    return maps
+
+
+def is_component_signal(path: Path) -> bool:
+    name = path.name.lower()
+    if name == "readme.md":
+        return not ({part.lower() for part in path.parts} & INDEX_NOISE_DIRS)
+    if name in COMPONENT_FILES:
+        return not is_excluded_dir(path.parent)
+    return path.suffix.lower() in COMPONENT_SUFFIXES
+
+
+def parse_map_lists(text: str) -> tuple[set[str], set[str]]:
+    listed: set[str] = set()
+    skip: set[str] = set()
+    mode: str | None = None
+    for raw in text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" \t"))
+        stripped = raw.strip()
+        if indent == 0:
+            key = stripped.split(":", 1)[0].strip()
+            rest = stripped.split(":", 1)[1].strip() if ":" in stripped else ""
+            if key in MAP_SECTIONS:
+                mode = "children"
+                continue
+            if key == "skip":
+                mode = "skip"
+                if rest.startswith("["):
+                    skip.update(item.strip(" '\"") for item in rest.strip("[]").split(",") if item.strip())
+                    mode = None
+                continue
+            mode = None
+            continue
+        if mode == "children":
+            match = re.search(r"\b(?:name|path):\s*['\"]?([^'\"#]+)", stripped)
+            if match:
+                listed.add(match.group(1).strip())
+        elif mode == "skip":
+            item = stripped[1:].strip() if stripped.startswith("-") else stripped
+            item = item.split(":", 1)[-1].strip().strip("'\"")
+            if item:
+                skip.add(item)
+    return listed, skip
+
+
+def listed_in_map(child: Path, parent: Path, listed: set[str], skip: set[str]) -> bool:
+    rel = posix(child.relative_to(parent)) if child != parent else child.name
+    names = {child.name, rel, posix(child)}
+    if names & skip:
+        return True
+    return bool(names & listed)
+
+
+def ancestor_maps(directory: Path, root: Path) -> list[Path]:
+    found: list[Path] = []
+    current = directory.resolve()
+    stop = root.resolve()
+    while True:
+        candidate = current / README_MAP
+        if candidate.is_file():
+            found.append(candidate)
+        if current == stop or current.parent == current:
+            break
+        current = current.parent
+    return found
+
+
+def working_readme_maps(root: Path, changed: list[Path]) -> list[Path]:
+    maps = git_tracked_readme_maps(root)
+    for path in changed:
+        if path.name == README_MAP and path.is_file():
+            maps.append(path)
+    return maps
+
+
+def map_gaps(changed: list[Path], root: Path) -> tuple[list[Path], list[tuple[Path, str]]]:
+    if not working_readme_maps(root, changed):
+        return [], []
+
+    missing_cards: list[Path] = []
+    stale_parents: list[tuple[Path, str]] = []
+    seen_dirs: set[Path] = set()
+
+    for path in changed:
+        if not path.exists() or is_excluded_dir(path.parent):
+            continue
+        if not is_component_signal(path):
+            continue
+        directory = path.parent.resolve()
+        if directory in seen_dirs:
+            continue
+        seen_dirs.add(directory)
+        if (directory / README_MAP).is_file():
+            continue
+
+        ancestors = ancestor_maps(directory.parent, root)
+        covered = False
+        for map_path in ancestors:
+            try:
+                text = map_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            listed, skip = parse_map_lists(text)
+            parent_dir = map_path.parent
+            if listed_in_map(directory, parent_dir, listed, skip):
+                covered = True
+                break
+            if listed or skip:
+                stale_parents.append((map_path, repo_rel(directory, root)))
+                covered = True
+                break
+        if not covered:
+            missing_cards.append(directory)
+
+    # unique stale pairs
+    unique_stale: list[tuple[Path, str]] = []
+    seen_pairs: set[tuple[str, str]] = set()
+    for map_path, child in stale_parents:
+        key = (str(map_path), child)
+        if key in seen_pairs:
+            continue
+        seen_pairs.add(key)
+        unique_stale.append((map_path, child))
+    return missing_cards, unique_stale
+
+
+def convert_paths(paths: list[Path], root: Path | None) -> list[Path]:
+    written: list[Path] = []
+    for md_path in paths:
+        if not md_path.is_file() or not is_durable_markdown(md_path):
+            continue
+        sidecar = sidecar_for(md_path)
+        if sidecar.exists():
+            continue
+        sidecar.write_text(emit_sidecar(extract_from_markdown(md_path, root)), encoding="utf-8")
+        written.append(sidecar)
+    return written
+
+
+def hook_field(data: dict, *keys: str):
+    for key in keys:
+        if key in data and data[key] not in (None, ""):
+            return data[key]
+    return None
+
+
+def read_hook_input() -> dict:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def check_stop() -> int:
+    data = read_hook_input()
+    reason = str(hook_field(data, "reason", "stop_reason") or "end_turn")
+    if reason not in {"end_turn", "completed", ""}:
+        return 0
+    if hook_field(data, "stopHookActive", "stop_hook_active") is True:
+        return 0
+
+    cwd_value = hook_field(data, "cwd", "workspaceRoot", "workspace_root") or str(Path.cwd())
+    root = git_root(Path(cwd_value))
+    if root is None:
+        return 0
+
+    changed = changed_paths(root)
+    missing = missing_sidecars(changed)
+    missing_maps, stale_parents = map_gaps(changed, root)
+    if not missing and not missing_maps and not stale_parents:
+        return 0
+
+    script = posix(Path(__file__))
+    parts: list[str] = []
+    if missing:
+        parts.append(
+            "Durable markdown is missing an md-agent sidecar ({stem}.agent.yaml).\n"
+            + "\n".join(f"- {repo_rel(path, root)}" for path in missing)
+            + f"\nCreate stubs with: python {script} convert <path>\n"
+            "Then fill facts. Do not write these into .readme.yaml."
+        )
+    if missing_maps:
+        parts.append(
+            "Component directory has no .readme.yaml exploration map "
+            "and is not listed on an ancestor map.\n"
+            + "\n".join(f"- {repo_rel(path, root)}" for path in missing_maps)
+        )
+    if stale_parents:
+        parts.append(
+            "Ancestor .readme.yaml is missing a new/changed child "
+            "(add it to children or skip).\n"
+            + "\n".join(
+                f"- {repo_rel(map_path, root)} ← {child}"
+                for map_path, child in stale_parents
+            )
+        )
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "Stop",
+                    "additionalContext": "\n\n".join(parts),
+                }
+            }
+        )
+    )
+    return 0
+
+
+def usage() -> str:
+    return (
+        "usage: md_agent_yaml.py convert [--repo] [paths...]\n"
+        "       md_agent_yaml.py check [--repo] [paths...]\n"
+        "       md_agent_yaml.py check-stop"
+    )
+
+
+def collect_targets(args: list[str], root: Path | None) -> list[Path]:
+    if "--repo" in args:
+        if root is None:
+            raise SystemExit("not a git repository")
+        found: list[Path] = []
+        for path in root.rglob("*.md"):
+            if is_durable_markdown(path):
+                found.append(path)
+        return found
+    explicit = [Path(item).resolve() for item in args if item != "--repo"]
+    if explicit:
+        return explicit
+    if root is None:
+        return []
+    return changed_paths(root)
+
+
+def main(argv: list[str]) -> int:
+    if not argv or argv[0] in {"-h", "--help"}:
+        print(usage())
+        return 0
+
+    command, *rest = argv
+    try:
+        if command == "check-stop":
+            return check_stop()
+
+        start = Path.cwd()
+        root = git_root(start)
+        targets = collect_targets(rest, root)
+
+        if command == "convert":
+            written = convert_paths(targets, root)
+            for path in written:
+                print(f"wrote {path}")
+            if not written:
+                print("no missing sidecars")
+            return 0
+
+        if command == "check":
+            missing = missing_sidecars(targets)
+            for path in missing:
+                print(repo_rel(path, root))
+            if root is not None:
+                missing_maps, stale_parents = map_gaps(
+                    targets if targets else changed_paths(root), root
+                )
+                for path in missing_maps:
+                    print(f"map-missing {repo_rel(path, root)}")
+                for map_path, child in stale_parents:
+                    print(f"map-stale {repo_rel(map_path, root)} <- {child}")
+            return 0
+
+        print(usage(), file=sys.stderr)
+        return 2
+    except Exception:
+        if command == "check-stop":
+            return 0
+        raise
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
Splits the two YAML contracts that agents were collapsing into one:

1. **md-agent/v1** — \{stem}.agent.yaml\ beside durable markdown (\	itle\, \purpose\, \udience\, \acts\, \last_synced\)
2. **readme-map/v1** — \.readme.yaml\ as a no-LSP directory exploration map (\children\ / \ntry_points\ / \skip\)

A child listed on an index does not need its own leaf card. Explorer now reads the map before LSP/Serena.

Companion PR: phoenixvc/org-meta (md-agent skill + \check-stop\ script the global Stop hook calls).

## What landed
- \skills/md-agent-yaml/\ — document sidecar schema, skill, converter
- \skills/doc-agent/references/readme-yaml-convention.md\ rewritten as readme-map/v1
- \eadme-yaml.schema.yaml\ machine schema
- doc-agent, document-creation, explorer-agent pointed at both contracts

## Test plan
- [x] \convert CLAUDE.md\ is a no-op
- [x] Listed child \pps/publisher\ does not map-nag
- [x] New unlisted \pps/newapp\ asks to update the parent \.readme.yaml\
- [x] Repo with no \.readme.yaml\ stays silent on map checks